### PR TITLE
CLI: Name ALL the CTAs

### DIFF
--- a/templates/what/cli/maintainable.hbs
+++ b/templates/what/cli/maintainable.hbs
@@ -18,7 +18,9 @@
                     out these "what if" situations before you even run your
                     program.
                 </p>
-                <a href="https://doc.rust-lang.org/book/2018-edition/ch09-00-error-handling.html" class="button button-secondary">Learn more</a>
+                <a href="https://doc.rust-lang.org/book/2018-edition/ch09-00-error-handling.html" class="button button-secondary">
+                    Rust's error handling
+                </a>
             </article>
             <article class="six columns box">
                 <header class="domain-icon">
@@ -31,6 +33,9 @@
                     features, refactor your application with the confidence that
                     you aren't breaking anything.
                 </p>
+                <a href="https://doc.rust-lang.org/book/2018-edition/ch12-03-improving-error-handling-and-modularity.html" class="button button-secondary">
+                    Refactoring Rust
+                </a>
             </article>
         </div>
     </div>

--- a/templates/what/cli/pitch.hbs
+++ b/templates/what/cli/pitch.hbs
@@ -15,7 +15,9 @@
                     you can be confident it's fast, easily testable,
                     and gives helpful output.
                 </p>
-                <a href="https://www.rust-lang.org" class="button button-secondary">??</a>
+                <a href="/learn" class="button button-secondary">
+                  Rust's guarantees
+                </a>
             </article>
             <article class="four columns box">
                 <header class="domain-icon">
@@ -26,53 +28,63 @@
                     Compile everything down to a single binary&mdash;no need for your users to have a runtime
                     or libraries installed.
                 </p>
-                <a href="https://crate-ci.github.io/release.html" class="button button-secondary">??</a>
+                <a href="https://crate-ci.github.io/release.html" class="button button-secondary">
+                    How to ship Rust code
+                </a>
             </article>
             <article class="four columns box">
-                    <header class="domain-icon">
-                        <img src="/static/images/cli-configs.svg" alt="" />
-                        <h3>Robust Configuration</h3>
-                    </header>
+                <header class="domain-icon">
+                    <img src="/static/images/cli-configs.svg" alt="" />
+                    <h3>Robust Configuration</h3>
+                </header>
                 <p>
                     Handle configuration files across platforms with ease.
                     Rust will deal with namespaces and formats for you.
                 </p>
-                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/config-files.html" class="button button-secondary">??</a>
+                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/config-files.html" class="button button-secondary">
+                    Start configuring
+                </a>
             </article>
         </div>
         <div class="row">
             <article class="four columns box">
-                    <header class="domain-icon">
-                        <img src="/static/images/cli-man.svg" alt="" />
-                        <h3>Manuals? Done.</h3>
-                    </header>
+                <header class="domain-icon">
+                    <img src="/static/images/cli-man.svg" alt="" />
+                    <h3>Manuals? Done.</h3>
+                </header>
                 <p>
                     Generate manual pages for your app automatically.
                     Just package the generated files and you're done.
                 </p>
-                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/docs.html" class="button button-secondary">??</a>
+                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/docs.html" class="button button-secondary">
+                    Learn how
+                </a>
             </article>
             <article class="four columns box">
-                    <header class="domain-icon">
-                        <img src="/static/images/cli-pipe.svg" alt="" />
-                        <h3><code>cat data | app</code></h3>
-                    </header>
+                <header class="domain-icon">
+                    <img src="/static/images/cli-pipe.svg" alt="" />
+                    <h3><code>cat data | app</code></h3>
+                </header>
                 <p>
                     In addition to talking to humans,
                     Rust has great tools to help you talk to machines.
                 </p>
-                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/machine-communication.html" class="button button-secondary">??</a>
+                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/machine-communication.html" class="button button-secondary">
+                    Communicate with machines
+                </a>
             </article>
             <article class="four columns box">
-                    <header class="domain-icon">
-                        <img src="/static/images/cli-logging.svg" alt="" />
-                        <h3>Flexible Logging</h3>
-                    </header>
+                <header class="domain-icon">
+                    <img src="/static/images/cli-logging.svg" alt="" />
+                    <h3>Flexible Logging</h3>
+                </header>
                 <p>
                     It's easy to add logging, and even easier to configure
                     it to different targets and with different styles.
                 </p>
-                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/human-communication.html" class="button button-secondary">???</a>
+                <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/human-communication.html" class="button button-secondary">
+                    Log, trace, comprehend
+                </a>
             </article>
         </div>
     </div>


### PR DESCRIPTION
I had two options. Either go with 'learn more' for all links, or to come
up with individual texts for every single one of them. I went with the
latter because it's more fun.

I'm not sure about the tone of the buttons. They should probably be less
casual and also in imperative form.

Part of #190 