### PR TITLE
Pin to specific version of nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,5 +2,4 @@
 /target/
 **/*.rs.bk
 /node_modules
-/static/styles/app.css
 /static/styles/*.map

--- a/RustConfig
+++ b/RustConfig
@@ -1,1 +1,1 @@
-VERSION=nightly
+VERSION=nightly-2018-05-13

--- a/static/styles/app.css
+++ b/static/styles/app.css
@@ -1,0 +1,141 @@
+/* stylelint-disable */
+/*!
+ * Hamburgers
+ * @description Tasty CSS-animated hamburgers
+ * @author Jonathan Suh @jonsuh
+ * @site https://jonsuh.com/hamburgers
+ * @link https://github.com/jonsuh/hamburgers
+ */
+.hamburger {
+  padding: 15px 15px;
+  display: inline-block;
+  cursor: pointer;
+  transition-property: opacity, filter;
+  transition-duration: 0.15s;
+  transition-timing-function: linear;
+  font: inherit;
+  color: inherit;
+  text-transform: none;
+  background-color: transparent;
+  border: 0;
+  margin: 0;
+  overflow: visible; }
+  .hamburger:hover {
+    opacity: 0.7; }
+
+.hamburger-box {
+  width: 40px;
+  height: 24px;
+  display: inline-block;
+  position: relative; }
+
+.hamburger-inner {
+  display: block;
+  top: 50%;
+  margin-top: -2px; }
+  .hamburger-inner, .hamburger-inner::before, .hamburger-inner::after {
+    width: 40px;
+    height: 4px;
+    background-color: #000;
+    border-radius: 4px;
+    position: absolute;
+    transition-property: transform;
+    transition-duration: 0.15s;
+    transition-timing-function: ease; }
+  .hamburger-inner::before, .hamburger-inner::after {
+    content: "";
+    display: block; }
+  .hamburger-inner::before {
+    top: -10px; }
+  .hamburger-inner::after {
+    bottom: -10px; }
+
+/*
+ * Boring
+ */
+.hamburger--boring .hamburger-inner, .hamburger--boring .hamburger-inner::before, .hamburger--boring .hamburger-inner::after {
+  transition-property: none; }
+.hamburger--boring.is-active .hamburger-inner {
+  transform: rotate(45deg); }
+  .hamburger--boring.is-active .hamburger-inner::before {
+    top: 0;
+    opacity: 0; }
+  .hamburger--boring.is-active .hamburger-inner::after {
+    bottom: 0;
+    transform: rotate(-90deg); }
+
+/*
+ * Elastic
+ */
+.hamburger--elastic .hamburger-inner {
+  top: 2px;
+  transition-duration: 0.275s;
+  transition-timing-function: cubic-bezier(0.68, -0.55, 0.265, 1.55); }
+  .hamburger--elastic .hamburger-inner::before {
+    top: 10px;
+    transition: opacity 0.125s 0.275s ease; }
+  .hamburger--elastic .hamburger-inner::after {
+    top: 20px;
+    transition: transform 0.275s cubic-bezier(0.68, -0.55, 0.265, 1.55); }
+.hamburger--elastic.is-active .hamburger-inner {
+  transform: translate3d(0, 10px, 0) rotate(135deg);
+  transition-delay: 0.075s; }
+  .hamburger--elastic.is-active .hamburger-inner::before {
+    transition-delay: 0s;
+    opacity: 0; }
+  .hamburger--elastic.is-active .hamburger-inner::after {
+    transform: translate3d(0, -20px, 0) rotate(-270deg);
+    transition-delay: 0.075s; }
+
+/* stylelint-enable */
+label.hamburger {
+  float: right; }
+  @media (min-width: 750px) {
+    label.hamburger {
+      display: none; } }
+
+.logo-small {
+  width: 50px;
+  height: 50px;
+  margin-top: 9px; }
+  @media (min-width: 750px) {
+    .logo-small {
+      float: left; } }
+
+nav {
+  display: none;
+  flex-direction: column;
+  border: none;
+  width: 100%;
+  background-color: #fff; }
+  @media (min-width: 750px) {
+    nav {
+      display: inline-block;
+      text-align: right;
+      margin: auto;
+      margin-top: 18px;
+      padding-bottom: 30px;
+      width: 87%; }
+      nav a {
+        padding-left: 1%; } }
+
+input:checked ~ nav {
+  display: flex;
+  flex-direction: column; }
+
+body {
+  background-color: #fff;
+  color: #454c53;
+  font-size: 2rem; }
+  body a {
+    text-decoration: none;
+    color: #454c53; }
+  @media (min-width: 750px) {
+    body {
+      font-size: 1rem; }
+      body a:hover {
+        color: #4e545b; }
+      body a:active {
+        color: #e7e7e8; } }
+
+/*# sourceMappingURL=app.css.map */

--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>{{title}}</title>
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="stylesheet" href="/static/styles/skeleton.css"/>
     <link rel="stylesheet" href="/static/styles/app.css"/>
     <link rel="shortcut icon" href="/static/images/favicon.ico" type="image/x-icon">


### PR DESCRIPTION
Pinning to 5/13 version. It builds!

Also: adds the compiled `app.css back` (woops, it was in the `.gitignore`) and adds viewport/content info so it works on actual mobile devices instead of showing a tiny version of the desktop site regardless of media queries.

![image](https://user-images.githubusercontent.com/4008348/40258785-9f6397c4-5aa7-11e8-994b-3a92396a45d7.png)


