### PR TITLE
reduce highlight block height from 30px to 24px

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -289,9 +289,9 @@ header h1 {
 }
 
 .highlight {
-  height: 30px;
+  height: 24px;
   position: relative;
-  top: -30px;
+  top: -24px;
   left: -10px;
   width: 120%;
   max-width: 90vw;


### PR DESCRIPTION

![highlightboxchangeproposal](https://user-images.githubusercontent.com/8891908/49652283-770dfd80-f9e6-11e8-9805-ccd1f30aabef.png)
height change necessitates also changing `top` positioning to -24px in order to maintain alignment relative to bottom of text.