### PR TITLE
feat(landing): responsify domain section

### DIFF
--- a/templates/panels/domains.hbs
+++ b/templates/panels/domains.hbs
@@ -1,54 +1,80 @@
 <section class="purple">
   <div class="container">
     <header>
-      <h2>Build it in Rust</h2>
+      <h2>
+        Build it in Rust
+      </h2>
       <div class="highlight"></div>
     </header>
-    <div class="row">
-      <div class="three columns flex vertical space-around" id="command-line">
-        <div class="domain-icon">
-          <img src="/static/images/cli.svg" alt="terminal"/>
-          <h3>Command-line</h3>
+
+    <div class="flex-none flex-l flex-row">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
+        <div class="v-top tc-l">
+          <img src="/static/images/cli.svg" alt="terminal"
+               class="mw3 mw4-ns"/>
         </div>
-        <p>
-          Whip up a CLI tool quickly with Rust's robust ecosystem.
-          Rust helps you maintain your app with confidence and distribute it with ease.
-        </p>
-        <a href="/what/cli" class="button button-secondary">Learn More</a>
+        <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
+          <h3 class="tc-l">
+            Command Line
+          </h3>
+          <p class="flex-grow-1">
+            Whip up a CLI tool quickly with Rust's robust ecosystem.
+            Rust helps you maintain your app with confidence and distribute it with ease.
+          </p>
+          <a href="/what/cli" class="button button-secondary">Learn More</a>
+        </div>
       </div>
-      <div class="three columns flex vertical space-around" id="web-assembly">
-        <div class="domain-icon">
-          <img src="/static/images/webassembly.svg" alt="gear with puzzle piece elements"/>
-          <h3>WebAssembly</h3>
+
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
+        <div class="v-top tc-l">
+          <img src="/static/images/webassembly.svg" alt="gear with puzzle piece elements"
+               class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
+          <h3 class="tc-l">
+            WebAssembly
+          </h3>
+          <p class="flex-grow-1">
           Use Rust to supercharge your JavaScript, one module at a time.
           Publish to npm, bundle with WebPack, and you're off to the races.
-        </p>
-        <a href="/what/wasm" class="button button-secondary">Learn More</a>
-      </div>
-      <div class="three columns flex vertical space-around" id="networking">
-        <div class="domain-icon">
-          <img src="/static/images/networking.svg" alt="a cloud with nodes"/>
-          <h3>Networking</h3>
+          </p>
+          <a href="/what/wasm" class="button button-secondary">Learn More</a>
         </div>
-        <p>
-          Predicatable performance. Tiny resource footprint. Rock-solid reliability.
-          Rust is great for network services.
-        </p>
-        <a href="/what/networking" class="button button-secondary">Learn More</a>
       </div>
-      <div class="three columns flex vertical space-around" id="embedded">
-        <div class="domain-icon">
-          <img src="/static/images/embedded.svg" alt="an embedded device chip"/>
-          <h3>Embedded</h3>
+
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
+        <div class="v-top tc-l">
+          <img src="/static/images/networking.svg" alt="a cloud with nodes"
+               class="mw3 mw4-ns"/>
         </div>
-        <p>
-          Targeting low-resource devices?
-          Need low-level control without giving up high-level conveniences?
-          Rust has you covered.
-        </p>
-        <a href="/what/embedded" class="button button-secondary">Learn More</a>
+        <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
+          <h3 class="tc-l">
+            Networking
+          </h3>
+          <p class="flex-grow-1">
+            Predicatable performance. Tiny resource footprint. Rock-solid reliability.
+            Rust is great for network services.
+          </p>
+          <a href="/what/networking" class="button button-secondary">Learn More</a>
+        </div>
+      </div>
+
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
+        <div class="v-top tc-l">
+          <img src="/static/images/embedded.svg" alt="an embedded device chip"
+               class="mw3 mw4-ns"/>
+        </div>
+        <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
+          <h3 class="tc-l">
+            Embedded
+          </h3>
+          <p class="flex-grow-1">
+            Targeting low-resource devices?
+            Need low-level control without giving up high-level conveniences?
+            Rust has you covered.
+          </p>
+          <a href="/what/embedded" class="button button-secondary">Learn More</a>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Makes the domain section on the landing page responsive, and adjusted vertical rhythm so the buttons line up nicely. Thanks!

## Screenshots
- [mobile](https://user-images.githubusercontent.com/2467194/48674506-5a03ae80-eb4d-11e8-9b2c-ab44610de65a.png)
- [tablet](https://user-images.githubusercontent.com/2467194/48674507-5a03ae80-eb4d-11e8-8035-c5864fd454ff.png)
- [desktop](https://user-images.githubusercontent.com/2467194/48674508-5a03ae80-eb4d-11e8-9fb9-a4c78579a5f7.png)