### PR TITLE
Hyphenate "low-resource"

### DIFF
--- a/templates/panels/production.hbs
+++ b/templates/panels/production.hbs
@@ -7,7 +7,7 @@
     <div class="description">
       <p class="lh-copy f2">
         Hundreds of companies around the world are using Rust in production
-        today for fast, low resource, cross-platform solutions. Software you know
+        today for fast, low-resource, cross-platform solutions. Software you know
         and love, like <a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/" target="_blank" rel="noopener">Firefox</a>, <a href="https://blogs.dropbox.com/tech/2016/06/lossless-compression-with-brotli/" target="_blank" rel="noopener">Dropbox</a>, and <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/" target="_blank" rel="noopener">Cloudflare</a>, uses Rust. <strong>From startups to large
         corporations, from embedded devices to scalable web services, Rust is a great fit.</strong>
       </p>


### PR DESCRIPTION
This is hyphenated in the one other place it shows up on the landing page,
but it wasn't here. That especially stuck out alongside the
hyphenated "cross-platform" that followed.