### PR TITLE
Fix alignment on the production page

### DIFF
--- a/templates/production/index.hbs
+++ b/templates/production/index.hbs
@@ -12,21 +12,23 @@
       <h2>Whitepapers</h2>
       <div class="highlight"></div>
     </header>
-    <div class="row">
-      <div class="six columns" id="npm-whitepaper">
+    <div class="flex flex-column flex-row-l">
+      <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
         <h3>npm</h3>
         <p>Read how <a href="https://www.npmjs.com/" target="_blank" rel="noopener">npm</a>, who runs the JavaScript Registry of the same name, found Rust to be boring to deploy.</p>
-      <a class="button button-secondary" href="/static/pdfs/Rust-npm-Whitepaper.pdf">Read the whitepaper</a>
+        <a class="button button-secondary" href="/static/pdfs/Rust-npm-Whitepaper.pdf">Read the whitepaper</a>
       </div>
-      <div class="six columns" id="chucklefish-whitepaper">
+      <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
         <h3>Chucklefish</h3>
         <p><a href="https://chucklefish.org/" target="_blank" rel="noopener">Chucklefish</a>, the video game company that published Stardew Valley and Starbound, is using Rust in their new projects Wargroove and Witchbrook to get safe concurrency and portability.</p>
       <a class="button button-secondary" href="/static/pdfs/Rust-Chucklefish-Whitepaper.pdf">Read the whitepaper</a>
       </div>
-      <div class="six columns" id="tilde-whitepaper">
+    </div>
+    <div class="flex flex-column flex-row-l">
+      <div class="mh2-l pt0 flex flex-column justify-between-l">
         <h3>Tilde</h3>
         <p>Learn how Rust helps <a href="http://www.tilde.io/" target="_blank" rel="noopener">Tilde</a>, makers of <a href="https://www.skylight.io/" target="_blank" rel="noopener">Skylight</a>, use minimal resources to enable feature-rich performance monitoring of their customers’ applications.</p>
-      <a class="button button-secondary" href="/static/pdfs/Rust-Tilde-Whitepaper.pdf">Read the whitepaper</a>
+        <a class="button button-secondary" href="/static/pdfs/Rust-Tilde-Whitepaper.pdf">Read the whitepaper</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Sooo I tried following pietro's advice to look at https://www.rust-lang.org/community to improve the alignment, and I got the indentation of tilde fixed and the buttons in the top row aligned but I couldn't figure out how to get the tilde button to be the same width as the npm button:

<img width="1272" alt="screen shot 2019-02-26 at 8 40 32 pm" src="https://user-images.githubusercontent.com/193874/53459376-827e2d00-3a07-11e9-880e-371c75ec1c76.png">

And in the course of trying to figure it out, I accidentally did this, which I think looks a lot better anyway because there's 3 whitepapers right now:

<img width="1164" alt="screen shot 2019-02-26 at 8 41 27 pm" src="https://user-images.githubusercontent.com/193874/53459396-9aee4780-3a07-11e9-8d92-e2125501086b.png">

so i'm going to merge this when CI passes!


