### PR TITLE
fix(governance): subwg member names should not be h3

### DIFF
--- a/templates/governance/group.hbs
+++ b/templates/governance/group.hbs
@@ -88,7 +88,7 @@
           <div id="{{st.name}}-leads">
             {{#each st.leads as |lead|}}
               <div class="two columns group-member">
-                <h3>{{lead}}</h3>
+                <p class="name">{{lead}}</p>
                 <img src="https://avatars.githubusercontent.com/{{lead}}" />
               </div>
             {{/each~}}


### PR DESCRIPTION
fixes #385 