### PR TITLE
Align CTAs

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -477,7 +477,9 @@ blockquote::before {
 }
 
 #cli-pitch,
-#cli-features {
+#cli-features,
+#embedded-why-rust,
+#embedded-get-started {
   .domain-icon {
     display: block;
     padding-bottom: 0;

--- a/templates/what/embedded/get-started.hbs
+++ b/templates/what/embedded/get-started.hbs
@@ -6,20 +6,20 @@
     </header>
     <div class="row">
       <div class="four columns" id="discovery-book">
-        <div class="domain-icon">
+        <header class="domain-icon">
           <img src="/static/images/chip1.svg" alt="DIP-6 package"/>
           <h3>The discovery book</h3>
-        </div>
+        </header>
         <p>
           Learn embedded development from the ground up&mdash;using Rust!
         </p>
         <a href="https://rust-embedded.github.io/discovery/" class="button button-secondary">Read</a>
       </div>
       <div class="four columns" id="embedded-rust-book">
-        <div class="domain-icon">
+        <header class="domain-icon">
           <img src="/static/images/chip2.svg" alt="TFQP-16 package"/>
           <h3>The Embedded Rust book</h3>
-        </div>
+        </header>
         <p>
           Already familiar with Embedded development?
           Jump in with Rust and start reaping the benefits.
@@ -27,10 +27,10 @@
         <a href="https://rust-embedded.github.io/book/" class="button button-secondary">Read</a>
       </div>
       <div class="four columns" id="embedonomicon">
-        <div class="domain-icon">
+        <header class="domain-icon">
           <img src="/static/images/chip3.svg" alt="BGA package" />
           <h3>The Embedonomicon</h3>
-        </div>
+        </header>
         <p>
           Look under the hood of foundational embedded libraries.
         </p>

--- a/templates/what/embedded/pitch.hbs
+++ b/templates/what/embedded/pitch.hbs
@@ -5,34 +5,34 @@
       <div class="highlight"></div>
     </header>
     <div class="row">
-      <div class="four columns" id="powerful-static-analysis">
-        <div class="domain-icon">
+      <div class="four columns box" id="powerful-static-analysis">
+        <header class="domain-icon">
           <img src="/static/images/microscope.svg" alt="A microscope"/>
           <h3>Powerful static analysis</h3>
-        </div>
-        <p>
+        </header>
+        <p class="box-content">
           Enforce pin and peripheral configuration at compile time. Guarantee that resources won't be used by
           unintended parts of your application.
         </p>
         <a href="https://docs.rust-embedded.org/book/static-guarantees/" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns" id="flexible-memory-management">
-        <div class="domain-icon">
+      <div class="four columns box" id="flexible-memory-management">
+        <header class="domain-icon">
           <img src="/static/images/ram-memory.svg" alt="A RAM stick"/>
           <h3>Flexible memory management</h3>
-        </div>
-        <p>
+        </header>
+        <p class="box-content">
           Dynamic memory allocation is optional. Use a global allocator and dynamic data structures.
           Or leave out the heap altogether and statically allocate everything.
         </p>
           <a href="https://docs.rust-embedded.org/book/collections/" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns" id="safe-concurrency">
-        <div class="domain-icon">
+      <div class="four columns box" id="safe-concurrency">
+        <header class="domain-icon">
           <img src="/static/images/gears.svg" alt="Gears"/>
           <h3>Fearless concurrency</h3>
-        </div>
-        <p>
+        </header>
+        <p class="box-content">
           Rust makes it impossible to accidentally share state between threads.
           Use any concurrency approach you like, and you'll still get Rust's strong guarantees.
         </p>
@@ -40,34 +40,34 @@
       </div>
     </div>
     <div class="row">
-      <div class="four columns" id="Interoperability">
-        <div class="domain-icon">
+      <div class="four columns box" id="Interoperability">
+        <header class="domain-icon">
           <img src="/static/images/handshake.svg" alt="Handshake" />
           <h3>Interoperability</h3>
-        </div>
-        <p>
+        </header>
+        <p class="box-content">
           Integrate Rust into your existing C codebase or leverage an existing SDK to write a Rust
           application.
         </p>
         <a href="https://docs.rust-embedded.org/book/interoperability/" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns" id="portability">
-        <div class="domain-icon">
+      <div class="four columns box" id="portability">
+        <header class="domain-icon">
           <img src="/static/images/luggage.svg" alt="Luggage trolley" />
           <h3>Portability</h3>
-        </div>
-        <p>
+        </header>
+        <p class="box-content">
           Write a library or driver once, and use it with a variety of systems, ranging
           from very small microcontrollers to powerful SBCs.
         </p>
           <a href="https://docs.rust-embedded.org/book/portability/" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns">
-        <div class="domain-icon">
+      <div class="four columns box">
+        <header class="domain-icon">
           <img src="/static/images/cli-rustc-approved.svg" alt="Shield Logo" />
           <h3>Community driven</h3>
-        </div>
-        <p>
+        </header>
+        <p class="box-content">
           As part of the Rust open source project, support for embedded systems is driven by a best-in-class open source community, with support from commercial partners.
         </p>
         <a href="https://github.com/rust-embedded/wg" class="button button-secondary">Learn more</a>


### PR DESCRIPTION
- Align CTAs

    Fixes #135 but might need to be re-done when switching CSS frameworks
    and when we finally fix how these layouts look on mobile.
- Adjust domain icon overrides

    The markup seems to be very inconsistent with .box, header.domain-icon,
    .box-content only used sometimes. This is the only page that seems to
    suffer from it though (wrong looking spacings), so I aligned it with
    what the CLI page uses.