### PR TITLE
Use official capitalization for webpack

### DIFF
--- a/templates/components/panels/domains.hbs
+++ b/templates/components/panels/domains.hbs
@@ -46,7 +46,7 @@
           </h3>
           <p class="flex-grow-1">
           Use Rust to supercharge your JavaScript, one module at a time.
-          Publish to npm, bundle with WebPack, and you’re off to the races.
+          Publish to npm, bundle with webpack, and you’re off to the races.
           </p>
           <a href="/what/wasm" class="button button-secondary">Learn More</a>
         </div>

--- a/templates/components/what/wasm/js.hbs
+++ b/templates/components/what/wasm/js.hbs
@@ -21,7 +21,7 @@
                 </div>
                 <p>
                     Publish Rust WebAssembly packages to package registries like npm.
-                    Bundle and ship them with WebPack, Parcel, and others.
+                    Bundle and ship them with webpack, Parcel, and others.
                     Maintain them with tools like <code>npm audit</code> and Greenkeeper.
                 </p>
             </div>


### PR DESCRIPTION
The official casing for webpack is all-lowercase, as shown on the [official website](https://webpack.js.org/).