### PR TITLE
Reject invalid governance pages and add some tests

### DIFF
--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,6 +1,7 @@
 use reqwest;
 use rust_team_data::v1::{Team, TeamKind, Teams, BASE_URL};
 use std::any::Any;
+use std::cmp::Reverse;
 use std::error::Error;
 use std::fmt;
 
@@ -24,6 +25,7 @@ pub struct PageData {
     wgs: Vec<Team>,
 }
 
+#[derive(Clone)]
 struct Data {
     teams: Vec<Team>,
 }
@@ -60,10 +62,12 @@ impl Data {
                 TeamKind::WorkingGroup => data.wgs.push(team),
             });
 
-        data.teams
-            .sort_by_key(|team| -team.team.website_data.as_ref().unwrap().weight);
-        data.wgs
-            .sort_by_key(|team| -team.team.website_data.as_ref().unwrap().weight);
+        data.teams.sort_by_key(|index_team| {
+            Reverse(index_team.team.website_data.as_ref().unwrap().weight)
+        });
+        data.wgs.sort_by_key(|index_team| {
+            Reverse(index_team.team.website_data.as_ref().unwrap().weight)
+        });
         Ok(data)
     }
 

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -69,7 +69,8 @@ impl Data {
 
     pub fn page_data(self, section: &str, team_name: &str) -> Result<PageData, Box<Error>> {
         // Find the main team first
-        let main_team = self.teams
+        let main_team = self
+            .teams
             .iter()
             .filter(|team| team.website_data.as_ref().map(|ws| ws.page.as_str()) == Some(team_name))
             .filter(|team| kind_to_str(team.kind) == section)
@@ -148,8 +149,8 @@ impl fmt::Display for TeamNotFound {
 
 #[cfg(test)]
 mod tests {
-    use rust_team_data::v1::{Team, TeamKind, TeamMember, TeamWebsite};
     use super::{Data, TeamNotFound};
+    use rust_team_data::v1::{Team, TeamKind, TeamMember, TeamWebsite};
 
     fn dummy_team(name: &str) -> Team {
         Team {
@@ -237,9 +238,24 @@ mod tests {
         bar.kind = TeamKind::WorkingGroup;
         let data = Data::dummy(vec![foo, bar]);
 
-        assert!(data.clone().page_data("teams", "unknown").err().unwrap().is::<TeamNotFound>());
-        assert!(data.clone().page_data("wgs", "foo").err().unwrap().is::<TeamNotFound>());
-        assert!(data.clone().page_data("teams", "bar").err().unwrap().is::<TeamNotFound>());
+        assert!(data
+            .clone()
+            .page_data("teams", "unknown")
+            .err()
+            .unwrap()
+            .is::<TeamNotFound>());
+        assert!(data
+            .clone()
+            .page_data("wgs", "foo")
+            .err()
+            .unwrap()
+            .is::<TeamNotFound>());
+        assert!(data
+            .clone()
+            .page_data("teams", "bar")
+            .err()
+            .unwrap()
+            .is::<TeamNotFound>());
     }
 
     #[test]
@@ -248,6 +264,10 @@ mod tests {
         foo.subteam_of = Some("bar".into());
         let data = Data::dummy(vec![foo, dummy_team("bar")]);
 
-        assert!(data.page_data("teams", "foo").err().unwrap().is::<TeamNotFound>());
+        assert!(data
+            .page_data("teams", "foo")
+            .err()
+            .unwrap()
+            .is::<TeamNotFound>());
     }
 }

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -4,6 +4,102 @@ use std::any::Any;
 use std::error::Error;
 use std::fmt;
 
+#[derive(Default, Serialize)]
+pub struct IndexData {
+    teams: Vec<IndexTeam>,
+    wgs: Vec<IndexTeam>,
+}
+
+#[derive(Serialize)]
+struct IndexTeam {
+    #[serde(flatten)]
+    team: Team,
+    url: String,
+}
+
+#[derive(Serialize)]
+pub struct PageData {
+    pub team: Team,
+    subteams: Vec<Team>,
+    wgs: Vec<Team>,
+}
+
+struct Data {
+    teams: Vec<Team>,
+}
+
+impl Data {
+    fn load() -> Result<Self, Box<Error>> {
+        Ok(Data {
+            teams: crate::cache::get::<Vec<Team>>(get_teams)?,
+        })
+    }
+
+    fn index_data(self) -> Result<IndexData, Box<Error>> {
+        let mut data = IndexData::default();
+
+        self.teams
+            .into_iter()
+            .filter(|team| team.website_data.is_some())
+            .filter(|team| team.subteam_of.is_none())
+            .map(|team| IndexTeam {
+                url: format!(
+                    "{}/{}",
+                    kind_to_str(team.kind),
+                    team.website_data.as_ref().unwrap().page
+                ),
+                team,
+            })
+            .for_each(|team| match team.team.kind {
+                TeamKind::Team => data.teams.push(team),
+                TeamKind::WorkingGroup => data.wgs.push(team),
+            });
+
+        data.teams
+            .sort_by_key(|team| -team.team.website_data.as_ref().unwrap().weight);
+        data.wgs
+            .sort_by_key(|team| -team.team.website_data.as_ref().unwrap().weight);
+        Ok(data)
+    }
+
+    pub fn page_data(self, section: &str, team_name: &str) -> Result<PageData, Box<Error>> {
+        // Find the main team first
+        let main_team = self.teams
+            .iter()
+            .filter(|team| team.website_data.as_ref().map(|ws| ws.page.as_str()) == Some(team_name))
+            .filter(|team| kind_to_str(team.kind) == section)
+            .next()
+            .cloned()
+            .ok_or(TeamNotFound)?;
+
+        // Then find all the subteams and wgs
+        let mut subteams = Vec::new();
+        let mut wgs = Vec::new();
+        self.teams
+            .into_iter()
+            .filter(|team| team.website_data.is_some())
+            .filter(|team| team.subteam_of.as_ref() == Some(&main_team.name))
+            .for_each(|team| match team.kind {
+                TeamKind::Team => subteams.push(team),
+                TeamKind::WorkingGroup => wgs.push(team),
+            });
+
+        Ok(PageData {
+            team: main_team,
+            subteams,
+            wgs,
+        })
+    }
+}
+
+pub fn index_data() -> Result<IndexData, Box<Error>> {
+    Data::load()?.index_data()
+}
+
+pub fn page_data(section: &str, team_name: &str) -> Result<PageData, Box<Error>> {
+    Data::load()?.page_data(section, team_name)
+}
+
 fn get_teams() -> Result<Box<Any>, Box<Error>> {
     let resp: Teams = reqwest::get(&format!("{}/teams.json", BASE_URL))?
         .error_for_status()?
@@ -17,93 +113,11 @@ fn get_teams() -> Result<Box<Any>, Box<Error>> {
     ))
 }
 
-pub fn teams() -> Result<Vec<Team>, Box<Error>> {
-    ::cache::get(get_teams)
-}
-
 fn kind_to_str(kind: TeamKind) -> &'static str {
     match kind {
         TeamKind::Team => "teams",
         TeamKind::WorkingGroup => "wgs",
     }
-}
-
-#[derive(Serialize)]
-struct IndexTeam {
-    #[serde(flatten)]
-    team: Team,
-    url: String,
-}
-
-#[derive(Default, Serialize)]
-pub struct IndexData {
-    teams: Vec<IndexTeam>,
-    wgs: Vec<IndexTeam>,
-}
-
-pub fn index_data() -> Result<IndexData, Box<Error>> {
-    let mut data = IndexData::default();
-
-    teams()?
-        .into_iter()
-        .filter(|team| team.website_data.is_some())
-        .filter(|team| team.subteam_of.is_none())
-        .map(|team| IndexTeam {
-            url: format!(
-                "{}/{}",
-                kind_to_str(team.kind),
-                team.website_data.as_ref().unwrap().page
-            ),
-            team,
-        })
-        .for_each(|team| match team.team.kind {
-            TeamKind::Team => data.teams.push(team),
-            TeamKind::WorkingGroup => data.wgs.push(team),
-        });
-
-    data.teams
-        .sort_by_key(|team| -team.team.website_data.as_ref().unwrap().weight);
-    data.wgs
-        .sort_by_key(|team| -team.team.website_data.as_ref().unwrap().weight);
-    Ok(data)
-}
-
-#[derive(Serialize)]
-pub struct PageData {
-    pub team: Team,
-    subteams: Vec<Team>,
-    wgs: Vec<Team>,
-}
-
-pub fn page_data(section: &str, team_name: &str) -> Result<PageData, Box<Error>> {
-    let teams = teams()?;
-
-    // Find the main team first
-    let main_team = teams
-        .iter()
-        .filter(|team| team.website_data.as_ref().map(|ws| ws.page.as_str()) == Some(team_name))
-        .filter(|team| kind_to_str(team.kind) == section)
-        .next()
-        .cloned()
-        .ok_or(TeamNotFound)?;
-
-    // Then find all the subteams and wgs
-    let mut subteams = Vec::new();
-    let mut wgs = Vec::new();
-    teams
-        .into_iter()
-        .filter(|team| team.website_data.is_some())
-        .filter(|team| team.subteam_of.as_ref() == Some(&main_team.name))
-        .for_each(|team| match team.kind {
-            TeamKind::Team => subteams.push(team),
-            TeamKind::WorkingGroup => wgs.push(team),
-        });
-
-    Ok(PageData {
-        team: main_team,
-        subteams,
-        wgs,
-    })
 }
 
 pub struct TeamNotFound;


### PR DESCRIPTION
This PR rejects standalone governance pages for subteams, and adds a few tests on the backend code to make sure we don't regress on that page.