### PR TITLE
Prevent Google Calendar iframe from overflowing.

### DIFF
--- a/templates/panels/get-involved.hbs
+++ b/templates/panels/get-involved.hbs
@@ -31,7 +31,7 @@
       </div>
       <div class="four columns" id="upcoming-events">
         <h3>Upcoming Events</h3>
-        <iframe src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=400&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com&amp;color=%23691426&amp;ctz=Europe%2FMadrid"
+        <iframe class="twelve columns" src="https://calendar.google.com/calendar/embed?showTitle=0&amp;showPrint=0&amp;showTabs=0&amp;showCalendars=0&amp;mode=AGENDA&amp;height=400&amp;wkst=1&amp;bgcolor=%23FFFFFF&amp;src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com&amp;color=%23691426&amp;ctz=Europe%2FMadrid"
           style="border-width:0" height="400" frameborder="0" scrolling="no"></iframe>
       </div>
     </div>


### PR DESCRIPTION
The tweak here makes it properly behave as a flexible grid item, which means it gets *squished*, but it does not cause horizontal overflow on the page.