### PR TITLE
feat(langvalues): improve vertical rhythm of values

### DIFF
--- a/templates/panels/language-values.hbs
+++ b/templates/panels/language-values.hbs
@@ -7,7 +7,7 @@
       <div class="highlight"></div>
     </header>
     <div class="flex flex-column flex-row-l pv4 pv0-l">
-      <section class="flex flex-column mw8 measure-wide-l pv3 pv5-m pt6-ns pr4-l">
+      <section class="flex flex-column mw8 measure-wide-l pv3 pt4-ns pr4-l">
         <h3 class="f2 f1-l">Performance</h3>
         <p class="f3 lh-copy">
           Rust is blazingly fast and memory-efficient: with no runtime or
@@ -15,7 +15,7 @@
           embedded devices, or even integrate with other languages.
         </p>
       </section>
-      <section class="flex flex-column mw8 measure-wide-l pv3 pv5-m pt6-ns ph3-l">
+      <section class="flex flex-column mw8 measure-wide-l pv3 pt4-ns ph3-l">
         <h3 class="f2 f1-l">Reliability</h3>
         <p class="f3 lh-copy">
           Rust's rich type system and rock-solid compiler guarantee
@@ -23,7 +23,7 @@
           many other classes of bugs at compile-time.
         </p>
       </section>
-      <section class="flex flex-column mw8 measure-wide-l pv3 pv5-m pt6-ns pl4-l">
+      <section class="flex flex-column mw8 measure-wide-l pv3 pt4-ns pl4-l">
         <h3 class="f2 f1-l">Productivity</h3>
         <p class="f3 lh-copy">
           Rust has great documentation, a friendly compiler with useful error


### PR DESCRIPTION
Just a tweak to the spacing on the language values. On laptop-style screens, this makes them mostly visible. It also just removes extra vertical space that looked odd.

Before:

<img width="1440" alt="before" src="https://user-images.githubusercontent.com/2403023/48724962-57a66080-ebf0-11e8-80ea-a95794460c89.png">

After:

<img width="1440" alt="after" src="https://user-images.githubusercontent.com/2403023/48724960-570dca00-ebf0-11e8-82dd-084e728b1f7d.png">
