### PR TITLE
fold footer license into licenses page

### DIFF
--- a/templates/footer.hbs
+++ b/templates/footer.hbs
@@ -15,7 +15,7 @@
         <h4>Terms and Policies</h4>
         <ul>
           <li><a href="/policies/code-of-conduct">Code of Conduct</a></li>
-          <li><a href="/policies/license">License</a></li>
+          <li><a href="/policies/licenses">Licenses</a></li>
           <li><a href="/policies/media-guide">Logo Policy and Media Guide</a></li>
           <li><a href="/policies/security">Security Disclosures</a></li>
         </ul>
@@ -30,10 +30,8 @@
 
     </div>
     <div class="attribution">
-      Maintained by the Rust Team. See a typo? Send a fix <a href="https://github.com/rust-lang/wubwub">here</a>!
-      <div>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/"
-          title="Flaticon">www.flaticon.com</a> is licensed by <a href="http://creativecommons.org/licenses/by/3.0/"
-          title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a></div>
+      Maintained by the Rust Team. See a typo? Send a fix
+      <a href="https://github.com/rust-lang/wubwub">here</a>!
     </div>
   </div>
 </footer>

--- a/templates/policies/index.hbs
+++ b/templates/policies/index.hbs
@@ -12,7 +12,7 @@
     <ul>
       <li><a href="/policies/media-guide">Media Guide</a></li>
       <li><a href="/policies/security">Security</a></li>
-      <li><a href="/policies/license">License</a></li>
+      <li><a href="/policies/licenses">Licenses</a></li>
       <li><a href="/policies/code-of-conduct">Code of Conduct</a></li>
     </ul>
     <p>Emerged into consciousness, encyclopaedia galactica muse about dream of the mind's eye prime number? Extraordinary claims require extraordinary evidence star stuff harvesting star light! Muse about finite but unbounded, Cambrian explosion cosmic ocean encyclopaedia galactica courage of our questions vastness is bearable only through love and billions upon billions upon billions upon billions upon billions upon billions upon billions.</p>

--- a/templates/policies/licenses.hbs
+++ b/templates/policies/licenses.hbs
@@ -2,12 +2,16 @@
 
 <header>
   <div class="container">
-    <h1>License</h1>
+    <h1>Licenses</h1>
   </div>
 </header>
 
 <section id="license" class="purple">
   <div class="container">
+    <header>
+      <h2>License</h2>
+      <div class="highlight"></div>
+    </header>
     <p>The Rust Programing Language and all other official projects are generally dually licensed:</p>
     <ul>
       <li><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a></li>
@@ -17,6 +21,20 @@
     <p>If you have a specific question or concern about how the Rust project or any of its associated projects are licensed, please contact the Rust Core Team.</p>
     <a href="mailto:core-team@rust-lang.org" class="button button-secondary">Email The Core Team</a>
   </div>
+</section>
+
+<section id="license" class="red">
+  <div class="container">
+    <header>
+      <h2>Attribution</h2>
+      <div class="highlight"></div>
+    </header>
+    <p>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a>
+      from <a href="https://www.flaticon.com/"
+              title="Flaticon">www.flaticon.com</a> is licensed by
+            <a href="http://creativecommons.org/licenses/by/3.0/"
+               title="Creative Commons BY 3.0" target="_blank">CC 3.0 BY</a>
+    </p>
 </section>
 
 {{/inline}}

--- a/templates/production/index.hbs
+++ b/templates/production/index.hbs
@@ -90,7 +90,7 @@
         <div class="highlight highlight-green">
       </header>
       <p>White dwarf. Corpus callosum. Brain is the seed of intelligence rings of Uranus how far away vastness?</p>
-      <a href="/policies/license" class="button button-secondary">Policies: License</a>
+      <a href="/policies/licenses" class="button button-secondary">Policies: License</a>
     </div>
   </div>
 </section>


### PR DESCRIPTION
Renames the License page to Licenses, and moves the icon attribution from the footer to the Licenses page. As per #145. Thanks!

## Screenshot
![licenses](https://screenshotscdn.firefoxusercontent.com/images/303372d4-ec99-4a12-8fa8-461bb35470f3.png)