### PR TITLE
fix(tools): set heading levels correctly for doc outline

### DIFF
--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -74,9 +74,9 @@
     </p>
     <div class="row">
       <div class="four columns" id="type-systems">
-        <h2 class="code-header">
+        <h3 class="code-header">
           Install
-        </h2>
+        </h3>
         <p>
           With tens of thousands of packages, there's a good chance
           <a href="https://crates.io" target="_blank" rel="noopener">crates.io</a> has the solution you're
@@ -85,9 +85,9 @@
         </p>
       </div>
       <div class="four columns" id="linting">
-        <h2 class="code-header">
+        <h3 class="code-header">
           Test
-        </h2>
+        </h3>
         <p>
           Bring confidence to your code through Rust's excellent testing tools.
           <code>cargo test</code> is Rust's unified solution to testing. Write
@@ -96,9 +96,9 @@
         </p>
       </div>
       <div class="four columns" id="type-systems">
-        <h2 class="code-header">
+        <h3 class="code-header">
           Deploy
-        </h2>
+        </h3>
         <p>
           <code>cargo build</code> creates lean binaries for every platform.
           With a single command your code can target Windows, Linux, OSX, and
@@ -113,9 +113,9 @@
 <section id="tools-debug" class="red">
   <div class="container">
     <header>
-      <h2>
+      <h3>
         Velocity through automation
-      </h2>
+      </h3>
       <div class="highlight highlight-red"></div>
     </header>
     <br>
@@ -125,9 +125,9 @@
     </p>
     <div class="row">
       <div class="four columns" id="type-systems">
-        <h2 class="code-header">
+        <h3 class="code-header">
           Rustfmt
-        </h2>
+        </h3>
         <p>
           Rustfmt automatically formats Rust code, making it easier to read,
           write, and maintain. And most importantly: never debate spacing or
@@ -137,9 +137,9 @@
              class="button button-secondary">Go to repo</a>
       </div>
       <div class="four columns" id="type-systems">
-        <h2 class="code-header">
+        <h3 class="code-header">
           Clippy
-        </h2>
+        </h3>
         <p>
           <em>"It looks like you're writing an Iterator."</em> <br> Clippy
           helps developers of all experience levels write idiomatic code, and
@@ -149,9 +149,9 @@
              class="button button-secondary">Go to repo</a>
       </div>
       <div class="four columns" id="type-systems">
-        <h2 class="code-header">
+        <h3 class="code-header">
           Cargo Doc
-        </h2>
+        </h3>
         <p>
           Cargo's doc builder makes it to so no API ever goes undocumented. It's
           available locally through <code>cargo doc</code>, and online for


### PR DESCRIPTION
Just replacing some `h2`s with `h3`s to get the document outline correct.