### PR TITLE
Verify category before loading file

### DIFF
--- a/src/category.rs
+++ b/src/category.rs
@@ -1,0 +1,45 @@
+use rocket::http::RawStr;
+use rocket::request::FromParam;
+
+const CATEGORIES: [&str; 8] = [
+    "community",
+    "contribute",
+    "governance",
+    "learn",
+    "policies",
+    "production",
+    "tools",
+    "what",
+];
+
+pub struct Category {
+    name: String,
+}
+
+impl Category {
+    pub fn name(&self) -> &str {
+        self.name.as_str()
+    }
+
+    pub fn index(&self) -> String {
+        format!("{}/index", self.name())
+    }
+}
+
+impl<'r> FromParam<'r> for Category {
+    type Error = &'r RawStr;
+
+    fn from_param(param: &'r RawStr) -> Result<Self, Self::Error> {
+        let res = param.url_decode();
+        match res {
+            Ok(url) => {
+                if CATEGORIES.contains(&url.as_str()) {
+                    Ok(Category { name: url })
+                } else {
+                    Err(RawStr::from_str("no such category"))
+                }
+            }
+            Err(e) => Err(RawStr::from_str("url illegal in utf-8")),
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ extern crate rocket_contrib;
 #[macro_use]
 extern crate serde_derive;
 
+mod category;
+
 use std::fs::File;
 use std::io::prelude::*;
 use std::path::{Path, PathBuf};
@@ -16,6 +18,8 @@ use rocket::response::NamedFile;
 use rocket_contrib::Template;
 
 use sass_rs::{compile_file, Options};
+
+use category::Category;
 
 #[derive(Serialize)]
 struct Context {
@@ -42,11 +46,11 @@ fn files(file: PathBuf) -> Option<NamedFile> {
 }
 
 #[get("/<category>")]
-fn category(category: String) -> Template {
-    let page = format!("{}/index", category.as_str()).to_string();
+fn category(category: Category) -> Template {
+    let page = category.index();
     let title = format!("Rust - {}", page).to_string();
     let context = Context {
-        page: category,
+        page: category.name().to_string(),
         title: title,
         parent: "layout".to_string(),
     };
@@ -54,8 +58,8 @@ fn category(category: String) -> Template {
 }
 
 #[get("/<category>/<subject>", rank = 2)]
-fn subject(category: String, subject: String) -> Template {
-    let page = format!("{}/{}", category.as_str(), subject.as_str()).to_string();
+fn subject(category: Category, subject: String) -> Template {
+    let page = format!("{}/{}", category.name(), subject.as_str()).to_string();
     let title = format!("Rust - {}", page).to_string();
     let context = Context {
         page: subject,


### PR DESCRIPTION
Verify category to *real* categories only, rather than seeing everything `/<category>` as categories.

Also solves favicon.ico (seen as category) problem in development environment.

* Not sure who are the categories
  * Currently I manually checked all the links...
  * Should they be loaded / tested dynamically during app start up? (e.g. through a directory scan?)