### PR TITLE
remove language-values

### DIFF
--- a/templates/what/index.hbs
+++ b/templates/what/index.hbs
@@ -13,12 +13,6 @@
   <h3><a href="what/server">Server</a></h3>
 </section>
 
-<section id="language-values">
-  <h2>Language Values</h2>
-  <p>teaser copy</p>
-  <h3><a href="what/language-values">Learn More</a></h3>
-</section>
-
 <section id="Production">
   <h2>Production</h2>
   <p>teaser copy</p>

--- a/templates/what/language-values.hbs
+++ b/templates/what/language-values.hbs
@@ -1,8 +1,0 @@
-{{#*inline "page"}}
-
-<section>
-  <h1>Language Values</h1>
-</section>
-
-{{/inline}}
-{{~> (parent)~}}

--- a/templates/what/release-timeline.hbs
+++ b/templates/what/release-timeline.hbs
@@ -7,7 +7,6 @@
 <section>
   <a href="governance">Learn more about Rust's governance</a>
   <a href="contribute">Contribute to Rust</a>
-  <a href="what/language-values">Learn more about Rust's Values</a>
 </section>
 
 {{/inline}}


### PR DESCRIPTION
Removes the Language Values page as per https://github.com/rust-lang/wubwub/issues/145. With https://github.com/rust-lang/wubwub/pull/154 this might leave the Release Timeline page a bit empty, but I propose we address that in a separate PR. Thanks!