### PR TITLE
Fix style around Rust name

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -147,6 +147,11 @@ div.brand {
   }
 }
 
+a.brand {
+  color: black;
+  text-decoration: none;
+}
+
 .domain-icon {
   min-height: 100px;
   img {

--- a/templates/nav.hbs
+++ b/templates/nav.hbs
@@ -1,6 +1,6 @@
 <nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns">
   <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
-    <a href="/">
+    <a href="/" class="brand">
       <img class="v-mid ml0-l" alt="Rust Logo" src="/static/images/rust-logo-blk.svg">
       {{#unless is_landing}}
         <span class="dib ml1 ml0-l">Rust</span>


### PR DESCRIPTION
Before:
<img width="201" alt="screen shot 2018-12-12 at 1 58 32 pm" src="https://user-images.githubusercontent.com/762626/49839952-54316f80-fd7f-11e8-8010-5dc792380db2.png">

After:
<img width="224" alt="screen shot 2018-12-12 at 1 57 29 pm" src="https://user-images.githubusercontent.com/762626/49839949-50055200-fd7f-11e8-83b3-3fc7da69aabf.png">

This is a regression caused by 84c6a9f2e19d9d2bc6b65f3f96d4614ba4bf02df

r? @chriskrycho 