### PR TITLE
Update with final embedded book links

### DIFF
--- a/templates/what/embedded/pitch.hbs
+++ b/templates/what/embedded/pitch.hbs
@@ -14,7 +14,7 @@
           Enforce pin and peripheral configuration at compile time. Guarantee that resources won't be used by
           unintended parts of your application.
         </p>
-        <a href="https://github.com/rust-embedded/book/issues/5" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/static-guarantees/" class="button button-secondary">Learn more</a>
       </div>
       <div class="four columns" id="flexible-memory-management">
         <div class="domain-icon">
@@ -25,7 +25,7 @@
           Dynamic memory allocation is optional. Use a global allocator and dynamic data structures.
           Or leave out the heap altogether and statically allocate everything.
         </p>
-          <a href="https://github.com/rust-embedded/book/issues/8" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/collections/" class="button button-secondary">Learn more</a>
       </div>
       <div class="four columns" id="safe-concurrency">
         <div class="domain-icon">
@@ -36,7 +36,7 @@
           Rust makes it impossible to accidentally share state between threads.
           Use any concurrency approach you like, and you'll still get Rust's strong guarantees.
         </p>
-        <a href="https://github.com/rust-embedded/book/issues/7" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/concurrency/" class="button button-secondary">Learn more</a>
       </div>
     </div>
     <div class="row">
@@ -49,7 +49,7 @@
           Integrate Rust into your existing C codebase or leverage an existing SDK to write a Rust
           application.
         </p>
-        <a href="https://github.com/rust-embedded/book/issues/1" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/interoperability/" class="button button-secondary">Learn more</a>
       </div>
       <div class="four columns" id="portability">
         <div class="domain-icon">
@@ -60,7 +60,7 @@
           Write a library or driver once, and use it with a variety of systems, ranging
           from very small microcontrollers to powerful SBCs.
         </p>
-          <a href="https://github.com/rust-embedded/book/issues/6" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/portability/" class="button button-secondary">Learn more</a>
       </div>
       <div class="four columns">
         <div class="domain-icon">


### PR DESCRIPTION
NOTE: These links will not work until https://github.com/rust-embedded/book/pull/80 lands, however this should likely be in the next hour or so.