### PR TITLE
feat(governance): make Governance responsive

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -575,11 +575,14 @@ blockquote::before {
   }
 }
 
+
+@media screen and (min-width: 60em) {
+  .max-width-quarter-l {
+    max-width: 25%;
+  }
+}
+
 .team {
-  min-height: 250px;
-  max-height: 250px;
-  float: left;
-  width: 25%;
   text-align: center;
   padding: 20px;
   margin: 20px;

--- a/templates/governance/index.hbs
+++ b/templates/governance/index.hbs
@@ -13,8 +13,8 @@
       <h2>Roadmap and RFC process</h2>
       <div class="highlight"></div>
     </header>
-    <div class="row">
-      <div class="six columns">
+    <div class="flex flex-column flex-row-l">
+      <div class="mw8 flex flex-column justify-between pt0 bp2 pv3-ns ph3-l">
         <p>Each major decision in Rust starts as a Request for Comments (RFC).
           Everyone is invited to discuss the proposal, to work toward a shared understanding of the tradeoffs.
           Though sometimes arduous, this community deliberation is Rust's secret sauce for quality.
@@ -22,7 +22,7 @@
         <a href="https://github.com/rust-lang/rfcs" target="_blank" rel="noopener" class="button button-secondary">Learn
           more</a>
       </div>
-      <div class="six columns">
+      <div class="mw8 flex flex-column justify-between pt0 bp2 pv3-ns ph3-l">
         <p>The RFC process is also used to establish a yearly roadmap laying out our aspirations for that year.
           This shared vision is essential for keeping the development process focused.
         </p>
@@ -41,10 +41,10 @@
     </header>
     <p>Each aspect of the Rust project is managed by a dedicated leadership team:</p>
     <h3>Teams</h3>
-    <div id="teams" class="row">
+    <div id="teams" class="flex flex-column flex-row-l flex-wrap-l justify-start tc">
       {{#each data.teams as |team| ~}}
-      <div class="team">
-        <h4>{{team.name~}}</h4>
+      <div class="flex flex-column justify-between ba br3 b--white mw-100 w-100-l pa3 ma4 max-width-quarter-l">
+        <h4 class="f2 fw6">{{team.name~}}</h4>
         <p>{{team.description}}</p>
         <a href="/governance/teams/{{team.route}}" class="button button-secondary">Learn More</a>
       </div>
@@ -52,10 +52,10 @@
     </div>
     <hr />
     <h3>Working Groups</h3>
-    <div id="wgs" class="row">
+    <div id="wgs" class="flex flex-column flex-row-l flex-wrap-l justify-start tc">
       {{#each data.wgs as |wg| ~}}
-      <div class="team">
-        <h4>{{wg.name~}}</h4>
+      <div class="flex flex-column justify-between ba br3 b--white mw-100 w-100-l pa3 ma4 max-width-quarter-l">
+        <h4 class="f2 fw6">{{wg.name~}}</h4>
         <p>{{wg.description}}</p>
         <a href="/governance/wgs/{{wg.route}}" class="button button-secondary">Learn More</a>
       </div>


### PR DESCRIPTION
I also stole the border radius (which is :100:) from @sendilkumarn's #302 PR.

<details><summary>small phone</summary>
<img width="318" alt="small-phone" src="https://user-images.githubusercontent.com/2403023/48723087-51fa4c00-ebeb-11e8-90c8-66ea17daaec4.png">
</details>
<details><summary>tablet – portrait</summary>
<img width="456" alt="tablet-portrait" src="https://user-images.githubusercontent.com/2403023/48723096-558dd300-ebeb-11e8-91ad-69757e35d602.png">
</details>
<details><summary>tablet – landscape</summary>
<img width="810" alt="tablet-landscape" src="https://user-images.githubusercontent.com/2403023/48723095-558dd300-ebeb-11e8-911c-bb6cb5a44795.png">
</details>
<details><summary>laptop</summary>
<img width="1057" alt="laptop" src="https://user-images.githubusercontent.com/2403023/48723094-558dd300-ebeb-11e8-8b31-6ee82666f959.png">
</details>
