### PR TITLE
feat(style): stop small screen overflow

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -266,6 +266,7 @@ section header h2 {
   top: -30px;
   left: -10px;
   width: 120%;
+  max-width: 90vw;
 }
 
 footer {
@@ -559,7 +560,6 @@ blockquote::before {
     .highlight {
       height: 20px;
       top: -20px;
-      max-width: calc(100vw - 1em);
     }
 
     h2.subtitle {


### PR DESCRIPTION
This fixes overflow on all pages except governance (which has a problem with the team elements not being responsive). Closes #287. Thanks!