### PR TITLE
Make Learn page icons match the size of others

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -140,7 +140,7 @@
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pv4 pv5-m pv6-ns ph4-l">
         <div class="v-top tc-l">
           <img src="/static/images/reference.svg" alt="A bookshelf icon"
-               class="mw4 mw5-ns" />
+               class="mw3 mw4-ns" />
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <p>The Reference is not a formal spec, but is more detailed and
@@ -155,7 +155,7 @@
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pv4 pv5-m pv6-ns ph4-l">
         <div class="v-top tc-l">
           <img src="/static/images/nomicon.svg" alt="Two hands cradling fire"
-               class="mw4 mw5-ns" />
+               class="mw3 mw4-ns" />
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <p> The Rustonomicon is your guidebook to the dark
@@ -171,7 +171,7 @@
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pv3 pv5-m pv6-ns ph4-l">
         <div class="v-top tc-l">
           <img src="/static/images/unstable.svg" alt="A hand sharing sparkles"
-               class="mw4 mw5-ns" />
+               class="mw3 mw4-ns" />
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <p>The Unstable Book has documentation for unstable features that you


### PR DESCRIPTION
fixes #650 

Fixes the icons at the bottom of the Learn page to match the sizing of icons on the home page.  By doing this, the whole of the Learn page fits horizontally on a small screen.

Before:
![img_2771](https://user-images.githubusercontent.com/36467736/50540853-5735a980-0b4e-11e9-806b-d44e87f8ae5d.PNG)

After:
![img_2769](https://user-images.githubusercontent.com/36467736/50540852-53a22280-0b4e-11e9-8caf-6a522f7a832c.PNG)

Caveat:
This makes the icons smaller on larger screens too; however, it may not be a problem because it still matches the icon size of the home page.

Before:
![screenshot_2018-12-29 learn - rust programming language 1](https://user-images.githubusercontent.com/36467736/50541062-77fffe00-0b52-11e9-9c55-6b4877743af6.png)

After:
![screenshot_2018-12-29 learn - rust programming language](https://user-images.githubusercontent.com/36467736/50541046-48e98c80-0b52-11e9-8bb5-6f379cf2dd16.png)


