### PR TITLE
link to latest eclipse ide for rust developers available (this fixes issue #703)

### DIFF
--- a/templates/components/tools/editors.hbs
+++ b/templates/components/tools/editors.hbs
@@ -18,7 +18,7 @@
 </div>
 <div class="row">
   <div class="three columns">
-    <a href="https://www.eclipse.org/downloads/packages/release/photon/r/eclipse-ide-rust-developers-includes-incubating-components" target="_blank" rel="noopener"
+    <a href="https://www.eclipse.org/downloads/packages/release/2018-12/r/eclipse-ide-rust-developers-includes-incubating-components" target="_blank" rel="noopener"
        class="button button-secondary">Eclipse</a>
   </div>
   <div class="three columns">


### PR DESCRIPTION
The latest available is for Eclipse 2018-12 at this point, not 2018-09 as stated in the issue and the commit message.