### PR TITLE
add charset utf-8 to head

### DIFF
--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <meta charset="utf-8">
     <title>{{title}}</title>
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <meta name="description" content="A systems programming language that runs blazingly fast, prevents segfaults, and guarantees thread safety.">


### PR DESCRIPTION
Adds the missing `charset` meta tag to the headers. This reduces the amount of guessing a browser has to do when parsing the HTML. Thanks!