### PR TITLE
i18n scaffold

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1700,6 +1700,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 [dependencies]
 lazy_static = "1.2.0"
 rand = "0.6"
+regex = "1"
 rocket = "0.4"
 serde = "1.0"
 serde_derive = "1.0"

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -1,0 +1,84 @@
+use rocket::{Request, Response};
+
+use regex::Regex;
+use rocket::fairing::{Fairing, Info, Kind};
+use std::io::Cursor;
+
+pub trait I18NProvider {
+    fn should_i18n(&self, request: &Request) -> bool {
+        let nots = ["static"];
+        let possibles = ["governance", "learn", "production", "tools"];
+        let mut ret = true; // frontpage
+        for (i, ref s) in request.uri().segments().enumerate() {
+            match i {
+                0 => ret = !nots.iter().any(|v| v == s) && possibles.iter().any(|v| v == s),
+                _ => (),
+            }
+        }
+        ret
+    }
+
+    fn get_language(&self, request: &Request) -> String {
+        request
+            .get_query_value("lang")
+            .and_then(|r| r.ok())
+            .unwrap_or("en".into())
+    }
+
+    fn do_i18n(&self, lang: &str, text: &str) -> String {
+        let re = Regex::new(r"::[^ ]+?::").unwrap();
+        let mut new_text: String = String::from(text.clone());
+        let mut diff: isize = 0;
+        for mat in re.find_iter(&text) {
+            let old_length: usize = mat.end() - mat.start();
+            let id = &mat.as_str()[2..old_length - 2];
+            let ltext = self.i18n_token(lang, id);
+            let new_length: usize = ltext.len();
+            let replaced_start: usize = (mat.start() as isize + diff) as usize;
+            let replaced_end: usize = replaced_start + old_length;
+            diff = diff + new_length as isize - old_length as isize;
+            new_text.replace_range(replaced_start..replaced_end, ltext.as_str());
+        }
+        new_text
+    }
+
+    fn i18n_token(&self, lang: &str, text_id: &str) -> String;
+}
+
+struct DummyProvider;
+
+impl I18NProvider for DummyProvider {
+    fn i18n_token(&self, lang: &str, text_id: &str) -> String {
+        format!("::localized text for {} from {}::", text_id, lang)
+    }
+}
+
+pub struct I18N {
+    provider: Box<I18NProvider + Send + Sync>,
+}
+
+impl I18N {
+    pub fn dummy() -> I18N {
+        I18N {
+            provider: Box::new(DummyProvider {}),
+        }
+    }
+}
+
+impl Fairing for I18N {
+    fn info(&self) -> Info {
+        Info {
+            name: "I18N/L10N",
+            kind: Kind::Response,
+        }
+    }
+
+    fn on_response(&self, request: &Request, response: &mut Response) {
+        if self.provider.should_i18n(request) {
+            let lang = self.provider.get_language(request);
+            let body_original = response.body_string().unwrap();
+            let body_new = self.provider.do_i18n(&lang, &body_original);
+            response.set_sized_body(Cursor::new(body_new));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,12 @@ extern crate serde;
 #[macro_use]
 extern crate serde_derive;
 
+extern crate regex;
+//extern crate fluent;
+
 mod cache;
 mod category;
+mod i18n;
 mod production;
 mod redirect;
 mod rust_version;
@@ -42,6 +46,8 @@ use rocket_contrib::templates::Template;
 use sass_rs::{compile_file, Options};
 
 use category::Category;
+
+use i18n::I18N;
 
 #[derive(Serialize)]
 struct Context<T: ::serde::Serialize> {
@@ -270,6 +276,7 @@ fn main() {
 
     rocket::ignite()
         .attach(Template::fairing())
+        .attach(I18N::dummy())
         .mount(
             "/",
             routes![


### PR DESCRIPTION
This is to fill the previous promise: #96  .

Eventually, it seems rust-fluent doesn't yet provide an easy-to-use method for production use. But either way, the scaffold for i18n shall be implemented, independent from fluent.

This is a work-in-progress version for that scaffold. All fluent-related parts are commented out.

Basically, a new file `i18n.rs` is added to handle it. It works as a fairing, by modifying the data proceeded by Handlebars templates.
In this implementation, any data in `::TEXT_ID::` are going to be translated: `TEXT_ID` extracted from here is fed to `i18n_text()` function, and the returned string will replace the original `::TEXT_ID::` part.

I'm wondering: 

1. How should the `shall_i18n()` function be working? The current one is really a hack, but I can't think of a better way at the moment.
2. Should I add a new trait to do the actual i18n work, and implement it? Do we need to bother doing so? (because it will never be a generic framework)


Hope rust-fluent can be utilized earlier, so that it can be used rather than having to "invent" a wrapper (not yet doing this, because the scaffold should be decided first).

(Changes will be made. I may force-push to the HEAD on my side...)

(I also modified the `Cargo.toml` because rocket v0.4 is in repo and the project won't compile in the previous `Cargo.toml`.)