### PR TITLE
Replace the core team email with a link to the users forum

### DIFF
--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -5,7 +5,7 @@
         <h4>Get help!</h4>
         <ul>
           <li><a href="https://doc.rust-lang.org" target="_blank" rel="noopener">Documentation</a></li>
-          <li><a href="mailto:core-team@rust-lang.org">Contact the Rust Team</a></li>
+          <li><a href="https://users.rust-lang.org" target="_blank" rel="noopener">Ask a Question on the Users Forum</a></li>
           <li><a href="http://ping.rust-lang.org">Check Website Status</a></li>
         </ul>
         <div class="languages">


### PR DESCRIPTION
We've been getting some emails to the internal core team email address that are much better suited for the users forum, such as "how do I get started with Rust?" We've also gotten the occasional Rust game question too :P 

I'd like to try to cut down the number of emails by removing the address from the "Get Help" section of the footer-- it's still on https://www.rust-lang.org/policies/licenses and https://www.rust-lang.org/policies/media-guide, which I think is fine and hopefully the folks ending up on those pages have a question that Core does need to answer.

I noticed the users forum wasn't in the footer, and that *is* a great place to ask questions, so I replaced the email address with a link there.