### PR TITLE
Cache the current Rust version.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,6 +1683,7 @@ dependencies = [
 name = "wubwub"
 version = "0.1.0"
 dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "reqwest 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 
 [dependencies]
+lazy_static = "1.2.0"
 rand = "0.6"
 rocket = "0.4"
 serde = "1.0"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,7 @@
 #![feature(proc_macro_hygiene, decl_macro)]
 
+#[macro_use]
+extern crate lazy_static;
 extern crate rand;
 extern crate reqwest;
 #[macro_use]

--- a/src/rust_version.rs
+++ b/src/rust_version.rs
@@ -1,12 +1,39 @@
 use reqwest;
+use std::sync::RwLock;
+use std::thread;
+use std::time::Instant;
 use toml;
 
+lazy_static! {
+    static ref CACHE: RwLock<Option<(String, Instant)>> = RwLock::new(None);
+}
+
+const CACHE_TTL_SECS: u64 = 120;
+
 pub fn rust_version() -> Option<String> {
+    cached_rust_version().or_else(fetch_rust_version)
+}
+
+fn cached_rust_version() -> Option<String> {
+    let cached = CACHE.read().unwrap();
+    let (version, timestamp) = cached.as_ref()?;
+    if timestamp.elapsed().as_secs() > CACHE_TTL_SECS {
+        // Update the cache in the background.
+        thread::spawn(fetch_rust_version);
+    }
+    Some(version.clone())
+}
+
+fn fetch_rust_version() -> Option<String> {
     let manifest = reqwest::get("https://static.rust-lang.org/dist/channel-rust-stable.toml")
         .ok()?
         .text()
         .ok()?;
     let manifest = manifest.parse::<toml::Value>().ok()?;
-    let rust_version = manifest["pkg"]["rust"]["version"].as_str()?.to_string();
-    Some(rust_version[..rust_version.find(' ')?].to_string())
+    let rust_version = manifest["pkg"]["rust"]["version"].as_str()?;
+    let version = rust_version[..rust_version.find(' ')?].to_string();
+
+    // Update the cache.
+    *CACHE.write().unwrap() = Some((version.clone(), Instant::now()));
+    Some(version)
 }


### PR DESCRIPTION
Currently, every time the home page is rendered, the web server downloads a TOML file from static.rust-lang.org and parses it to find the current Rust version.  This adds a significant amount of latency to the home page.

This patch caches the version in memory for up to 10 minutes.  This greatly speeds up home page rendering, at the cost of a 10-minute delay before a new version is reflected on the home page.