### PR TITLE
Add a link to 'getting started' from 'install'

### DIFF
--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -23,6 +23,11 @@
       <div class="highlight"></div>
     </header>
     <div>
+      <h3>Getting started</h3>
+      <p>
+        If you're just getting started with Rust and would like a more detailed walk-through, see our <a href="/learn/get-started">getting started</a> page.
+      </p>
+
       <h3>Toolchain management with <code>rustup</code></h3>
       <p>
         Rust is installed and managed by the
@@ -48,6 +53,7 @@
         <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md" target="_blank" rel="noopener"><code>rustup</code>
         documentation</a>.
       </p>
+
       <h3>Configuring the <code>PATH</code> environment variable</h3>
       <p>
         In the Rust development environment, all tools are installed to the
@@ -107,8 +113,8 @@
     <p>
       The installation described above, via <code>rustup</code>, is the preferred way to install Rust
       for most developers. However, Rust can be installed via other methods as well.
-      <a href="https://forge.rust-lang.org/other-installation-methods.html" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
     </p>
+    <a href="https://forge.rust-lang.org/other-installation-methods.html" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
   </div>
 </section>
 {{> tools/install-script }}


### PR DESCRIPTION
Fixes #500

Also fixes a very minor layout bug at the bottom of the install page.

<img width="1295" alt="screen shot 2018-12-12 at 2 28 58 pm" src="https://user-images.githubusercontent.com/762626/49840900-67ded500-fd83-11e8-80b6-508abd2f9b7c.png">
