### PR TITLE
fix(css): better color choice for Get Started.

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -44,8 +44,9 @@ header {
 }
 
 header .button.button-primary.button-download {
-  background-color: $red;
-  border-color: $red;
+  background-color: $yellow;
+  border-color: $yellow;
+  color: black;
   width: 100%;
   padding: 20px;
   height: auto;
@@ -54,8 +55,7 @@ header .button.button-primary.button-download {
 }
 
 header .button.button-primary.button-download:hover {
-  background-color: $purple;
-  border-color: $purple;
+  border-color: black;
 }
 
 h2.subtitle {


### PR DESCRIPTION
Fixes #321.

Jonathan's suggestion was a good one; I just implemented it exactly, inverting the colors for default and hover states. **Edit:** see [below].

[below]: 
https://github.com/rust-lang/new-rust-www/pull/327#issuecomment-440010559