### PR TITLE
Use 127.0.0.1 instead of localhost for dev to avoid lookup

### DIFF
--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,3 +1,3 @@
 [development]
-address = "localhost"
+address = "127.0.0.1"
 port = 7878


### PR DESCRIPTION
Hi just using ` 127.0.0.1 ` in Rocket development config instead of `localhost` to avoid lookup; cheers