### PR TITLE
"Get Started" button larger and better positioned; current stable version link smaller

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -75,7 +75,7 @@ header .button.button-primary.button-download {
   padding-left: 50px;
   height: auto;
   font-size: 2.75rem;
-  margin-top: 30%;
+  margin-top: 20px;
 }
 
 header .version-link {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -69,10 +69,17 @@ header .button.button-primary.button-download {
   border-color: $yellow;
   color: black;
   width: 100%;
-  padding: 20px;
+  padding-top: 20px;
+  padding-bottom: 20px;
+  padding-right: 50px;
+  padding-left: 50px;
   height: auto;
-  font-size: 2.25rem;
-  margin-top: 20px;
+  font-size: 2.75rem;
+  margin-top: 30%;
+}
+
+header .version-link {
+  font-size: 1.5rem;
 }
 
 header .button.button-primary.button-download {

--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -11,7 +11,7 @@
       <a class="button button-primary button-download ph4 mt0" href="/learn/get-started">
         Get started
       </a>
-      <p class="tc f3 f2-l mt3">
+      <p class="version-link tc f3 f2-l mt3">
         <a href="https://blog.rust-lang.org/2018/12/06/Rust-1.31-and-rust-2018.html">{{rust_version}}</a>
       </p>
     </div>


### PR DESCRIPTION
I fixed the position and size of the "Get Started" button and current stable version link; it is now larger and placed in a far more appealing way:

![image](https://user-images.githubusercontent.com/19353212/49693634-c3b41e80-fb35-11e8-8a4a-163fd13e2b83.png)

Any tweaks are appreciated.

Fixes #587 