### PR TITLE
fix(accessibility): render images with `img` not backgrounds.

### DIFF
--- a/src/styles/_tachyons-ext.scss
+++ b/src/styles/_tachyons-ext.scss
@@ -1,0 +1,13 @@
+// Custom classes we use to extend Tachyons
+
+@media screen and (min-width: 30em) and (max-width: 60em) {
+  .max-width-half-m {
+    max-width: 50%;
+  }
+}
+
+@media screen and (min-width: 60em) {
+  .max-width-quarter-l {
+    max-width: 25%;
+  }
+}

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -1,3 +1,5 @@
+@import 'tachyons-ext';
+
 $body-font: 'Fira Sans', Helvetica, Arial, sans-serif;
 $header-font: 'Alfa Slab One', serif;
 
@@ -410,29 +412,6 @@ blockquote::before {
   }
 }
 
-.rustfest {
-  background-image: url("/static/images/rustfest.jpg");
-  background-position: 50% 50%;
-  background-repeat:   no-repeat;
-  background-size:     cover;
-  height: 150px;
-}
-
-#rustbridge, #rustreach {
-  img {
-    width: 100%;
-  }
-  .img {
-    position: relative;
-    float: left;
-    width:  25%;
-    height: 100px;
-    background-position: 50% 50%;
-    background-repeat:   no-repeat;
-    background-size:     cover;
-  }
-}
-
 .tools-row {
   display: flex;
   flex-direction: row;
@@ -572,13 +551,6 @@ blockquote::before {
       font-size: 1.5em;
       margin-top: 20px;
     }
-  }
-}
-
-
-@media screen and (min-width: 60em) {
-  .max-width-quarter-l {
-    max-width: 25%;
   }
 }
 

--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -96,7 +96,7 @@
           target="_blank" rel="noopener" class="button button-secondary">Register your event</a>
       </div>
     </div>
-    <div class="rustfest"></div>
+    <img src="/static/images/rustfest.jpg" alt="RustFest participants">
   </div>
 </section>
 
@@ -120,10 +120,17 @@
            class="button button-secondary">Check out the Rustbridge repo</a>
       </div>
     </div>
-    <div class="img" style="background-image:url('/static/images/rustbridge-rustconf.jpg');"></div>
-    <div class="img" style="background-image:url('/static/images/rustbridge-paris.jpg');"></div>
-    <div class="img" style="background-image:url('/static/images/rustbridge-berlin.jpg');"></div>
-    <div class="img" style="background-image:url('/static/images/rustbridge-rbr.jpg');"></div>
+
+    {{!--
+      TODO: switch this to a `ul` when Skeleton is gone, since we can then also
+      remove our `section .container ul` settings.
+    --}}
+    <div class="list flex flex-column flex-row-ns flex-wrap-m flex-nowrap-l justify-center">
+      <div class="tc max-width-half-m ph1-ns"><img src="/static/images/rustbridge-rustconf.jpg" alt="RustBridge at RustConf" /></div>
+      <div class="tc max-width-half-m ph1-ns"><img src="/static/images/rustbridge-paris.jpg" alt="RustBridge Paris" /></div>
+      <div class="tc max-width-half-m ph1-ns"><img src="/static/images/rustbridge-berlin.jpg" alt="RustBridge Berlin" /></div>
+      <div class="tc max-width-half-m ph1-ns"><img src="/static/images/rustbridge-rbr.jpg" alt="RustBridge at Rust Belt Rust" /></div>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
resolves #357

<details><summary>small phone</summary>
<img width="162" alt="small-phone-1" src="https://user-images.githubusercontent.com/2403023/48792228-57be6300-ecb9-11e8-9132-f2086f89b69d.png">
<img width="161" alt="small-phone-2" src="https://user-images.githubusercontent.com/2403023/48792229-57be6300-ecb9-11e8-9c9c-7698326e961d.png">
</details>

<details><summary>tablet</summary>
<img width="845" alt="tablet-landscape" src="https://user-images.githubusercontent.com/2403023/48792230-5856f980-ecb9-11e8-90bc-48548efdc63c.png">
<img width="351" alt="tablet-portrait" src="https://user-images.githubusercontent.com/2403023/48792231-5856f980-ecb9-11e8-8dc9-11e67a96d6d7.png">
</details>

<details><summary>laptop</summary>
<img width="1367" alt="laptop" src="https://user-images.githubusercontent.com/2403023/48792227-57be6300-ecb9-11e8-8b94-36d224d507d9.png">
</details>

<details><summary>widescreen</summary>
<img width="829" alt="widescreen" src="https://user-images.githubusercontent.com/2403023/48792232-5856f980-ecb9-11e8-8d78-d2d2a285ff25.png">
</details>