### PR TITLE
Pinning the nightly version to 2018-12-08

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
 
   # tests pass
-  - rust: nightly
+  - rust: nightly-2018-12-08
     script:
     - cargo test --all --locked
     - rustup component add rustfmt-preview


### PR DESCRIPTION
This is required to make the CI work, since the
current nightly doesn't seem to include certain
components (rustfmt-preview)