### PR TITLE
Replace footer link to "All" with "All Policies"

### DIFF
--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -19,7 +19,7 @@
           <li><a href="/policies/licenses">Licenses</a></li>
           <li><a href="/policies/media-guide">Logo Policy and Media Guide</a></li>
           <li><a href="/policies/security">Security Disclosures</a></li>
-          <li><a href="/policies">All</a></li>
+          <li><a href="/policies">All Policies</a></li>
         </ul>
       </div>
       <div class="four columns mt3 mt0-l">


### PR DESCRIPTION
The other footer links make sense without looking at the header; "All" on its own is nondescriptive and confusing, whereas "All Policies" makes sense without context.