### PR TITLE
Add link to the edition guide from the "learn" page

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -55,6 +55,14 @@
         </div>
 
         <div class="pt4 pt3-l flex flex-column flex-row-l">
+          <a href="https://doc.rust-lang.org/edition-guide/index.html" target="_blank" rel="noopener"
+             class="button button-secondary mw6-l w-100">Edition Guide</a>
+          <p class="pl4-l">
+            Guide to the Rust editions.
+          </p>
+        </div>
+
+        <div class="pt4 pt3-l flex flex-column flex-row-l">
           <a href="https://doc.rust-lang.org/cargo/index.html" target="_blank" rel="noopener"
              class="button button-secondary mw6-l w-100">Cargo Book</a>
           <p class="pl4-l">


### PR DESCRIPTION
From the discussion at https://internals.rust-lang.org/t/no-love-for-the-edition-guide/9308/2