### PR TITLE
Stage 2 revisions: policies

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -14,7 +14,6 @@
       <div class="four columns" id="terms-and-policies">
         <h4>Terms and Policies</h4>
         <ul>
-          <li><a href="/policies">Policies Index</a></li>
           <li><a href="/policies/code-of-conduct">Code of Conduct</a></li>
           <li><a href="/policies/license">License</a></li>
           <li><a href="/policies/media-guide">Logo Policy and Media Guide</a></li>
@@ -23,16 +22,18 @@
       </div>
       <div class="four columns" id="rust-social">
         <h4>Social</h4>
-        <a href="#"><img src="/static/images/twitter.svg"/></a>
-        <a href="#"><img src="/static/images/youtube.svg"/></a>
-        <a href="#"><img src="/static/images/discord.svg"/></a>
-        <a href="#"><img src="/static/images/github.svg"/></a>
+        <a href="#"><img src="/static/images/twitter.svg" /></a>
+        <a href="#"><img src="/static/images/youtube.svg" /></a>
+        <a href="#"><img src="/static/images/discord.svg" /></a>
+        <a href="#"><img src="/static/images/github.svg" /></a>
       </div>
 
     </div>
     <div class="attribution">
       Maintained by the Rust Team. See a typo? Send a fix <a href="#">here</a>!
-      <div>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
+      <div>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/"
+          title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/"
+          title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
     </div>
   </div>
 </footer>

--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -14,15 +14,27 @@
     </header>
     <p><strong>Contact</strong>: <a href="mailto:rust-mods@rust-lang.org">rust-mods@rust-lang.org</a></p>
     <ul>
-      <li>We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.</li>
-      <li>On IRC, please avoid using overtly sexual nicknames or other nicknames that might detract from a friendly, safe and welcoming environment for all.</li>
+      <li>We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of
+        experience, gender identity and expression, sexual orientation, disability, personal appearance, body size,
+        race, ethnicity, age, religion, nationality, or other similar characteristic.</li>
+      <li>Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and
+        welcoming environment for all.</li>
       <li>Please be kind and courteous. There’s no need to be mean or rude.</li>
-      <li>Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.</li>
-      <li>Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.</li>
-      <li>We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.</li>
-      <li>Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the <a href="/team.html#Moderation-team">Rust moderation team</a> immediately. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.</li>
+      <li>Respect that people have differences of opinion and that every design or implementation choice carries a
+        trade-off and numerous costs. There is seldom a right answer.</li>
+      <li>Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a
+        fork and see how it works.</li>
+      <li>We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We
+        interpret the term “harassment” as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen
+          Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please
+        read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized
+        groups.</li>
+      <li>Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being
+        harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the <a
+          href="/team.html#Moderation-team">Rust moderation team</a> immediately. Whether you’re a regular contributor
+        or a newcomer, we care about making this community a safe place for you and we’ve got your back.</li>
       <li>Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.</li>
-</ul>
+    </ul>
   </div>
 </section>
 
@@ -32,21 +44,45 @@
       <h2>Moderation</h2>
       <div class="highlight highlight-green"></div>
     </header>
-    <p>These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs moderation, please contact the <a href="/team.html#Moderation-team">Rust moderation team</a>.</p>
+    <p>These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs
+      moderation, please contact the <a href="/team.html#Moderation-team">Rust moderation team</a>.</p>
     <ol>
-      <li>Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)</li>
-      <li>Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.</li>
+      <li>Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary
+        remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful
+        manner.)</li>
+      <li>Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not
+        allowed.</li>
       <li>Moderators will first respond to such remarks with a warning.</li>
-      <li>If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.</li>
+      <li>If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool
+        off.</li>
       <li>If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.</li>
-      <li>Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.</li>
-      <li>If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, <strong>in private</strong>. Complaints about bans in-channel are not allowed.</li>
-      <li>Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.</li>
+      <li>Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the
+        offended party a genuine apology.</li>
+      <li>If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with
+        a different moderator, <strong>in private</strong>. Complaints about bans in-channel are not allowed.</li>
+      <li>Moderators are held to a higher standard than other community members. If a moderator creates an
+        inappropriate situation, they should expect less leeway than others.</li>
     </ol>
-    <p>In the Rust community we strive to go the extra step to look out for each other. Don’t just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they’re off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.</p>
-    <p>And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could’ve communicated better — remember that it’s your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.</p>
-    <p>The enforcement policies listed above apply to all official Rust venues; including official IRC channels (#rust, #rust-internals, #rust-tools, #rust-libs, #rustc, #rust-beginners, #rust-docs, #rust-community, #rust-lang, and #cargo); GitHub repositories under rust-lang, rust-lang-nursery, and rust-lang-deprecated; and all forums under rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your own moderation policy so as to avoid confusion.</p>
-    <p><em>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling">Node.js Policy on Trolling</a> as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/">Contributor Covenant v1.3.0</a>.</em></p>
+    <p>In the Rust community we strive to go the extra step to look out for each other. Don’t just aim to be
+      technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive
+      issues, particularly if they’re off-topic; this all too often leads to unnecessary fights, hurt feelings, and
+      damaged trust; worse, it can drive people away from the community entirely.</p>
+    <p>And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what
+      it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances
+      are good there was something you could’ve communicated better — remember that it’s your responsibility to make
+      your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we
+      want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as
+      long as you earn their trust.</p>
+    <p>The enforcement policies listed above apply to all official Rust venues; including official IRC channels (#rust,
+      #rust-internals, #rust-tools, #rust-libs, #rustc, #rust-beginners, #rust-docs, #rust-community, #rust-lang, and
+      #cargo); Discord channels (https://discord.gg/rust-lang); GitHub repositories under rust-lang, rust-lang-nursery,
+      and rust-lang-deprecated; and all forums under
+      rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of
+      Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of
+      conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your
+      own moderation policy so as to avoid confusion.</p>
+    <p><em>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling">Node.js Policy on Trolling</a>
+        as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/">Contributor Covenant v1.3.0</a>.</em></p>
   </div>
 </section>
 


### PR DESCRIPTION
This is a quick PR which removes the link to the policy index (a page that seems unnecessary) and revises the CoC to account for Discord.

Some open questions:

- Do we actually want some kind of policy index page? Since we list *all* the policy documents in the footer, it seems unnecessary. (That said, this PR does not fully remove the page; it looks like the templating system requires an index page)

- Are there steps we can take to make these dense policy documents visually easier to digest (without changing the content)? Probably not high priority, but something to consider when working through styling.