### PR TITLE
Correct links pointing to old book location

### DIFF
--- a/templates/what/cli/maintainable.hbs
+++ b/templates/what/cli/maintainable.hbs
@@ -18,7 +18,7 @@
                     out these “what if” situations before you even run your
                     program.
                 </p>
-                <a href="https://doc.rust-lang.org/book/2018-edition/ch09-00-error-handling.html" target="_blank" rel="noopener" class="button button-secondary">
+                <a href="https://doc.rust-lang.org/book/ch09-00-error-handling.html" target="_blank" rel="noopener" class="button button-secondary">
                     Rust’s error handling
                 </a>
             </article>
@@ -33,7 +33,7 @@
                     features, refactor your application with the confidence that
                     you aren’t breaking anything.
                 </p>
-                <a href="https://doc.rust-lang.org/book/2018-edition/ch12-03-improving-error-handling-and-modularity.html" target="_blank" rel="noopener" class="button button-secondary">
+                <a href="https://doc.rust-lang.org/book/ch12-03-improving-error-handling-and-modularity.html" target="_blank" rel="noopener" class="button button-secondary">
                     Refactoring Rust
                 </a>
             </article>


### PR DESCRIPTION
The book is at a new location, the CLI page still pointed to the old one.