### PR TITLE
[WIP] Community page changes

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -4,9 +4,14 @@
   <h1>Community</h1>
 </header>
 
+<section id="get-in-touch">
+  <h2>Get in touch!</h2>
+  <p>We'd like to hear from you! We'll answer any question at <a href="mailto:community@rust-lang.org">community@rust-lang.org</a></p>
+</section>
+
 <section id="events">
-  <h2>Events</h2>
-  <p>teaser copy</p>
+  <h2>Meet</h2>
+  <p>Many community members run meetups or conferences!</p>
   <h3><a href="/community/events">Learn More</a></h3>
 </section>
 
@@ -14,6 +19,12 @@
   <h2>Content</h2>
   <p>teaser copy</p>
   <h3><a href="/community/content">Learn More</a></h3>
+</section>
+
+<section id="online">
+  <h2>Online</h2>
+  <p>teaser copy</p>
+  <h3><a href="/community/online">Learn More</a></h3>
 </section>
 
 <section id="rustbridge">


### PR DESCRIPTION
This is very WIP, but my starting point to getting some ideas out of my head.

![image1](https://user-images.githubusercontent.com/47542/43078235-2c5def92-8e8a-11e8-8eac-2206f24d20e9.jpeg)

My idea is to highlight all aspects of community quickly, and putting "you can get in touch/involved" front and center.

I would like to find new home for a lot of things on https://www.rust-lang.org/en-US/community.html, but a lot of these things (like the channel list) are high maintenance and should probably move out of the main page.


