### PR TITLE
Add bottom padding between the domain introduction and the domains list

### DIFF
--- a/templates/components/panels/domains.hbs
+++ b/templates/components/panels/domains.hbs
@@ -8,7 +8,7 @@
     </header>
 
     <div class="flex-none flex-l flex-row">
-      <p class="flex-grow-1">
+      <p class="flex-grow-1 pb2">
         In 2018, the Rust community decided to improve programming experience
         for a few distinct domains (see <a
         href="https://blog.rust-lang.org/2018/03/12/roadmap.html">the 2018


### PR DESCRIPTION
Fixes #543

Continues uppon review #654 

![before](https://user-images.githubusercontent.com/620941/50735478-1a059300-11b0-11e9-8293-a87ab5dd426d.png)
![after](https://user-images.githubusercontent.com/620941/50735479-1d991a00-11b0-11e9-87e9-303b39b23a5b.png)
