### PR TITLE
feat(wasm): replace gutenberg with cloudflare

### DIFF
--- a/templates/what/wasm/production.hbs
+++ b/templates/what/wasm/production.hbs
@@ -7,18 +7,18 @@
         <div class="testimonials">
             <div class="testimonial row">
                 <div class="four columns">
-                  <img src="/static/images/dropbox.svg" />
+                  <img src="/static/images/user-logos/cloudflare.svg" />
                 </div>
                 <div class="eight columns">
                     <blockquote>
-                        [Rust’s] properties make it easy to embed the DivANS codec in a
-                        webpage with WASM, as shown above.
+                       We can compile Rust to WASM, and call it from Serverless functions woven into the very fabric of the Internet. That's huge and I can't wait to do more of it.
                     </blockquote>
                     <p class="attribution">
-                        &ndash; Daniel Reiter Horn and Jongmin Baek,
-                        <a href="https://blogs.dropbox.com/tech/2018/06/building-better-compression-together-with-divans/">
-                            Building Better Compression Together with DivANS
+                        &ndash;  Steven Pack,
+                        <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/">
+                            Serverless Rust with Cloudflare Workers
                         </a>
+
                     </p>
                 </div>
             </div>
@@ -45,23 +45,18 @@
             </div>
             <div class="testimonial row">
                 <div class="four columns">
-                  <img src="/static/images/wordpress.png" />
+                  <img src="/static/images/dropbox.svg" />
                 </div>
                 <div class="eight columns">
                     <blockquote>
-                        The Rust part for WebAssembly plus the Javascript part totals 313
-                        lines of code. This is a tiny surface of code to review and to
-                        maintain compared to writing a Javascript parser from scratch… The
-                        WebAssembly binary is in average 86 times faster than the actual
-                        Javascript implementation… So not only it is safer, but it is faster
-                        than Javascript in this case. And it is only 300 lines of code.
+                        [Rust’s] properties make it easy to embed the DivANS codec in a
+                        webpage with WASM, as shown above.
                     </blockquote>
                     <p class="attribution">
-                        &ndash; Ivan Enderlin,
-                        <a href="https://mnt.io/2018/08/22/from-rust-to-beyond-the-webassembly-galaxy/">
-                            Parsing the WordPress Gutenberg Post Format in Rust and WebAssembly
+                        &ndash; Daniel Reiter Horn and Jongmin Baek,
+                        <a href="https://blogs.dropbox.com/tech/2018/06/building-better-compression-together-with-divans/">
+                            Building Better Compression Together with DivANS
                         </a>
-
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
fixes #191 

this should close out the outstanding requirements for the wasm page that aren't global css issues.

![screenshot_2018-11-14 rust - what wasm](https://user-images.githubusercontent.com/1163554/48509508-573c4d00-e81f-11e8-8f04-709e501fb466.png)
