### PR TITLE
Updated CoC -> Mod Team links

### DIFF
--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -30,7 +30,7 @@
         groups.</li>
       <li>Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being
         harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the <a
-          href="/team.html#Moderation-team">Rust moderation team</a> immediately. Whether you’re a regular contributor
+          href="/governance/teams/moderation">Rust moderation team</a> immediately. Whether you’re a regular contributor
         or a newcomer, we care about making this community a safe place for you and we’ve got your back.</li>
       <li>Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.</li>
     </ul>
@@ -45,7 +45,7 @@
       <div class="highlight"></div>
     </header>
     <p>These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs
-      moderation, please contact the <a href="/team.html#Moderation-team">Rust moderation team</a>.</p>
+      moderation, please contact the <a href="/governance/teams/moderation">Rust moderation team</a>.</p>
     <ol>
       <li>Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary
         remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful


### PR DESCRIPTION
This fixes #685, by pointing directly to the Moderation Team page