### PR TITLE
Move hamburgers SCSS into the project

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ the home of the new rust website
 
 1. As this is a [Rocket](https://rocket.rs/) app, you must have the most current version of Rust nightly installed on your local machine. You can install it using [`rustup`](https://rustup.rs/) by running `rustup default nightly`.
 
-1. We're using some third-party npm packages, so be sure to run `npm install`.
+1. We're using at least one third-party npm package, so be sure to run `npm install`.
 
 1. Compile the `.scss` files to `.css` by running `sass static/styles/app.scss static/styles/app.css`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,11 +2,6 @@
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
-    "hamburgers": {
-      "version": "0.9.3",
-      "resolved": "https://registry.npmjs.org/hamburgers/-/hamburgers-0.9.3.tgz",
-      "integrity": "sha512-7pC2GkvKcBtfUalg2Vfm2z3wOCUFI7ZHgqThUg6kHZ7ZcLelSzGhboB9UjlleRCBEUjAVCpcrdGdN7PcaJBQKQ=="
-    },
     "stylelint-config-recommended": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/stylelint-config-recommended/-/stylelint-config-recommended-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,5 @@
   "devDependencies": {
     "stylelint-config-standard": "^18.2.0"
   },
-  "dependencies": {
-    "hamburgers": "^0.9.3"
-  }
+  "dependencies": {}
 }

--- a/static/styles/app.scss
+++ b/static/styles/app.scss
@@ -1,5 +1,5 @@
 // THIRD-PARTY STYLES
-@import '../../node_modules/hamburgers/_sass/hamburgers/hamburgers';
+@import 'hamburgers/hamburgers';
 
 // VARIABLES
 @import 'variables/colors';

--- a/static/styles/hamburgers/_base.scss
+++ b/static/styles/hamburgers/_base.scss
@@ -1,0 +1,69 @@
+// Hamburger
+// ==================================================
+.hamburger {
+  padding: $hamburger-padding-y $hamburger-padding-x;
+  display: inline-block;
+  cursor: pointer;
+
+  transition-property: opacity, filter;
+  transition-duration: $hamburger-hover-transition-duration;
+  transition-timing-function: $hamburger-hover-transition-timing-function;
+
+  // Normalize (<button>)
+  font: inherit;
+  color: inherit;
+  text-transform: none;
+  background-color: transparent;
+  border: 0;
+  margin: 0;
+  overflow: visible;
+
+  &:hover {
+    @if $hamburger-hover-use-filter == true {
+      filter: $hamburger-hover-filter;
+    }
+    @else {
+      opacity: $hamburger-hover-opacity;
+    }
+  }
+}
+
+.hamburger-box {
+  width: $hamburger-layer-width;
+  height: $hamburger-layer-height * 3 + $hamburger-layer-spacing * 2;
+  display: inline-block;
+  position: relative;
+}
+
+.hamburger-inner {
+  display: block;
+  top: 50%;
+  margin-top: $hamburger-layer-height / -2;
+
+  &,
+  &::before,
+  &::after {
+    width: $hamburger-layer-width;
+    height: $hamburger-layer-height;
+    background-color: $hamburger-layer-color;
+    border-radius: $hamburger-layer-border-radius;
+    position: absolute;
+    transition-property: transform;
+    transition-duration: 0.15s;
+    transition-timing-function: ease;
+  }
+
+  &::before,
+  &::after {
+    content: "";
+    display: block;
+  }
+
+  &::before {
+    top: ($hamburger-layer-spacing + $hamburger-layer-height) * -1;
+  }
+
+  &::after {
+    bottom: ($hamburger-layer-spacing + $hamburger-layer-height) * -1;
+  }
+}

