### PR TITLE
Update social image links

### DIFF
--- a/templates/layout.hbs
+++ b/templates/layout.hbs
@@ -12,12 +12,12 @@
     <meta name="twitter:creator" content="@rustlang">
     <meta name="twitter:title" content="{{title}}">
     <meta name="twitter:description" content="Empowering everyone to build reliable and efficient software.">
-    <meta name="twitter:image" content="http://new-rust-www.herokuapp.com/static/images/rust-social.jpg">
+    <meta name="twitter:image" content="https://www.rust-lang.org/static/images/rust-social.jpg">
 
     <!-- Facebook OpenGraph -->
     <meta property="og:title" content="{{title}}" />
     <meta property="og:description" content="Empowering everyone to build reliable and efficient software.">
-    <meta property="og:image" content="http://new-rust-www.herokuapp.com/static/images/rust-social-wide.jpg" />
+    <meta property="og:image" content="https://www.rust-lang.org/static/images/rust-social-wide.jpg" />
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
 


### PR DESCRIPTION
Current links still point to new-rust-www.herokuapp.com.