### PR TITLE
align elements better by modernizing page to new rules

### DIFF
--- a/templates/what/embedded/get-started.hbs
+++ b/templates/what/embedded/get-started.hbs
@@ -4,34 +4,36 @@
       <h2>Get started!</h2>
       <div class="highlight"></div>
     </header>
-    <div class="row">
-      <div class="four columns" id="discovery-book">
-        <div class="domain-icon">
-          <img src="/static/images/chip1.svg" alt="DIP-6 package"/>
-          <h3>The discovery book</h3>
+    <div class="flex flex-column flex-row-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l" id="discovery-book">
+        <div class="v-top tc-l">
+          <img src="/static/images/chip1.svg" alt="DIP-6 package" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">The discovery book</h3>
+
+        <p class="flex-grow-1">
           Learn embedded development from the ground up&mdash;using Rust!
         </p>
         <a href="https://docs.rust-embedded.org/discovery/" target="_blank" rel="noopener" class="button button-secondary">Read</a>
       </div>
-      <div class="four columns" id="embedded-rust-book">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="embedded-rust-book">
         <div class="domain-icon">
-          <img src="/static/images/chip2.svg" alt="TFQP-16 package"/>
+          <img src="/static/images/chip2.svg" alt="TFQP-16 package" class="mw3 mw4-ns"/>
           <h3>The Embedded Rust book</h3>
         </div>
-        <p>
+        <p class="flex-grow-1">
           Already familiar with Embedded development?
           Jump in with Rust and start reaping the benefits.
         </p>
         <a href="https://docs.rust-embedded.org/book/" target="_blank" rel="noopener" class="button button-secondary">Read</a>
       </div>
-      <div class="four columns" id="embedonomicon">
-        <div class="domain-icon">
-          <img src="/static/images/chip3.svg" alt="BGA package" />
-          <h3>The Embedonomicon</h3>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="embedonomicon">
+        <div class="v-top tc-l">
+          <img src="/static/images/chip3.svg" alt="BGA package" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">The Embedonomicon</h3>
+
+        <p class="flex-grow-1">
           Look under the hood of foundational embedded libraries.
         </p>
         <a href="https://docs.rust-embedded.org/embedonomicon/" target="_blank" rel="noopener" class="button button-secondary">Read</a>

--- a/templates/what/embedded/pitch.hbs
+++ b/templates/what/embedded/pitch.hbs
@@ -4,34 +4,37 @@
       <h2>Why Rust?</h2>
       <div class="highlight"></div>
     </header>
-    <div class="row">
-      <div class="four columns" id="powerful-static-analysis">
-        <div class="domain-icon">
-          <img src="/static/images/microscope.svg" alt="A microscope"/>
-          <h3>Powerful static analysis</h3>
+    <div class="flex flex-column flex-row-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l" id="powerful-static-analysis">
+        <div class="tc-l">
+          <img src="/static/images/microscope.svg" alt="A microscope" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">Powerful static analysis</h3>
+
+        <p class="flex-grow-1">
           Enforce pin and peripheral configuration at compile time. Guarantee that resources won’t be used by
           unintended parts of your application.
         </p>
         <a href="https://docs.rust-embedded.org/book/static-guarantees/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns" id="flexible-memory-management">
-        <div class="domain-icon">
-          <img src="/static/images/ram-memory.svg" alt="A RAM stick"/>
-          <h3>Flexible memory management</h3>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="flexible-memory-management">
+        <div class="v-top tc-l">
+          <img src="/static/images/ram-memory.svg" alt="A RAM stick" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">Flexible memory management</h3>
+
+        <p class="flex-grow-1">
           Dynamic memory allocation is optional. Use a global allocator and dynamic data structures.
           Or leave out the heap altogether and statically allocate everything.
         </p>
           <a href="https://docs.rust-embedded.org/book/collections/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns" id="safe-concurrency">
-        <div class="domain-icon">
-          <img src="/static/images/gears.svg" alt="Gears"/>
-          <h3>Fearless concurrency</h3>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="safe-concurrency">
+        <div class="v-top tc-l">
+          <img src="/static/images/gears.svg" alt="Gears" class="mw3 mw4-ns"/>
         </div>
+        <h3 class="v-top tc-l">Fearless concurrency</h3>
+
         <p>
           Rust makes it impossible to accidentally share state between threads.
           Use any concurrency approach you like, and you’ll still get Rust’s strong guarantees.
@@ -39,35 +42,38 @@
         <a href="https://docs.rust-embedded.org/book/concurrency/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
       </div>
     </div>
-    <div class="row">
-      <div class="four columns" id="Interoperability">
-        <div class="domain-icon">
-          <img src="/static/images/handshake.svg" alt="Handshake" />
-          <h3>Interoperability</h3>
+    <div class="flex-none flex-l flex-row mt5-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
+        <div class="v-top tc-l">
+          <img src="/static/images/handshake.svg" alt="Handshake" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">Interoperability</h3>
+
+        <p class="flex-grow-1">
           Integrate Rust into your existing C codebase or leverage an existing SDK to write a Rust
           application.
         </p>
         <a href="https://docs.rust-embedded.org/book/interoperability/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns" id="portability">
-        <div class="domain-icon">
-          <img src="/static/images/luggage.svg" alt="Luggage trolley" />
-          <h3>Portability</h3>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="portability">
+        <div class="v-top tc-l">
+          <img src="/static/images/luggage.svg" alt="Luggage trolley" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">Portability</h3>
+
+        <p class="flex-grow-1">
           Write a library or driver once, and use it with a variety of systems, ranging
           from very small microcontrollers to powerful SBCs.
         </p>
-          <a href="https://docs.rust-embedded.org/book/portability/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/portability/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
       </div>
-      <div class="four columns">
-        <div class="domain-icon">
-          <img src="/static/images/cli-rustc-approved.svg" alt="Shield Logo" />
-          <h3>Community driven</h3>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="community-driven">
+        <div class="v-top tc-l">
+          <img src="/static/images/cli-rustc-approved.svg" alt="Shield Logo" class="mw3 mw4-ns"/>
         </div>
-        <p>
+        <h3 class="tc-l">Community driven</h3>
+
+        <p class="flex-grow-1">
           As part of the Rust open source project, support for embedded systems is driven by a best-in-class open source community, with support from commercial partners.
         </p>
         <a href="https://github.com/rust-embedded/wg" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>


### PR DESCRIPTION
This ports the structure of the CLI page over to the embedded page, aligning buttons properly and giving consistent spacing.

Headlines still seem a bit fuzzy because of their length, but it's a clearly improved.

Before:
![screenshot_2018-12-10 embedded - rust programming language 1](https://user-images.githubusercontent.com/47542/49720216-83e95600-fc5f-11e8-82a6-d0d4f9432dc4.png)


After: ![screenshot_2018-12-10 embedded - rust programming language](https://user-images.githubusercontent.com/47542/49720160-5dc3b600-fc5f-11e8-9fda-c1f25b40f298.png)