--- a/static/styles/hamburgers/hamburgers.scss
+++ b/static/styles/hamburgers/hamburgers.scss
@@ -1,0 +1,62 @@
+/* stylelint-disable */
+@charset "UTF-8";
+/*!
+ * Hamburgers
+ * @description Tasty CSS-animated hamburgers
+ * @author Jonathan Suh @jonsuh
+ * @site https://jonsuh.com/hamburgers
+ * @link https://github.com/jonsuh/hamburgers
+ */
+
+// Settings
+// ==================================================
+$hamburger-padding-x                       : 15px !default;
+$hamburger-padding-y                       : 15px !default;
+$hamburger-layer-width                     : 40px !default;
+$hamburger-layer-height                    : 4px !default;
+$hamburger-layer-spacing                   : 6px !default;
+$hamburger-layer-color                     : #000 !default;
+$hamburger-layer-border-radius             : 4px !default;
+$hamburger-hover-opacity                   : 0.7 !default;
+$hamburger-hover-transition-duration       : 0.15s !default;
+$hamburger-hover-transition-timing-function: linear !default;
+
+// To use CSS filters as the hover effect instead of opacity,
+// set $hamburger-hover-use-filter as true and
+// change the value of $hamburger-hover-filter accordingly.
+$hamburger-hover-use-filter: false !default;
+$hamburger-hover-filter    : opacity(50%) !default;
+
+// Types (Remove or comment out what you don’t need)
+// ==================================================
+$hamburger-types: (
+  boring,
+  elastic
+) !default;
+
+// Base Hamburger (We need this)
+// ==================================================
+@import "base";
+
+// Hamburger types
+// ==================================================
+
+@import "types/boring";
+@import "types/elastic";
+
+// ==================================================
+// Cooking up additional types:
+//
+// The Sass for each hamburger type should be nested
+// inside an @if directive to check whether or not
+// it exists in $hamburger-types so only the CSS for
+// included types are generated.
+//
+// e.g. hamburgers/types/_new-type.scss
+//
+// @if index($hamburger-types, new-type) {
+//   .hamburger--new-type {
+//     ...
+//   }
+// }
+/* stylelint-enable */

--- a/static/styles/hamburgers/types/_boring.scss
+++ b/static/styles/hamburgers/types/_boring.scss
@@ -1,0 +1,30 @@
+@if index($hamburger-types, boring) {
+  /*
+   * Boring
+   */
+  .hamburger--boring {
+    .hamburger-inner {
+      &,
+      &::before,
+      &::after {
+        transition-property: none;
+      }
+    }
+
+    &.is-active {
+      .hamburger-inner {
+        transform: rotate(45deg);
+
+        &::before {
+          top: 0;
+          opacity: 0;
+        }
+
+        &::after {
+          bottom: 0;
+          transform: rotate(-90deg);
+        }
+      }
+    }
+  }
+}

--- a/static/styles/hamburgers/types/_elastic.scss
+++ b/static/styles/hamburgers/types/_elastic.scss
@@ -1,0 +1,41 @@
+@if index($hamburger-types, elastic) {
+  /*
+   * Elastic
+   */
+  .hamburger--elastic {
+    .hamburger-inner {
+      top: $hamburger-layer-height / 2;
+      transition-duration: 0.275s;
+      transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+
+      &::before {
+        top: $hamburger-layer-height + $hamburger-layer-spacing;
+        transition: opacity 0.125s 0.275s ease;
+      }
+
+      &::after {
+        top: ($hamburger-layer-height * 2) + ($hamburger-layer-spacing * 2);
+        transition: transform 0.275s cubic-bezier(0.68, -0.55, 0.265, 1.55);
+      }
+    }
+
+    &.is-active {
+      .hamburger-inner {
+        $y-offset: $hamburger-layer-spacing + $hamburger-layer-height;
+
+        transform: translate3d(0, $y-offset, 0) rotate(135deg);
+        transition-delay: 0.075s;
+
+        &::before {
+          transition-delay: 0s;
+          opacity: 0;
+        }
+
+        &::after {
+          transform: translate3d(0, $y-offset * -2, 0) rotate(-270deg);
+          transition-delay: 0.075s;
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
So we don't have to hardcode the `node_modules` path!

I attempted to use webpack for this but after a little effort it did not seem worth it just to avoid adding a few SCSS files to the project. So this is me adding a few files to the project!

We probably could remove some more of the code from the hamburgers files but I think this is good for now (I already removed about 20 files).

Closes #14 