### PR TITLE
fix #429

### DIFF
--- a/templates/what/networking/take-json.hbs
+++ b/templates/what/networking/take-json.hbs
@@ -1,8 +1,8 @@
 #[derive(FromForm)]
 struct Task { name: String, completed: bool }
 
-#[post("/", data = "<task>")]
-fn new(task: Form<Task>) -> Flash<Redirect> {
+#[post("/", data = "&lt;task>")]
+fn new(task: Form&lt;Task>) -> Flash&lt;Redirect> {
     if task.name.is_empty() {
         Flash::error(Redirect::to("/"),
             "Cannot be empty.")


### PR DESCRIPTION
There were angle brackets in the original handlebars file, but they were being parsed out (the parser thinks its HTML). I replaced them with escaped HTML versions so that they show up correctly.