### PR TITLE
feat(landing): make first block responsive

### DIFF
--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,17 +1,20 @@
 {{#*inline "page"}}
-<header>
-  <div class="container">
-    <div class="row">
-      <div class="eight columns">
-        <h1>Rust</h1>
-        <h2 class="subtitle">The programming language that empowers <em>everyone</em> to become a systems programmer.</h2>
-      </div>
-      <div class="four columns">
-        <a class="button button-primary button-download" href="/learn/get-started">
-          Get started
-        </a>
-        <p style="text-align: center;">{{rust_version}}</p>
-      </div>
+<header class="mb6-ns">
+  <div class="container flex flex-column flex-row-l justify-between-l">
+    <div class="mw8-l">
+      <h1>Rust</h1>
+      <h2 class="mt4 f2 f1-ns">
+        The programming language that empowers <em>everyone</em> to become a
+        systems programmer.
+      </h2>
+    </div>
+    <div class="mt4 mt0-l">
+      <a class="button button-primary button-download ph4 mt0" href="/learn/get-started">
+        Get started
+      </a>
+      <p class="tc f3 f2-l mt3">
+        {{rust_version}}
+      </p>
     </div>
   </div>
 </header>


### PR DESCRIPTION
Makes the first block on the landing page responsive. Figured this might be important because it's the first thing people will see on the site. Thanks!

## Screenshots
- [mobile](https://user-images.githubusercontent.com/2467194/48720418-eed6dc80-ec1f-11e8-810f-3e9232a0f3b0.png)
- [tablet](https://user-images.githubusercontent.com/2467194/48720419-eed6dc80-ec1f-11e8-9a35-e1d2995596f8.png)
- [desktop](https://user-images.githubusercontent.com/2467194/48720420-eed6dc80-ec1f-11e8-852f-1cc22bddbd42.png)
