### PR TITLE
Make external links open in the same tab

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -18,7 +18,7 @@
         <p>
           Stay up to date with the Rust community!
         </p>
-        <a href="https://this-week-in-rust.org/" target="_blank" rel="noopener" class="button button-secondary">This Week in Rust</a>
+        <a href="https://this-week-in-rust.org/" class="button button-secondary">This Week in Rust</a>
       </div>
       <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
         <p>
@@ -50,7 +50,7 @@
           </p>
         </div>
 
-        <a href="https://users.rust-lang.org" target="_blank" rel="noopener" class="button button-secondary">Visit
+        <a href="https://users.rust-lang.org" class="button button-secondary">Visit
           Forum</a>
       </div>
 
@@ -63,7 +63,7 @@
             as well as the design of the language and the standard library.
           </p>
         </div>
-        <a href="https://internals.rust-lang.org/" target="_blank" rel="noopener" class="button button-secondary">Visit
+        <a href="https://internals.rust-lang.org/" class="button button-secondary">Visit
           Forum</a>
       </div>
 
@@ -78,12 +78,12 @@
         </div>
 
         {{!-- TODO: remove padding and margin once global declarations are gone --}}
-        <ul class="list pa0 ma0"> 
+        <ul class="list pa0 ma0">
           <li>
-            <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener" class="button button-secondary">Discord</a>
+            <a href="https://discord.gg/rust-lang" class="button button-secondary">Discord</a>
           </li>
           <li>
-            <a href="https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust" target="_blank" rel="noopener" class="button button-secondary">Mozilla IRC</a>
+            <a href="https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust" class="button button-secondary">Mozilla IRC</a>
           </li>
           <li>
             <a href="/governance" class="button button-secondary">Learn more about teams</a>
@@ -115,10 +115,10 @@
         <ul class="list ma0 pa0">
           <li>
             <a href="https://calendar.google.com/calendar/embed?showTitle=0&showPrint=0&showTabs=0&showCalendars=0&mode=AGENDA&height=400&wkst=1&bgcolor=%23FFFFFF&src=apd9vmbc22egenmtu5l6c5jbfc%40group.calendar.google.com&color=%23691426&ctz=Europe%2FMadrid"
-              target="_blank" rel="noopener" class="button button-secondary">View Calendar</a>
+              class="button button-secondary">View Calendar</a>
           </li>
           <li>
-            <a href="https://blog.rust-lang.org/2018/01/31/The-2018-Rust-Event-Lineup.html" target="_blank" rel="noopener"
+            <a href="https://blog.rust-lang.org/2018/01/31/The-2018-Rust-Event-Lineup.html"
               class="button button-secondary">Check out the 2018 Conference Lineup</a>
           </li>
         </ul>
@@ -138,12 +138,12 @@
         </div>
         <ul class="list ma0 pa0">
         <li>
-          <a href="https://github.com/rust-community/events-team#-rust-events-team" target="_blank" rel="noopener" class="button button-secondary">Check
+          <a href="https://github.com/rust-community/events-team#-rust-events-team" class="button button-secondary">Check
             out the events team repo</a>
         </li>
         <li>
           <a href="https://docs.google.com/forms/d/e/1FAIpQLSf52YXGhqBaHtCXtVna4iHYMK7IQaTqUW6V-ztsZC8C2TBInQ/viewform"
-            target="_blank" rel="noopener" class="button button-secondary">Register your event</a>
+            class="button button-secondary">Register your event</a>
         </li>
         </ul>
       </div>
@@ -169,8 +169,7 @@
           with a background in another programming language to learn Rust and
           join the community.
         </p>
-        <a href="https://github.com/rustbridge/team" target="_blank" rel="noopener"
-          class="button button-secondary">Check out the Rustbridge repo</a>
+        <a href="https://github.com/rustbridge/team" class="button button-secondary">Check out the Rustbridge repo</a>
       </div>
     </div>
 
@@ -197,8 +196,7 @@
         <p>
           Increasing Rust’s Reach is a program that matches Rust team members from all parts of the project with individuals who are underrepresented in Rust’s community and the tech industry for a partnership of three (3) months, from mid-May to mid-August. Each partnership agrees to a commitment of 3–5 hours per week working on a Rust Project.
         </p>
-        <a href="http://reach.rust-lang.org/" target="_blank" rel="noopener"
-           class="button button-secondary">Visit Website</a>
+        <a href="http://reach.rust-lang.org/" class="button button-secondary">Visit Website</a>
       </div>
     </div>
   </div>
@@ -217,9 +215,9 @@
         religion, or similar personal characteristic. Our
         <a href="/policies/code-of-conduct">code of conduct</a> sets the
         standards for behavior in all official Rust forums.
-    
+
         <br /><br />
-    
+
         If you feel you have been or are being harassed or made uncomfortable by a
         community member, please contact any of the
         <a href="mailto:rust-mods@rust-lang.org">Rust Moderation Team</a>

--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -4,8 +4,8 @@
       <div class="four columns mt3 mt0-l" id="get-help">
         <h4>Get help!</h4>
         <ul>
-          <li><a href="https://doc.rust-lang.org" target="_blank" rel="noopener">Documentation</a></li>
-          <li><a href="https://users.rust-lang.org" target="_blank" rel="noopener">Ask a Question on the Users Forum</a></li>
+          <li><a href="https://doc.rust-lang.org">Documentation</a></li>
+          <li><a href="https://users.rust-lang.org">Ask a Question on the Users Forum</a></li>
           <li><a href="http://ping.rust-lang.org">Check Website Status</a></li>
         </ul>
         <div class="languages">
@@ -27,17 +27,17 @@
       </div>
       <div class="four columns mt3 mt0-l">
         <h4>Social</h4>
-        <a href="https://twitter.com/rustlang" target="_blank" rel="noopener"><img src="/static/images/twitter.svg" alt="twitter logo" title="Twitter"/></a>
-        <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" target="_blank" rel="noopener"><img style="padding-top: 6px; padding-bottom:6px" src="/static/images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
-        <a href="https://discord.gg/rust-lang" target="_blank" rel="noopener"><img src="/static/images/discord.svg" alt="discord logo" title="Discord"/></a>
-        <a href="https://github.com/rust-lang" target="_blank" rel="noopener"><img src="/static/images/github.svg" alt="github logo" title="GitHub"/></a>
+        <a href="https://twitter.com/rustlang"><img src="/static/images/twitter.svg" alt="twitter logo" title="Twitter"/></a>
+        <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA"><img style="padding-top: 6px; padding-bottom:6px" src="/static/images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
+        <a href="https://discord.gg/rust-lang"><img src="/static/images/discord.svg" alt="discord logo" title="Discord"/></a>
+        <a href="https://github.com/rust-lang"><img src="/static/images/github.svg" alt="github logo" title="GitHub"/></a>
       </div>
 
     </div>
     <div class="attribution">
       <p>
         Maintained by the Rust Team. See a typo?
-        <a href="https://github.com/rust-lang/www.rust-lang.org" target="_blank" rel="noopener">Send a fix here</a>!
+        <a href="https://github.com/rust-lang/www.rust-lang.org">Send a fix here</a>!
       </p>
       <p>Looking for the <a href="https://prev.rust-lang.org">previous website</a>?</p>
     </div>

--- a/templates/components/nav.hbs
+++ b/templates/components/nav.hbs
@@ -14,7 +14,7 @@
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="/tools">Tools</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="/governance">Governance</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="/community">Community</a></li>
-    <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://blog.rust-lang.org/" target="_blank" rel="noopener">Blog</a></li>
+    <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://blog.rust-lang.org/">Blog</a></li>
   </ul>
 
   <div class=" w-100 w-auto-l flex-none flex justify-center pv4 pv-0-l languages">

--- a/templates/components/panels/get-involved.hbs
+++ b/templates/components/panels/get-involved.hbs
@@ -23,7 +23,7 @@
       Rust is truly a community effort, and we welcome contribution from hobbyists and production users, from
       newcomers and seasoned professionals. Come help us make the Rust experience even better!
       </p>
-      <a href="https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md" class="button button-secondary" target="_blank" rel="noopener">
+      <a href="https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md" class="button button-secondary">
         Read Contribution Guide
       </a>
     </div>

--- a/templates/components/panels/production.hbs
+++ b/templates/components/panels/production.hbs
@@ -8,7 +8,7 @@
       <p class="lh-copy f2">
         Hundreds of companies around the world are using Rust in production
         today for fast, low-resource, cross-platform solutions. Software you know
-        and love, like <a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/" target="_blank" rel="noopener">Firefox</a>, <a href="https://blogs.dropbox.com/tech/2016/06/lossless-compression-with-brotli/" target="_blank" rel="noopener">Dropbox</a>, and <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/" target="_blank" rel="noopener">Cloudflare</a>, uses Rust. <strong>From startups to large
+        and love, like <a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/">Firefox</a>, <a href="https://blogs.dropbox.com/tech/2016/06/lossless-compression-with-brotli/">Dropbox</a>, and <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/">Cloudflare</a>, uses Rust. <strong>From startups to large
         corporations, from embedded devices to scalable web services, Rust is a great fit.</strong>
       </p>
     </div>
@@ -22,7 +22,7 @@
           <p class="attribution">&ndash; Catherine West, Technical Lead</p>
         </div>
         <div class="four columns">
-          <a href="https://blog.chucklefish.org/about/" target="_blank" rel="noopener">
+          <a href="https://blog.chucklefish.org/about/">
             <img src="/static/images/user-logos/chucklefish.png" alt="Chucklefish Logo" class="w-33 w-60-ns h-auto" />
           </a>
         </div>
@@ -30,7 +30,7 @@
       <hr/>
       <div class="testimonial row">
         <div class="four columns">
-          <a href="https://www.youtube.com/watch?v=u6ZbF4apABk" target="_blank" rel="noopener"><img src="/static/images/user-logos/yelp.png" alt="Yelp Logo" class="w-80" /></a>
+          <a href="https://www.youtube.com/watch?v=u6ZbF4apABk"><img src="/static/images/user-logos/yelp.png" alt="Yelp Logo" class="w-80" /></a>
         </div>
         <div class="eight columns" id="yelp-testimonial">
           <blockquote>

--- a/templates/components/tools/editors.hbs
+++ b/templates/components/tools/editors.hbs
@@ -1,32 +1,32 @@
 <div class="row">
   <div class="three columns">
-    <a href="https://marketplace.visualstudio.com/items?itemName=rust-lang.rust" target="_blank" rel="noopener"
+    <a href="https://marketplace.visualstudio.com/items?itemName=rust-lang.rust"
        class="button button-secondary">VS Code</a>
   </div>
   <div class="three columns">
-    <a href="https://github.com/rust-lang/rust-enhanced" target="_blank" rel="noopener"
+    <a href="https://github.com/rust-lang/rust-enhanced"
        class="button button-secondary">Sublime Text 3</a>
   </div>
   <div class="three columns">
-    <a href="https://github.com/rust-lang-nursery/atom-ide-rust" target="_blank" rel="noopener"
+    <a href="https://github.com/rust-lang-nursery/atom-ide-rust"
        class="button button-secondary">Atom</a>
   </div>
   <div class="three columns">
-    <a href="https://plugins.jetbrains.com/plugin/8182-rust" target="_blank" rel="noopener"
+    <a href="https://plugins.jetbrains.com/plugin/8182-rust"
        class="button button-secondary">IntelliJ IDEA</a>
   </div>
 </div>
 <div class="row">
   <div class="three columns">
-    <a href="https://www.eclipse.org/downloads/packages/release/2018-12/r/eclipse-ide-rust-developers-includes-incubating-components" target="_blank" rel="noopener"
+    <a href="https://www.eclipse.org/downloads/packages/release/2018-12/r/eclipse-ide-rust-developers-includes-incubating-components"
        class="button button-secondary">Eclipse</a>
   </div>
   <div class="three columns">
-    <a href="https://github.com/rust-lang/rust.vim" target="_blank" rel="noopener"
+    <a href="https://github.com/rust-lang/rust.vim"
        class="button button-secondary">Vim</a>
   </div>
   <div class="three columns">
-    <a href="https://github.com/rust-lang/rust-mode" target="_blank" rel="noopener"
+    <a href="https://github.com/rust-lang/rust-mode"
        class="button button-secondary">Emacs</a>
   </div>
 </div>

--- a/templates/components/what/cli/example.hbs
+++ b/templates/components/what/cli/example.hbs
@@ -22,7 +22,7 @@
             </article>
         </div>
 
-        <a href="https://rust-lang-nursery.github.io/cli-wg/" target="_blank" rel="noopener" class="button button-secondary">Learn more with the CLI
+        <a href="https://rust-lang-nursery.github.io/cli-wg/" class="button button-secondary">Learn more with the CLI
             book</a>
     </div>
 </section>

--- a/templates/components/what/cli/maintainable.hbs
+++ b/templates/components/what/cli/maintainable.hbs
@@ -18,7 +18,7 @@
                     out these “what if” situations before you even run your
                     program.
                 </p>
-                <a href="https://doc.rust-lang.org/book/ch09-00-error-handling.html" target="_blank" rel="noopener" class="button button-secondary">
+                <a href="https://doc.rust-lang.org/book/ch09-00-error-handling.html" class="button button-secondary">
                     Rust’s error handling
                 </a>
             </article>
@@ -33,7 +33,7 @@
                     features, refactor your application with the confidence that
                     you aren’t breaking anything.
                 </p>
-                <a href="https://doc.rust-lang.org/book/ch12-03-improving-error-handling-and-modularity.html" target="_blank" rel="noopener" class="button button-secondary">
+                <a href="https://doc.rust-lang.org/book/ch12-03-improving-error-handling-and-modularity.html" class="button button-secondary">
                     Refactoring Rust
                 </a>
             </article>

--- a/templates/components/what/cli/pitch.hbs
+++ b/templates/components/what/cli/pitch.hbs
@@ -39,7 +39,7 @@
             Compile everything down to a single binary&mdash;no need for your
             users to have a runtime or libraries installed.
           </p>
-          <a href="https://rust-lang-nursery.github.io/cli-wg/tutorial/packaging.html" target="_blank" rel="noopener" class="button button-secondary">
+          <a href="https://rust-lang-nursery.github.io/cli-wg/tutorial/packaging.html" class="button button-secondary">
             How to ship Rust code
           </a>
         </div>
@@ -59,7 +59,7 @@
             Handle configuration files across platforms with ease.  Rust will
             deal with namespaces and formats for you.
           </p>
-          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/config-files.html" target="_blank" rel="noopener" class="button button-secondary">
+          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/config-files.html" class="button button-secondary">
               Start configuring
           </a>
         </div>
@@ -79,7 +79,7 @@
             Generate manual pages for your app automatically.  Just package the
             generated files and you’re done.
           </p>
-          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/docs.html" target="_blank" rel="noopener" class="button button-secondary">
+          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/docs.html" class="button button-secondary">
             Learn how
           </a>
         </div>
@@ -98,8 +98,7 @@
             In addition to talking to humans, Rust has great tools to help you
             talk to machines.
           </p>
-          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/machine-communication.html"
-            target="_blank" rel="noopener" class="button button-secondary">
+          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/machine-communication.html" class="button button-secondary">
             Communicate with machines
           </a>
         </div>
@@ -120,8 +119,7 @@
             It’s easy to add logging, and even easier to configure it to
             different targets and with different styles.
           </p>
-          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/human-communication.html"
-            target="_blank" rel="noopener" class="button button-secondary">
+          <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/human-communication.html" class="button button-secondary">
             Log, trace, comprehend
           </a>
         </div>

--- a/templates/components/what/cli/production.hbs
+++ b/templates/components/what/cli/production.hbs
@@ -14,8 +14,8 @@
                         One of the reasons we liked Rust was the crates.io ecosystem. [...] There is a lot of really good already existing infrastructure for building very nice command-line interfaces.
                     </blockquote>
                     <p class="attribution">
-                        &ndash; Armin Ronacher, 
-                        <a href="https://www.youtube.com/watch?v=2Xu6EdEBa5E" target="_blank" rel="noopener">
+                        &ndash; Armin Ronacher,
+                        <a href="https://www.youtube.com/watch?v=2Xu6EdEBa5E">
                             Rust at Sentry &ndash; PolyConf 2017
                         </a>
                     </p>
@@ -28,7 +28,7 @@
                     </blockquote>
                     <p class="attribution">
                         &ndash; Fletcher Nichol,
-                        <a href="https://www.youtube.com/watch?v=zAXbPnfTJg4" target="_blank" rel="noopener">
+                        <a href="https://www.youtube.com/watch?v=zAXbPnfTJg4">
                             Taking Rust to Production &ndash; RustFest Kyiv
                         </a>
                     </p>

--- a/templates/components/what/embedded/get-started.hbs
+++ b/templates/components/what/embedded/get-started.hbs
@@ -14,7 +14,7 @@
         <p class="flex-grow-1">
           Learn embedded development from the ground up&mdash;using Rust!
         </p>
-        <a href="https://docs.rust-embedded.org/discovery/" target="_blank" rel="noopener" class="button button-secondary">Read</a>
+        <a href="https://docs.rust-embedded.org/discovery/" class="button button-secondary">Read</a>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="embedded-rust-book">
         <div class="domain-icon">
@@ -25,7 +25,7 @@
           Already familiar with Embedded development?
           Jump in with Rust and start reaping the benefits.
         </p>
-        <a href="https://docs.rust-embedded.org/book/" target="_blank" rel="noopener" class="button button-secondary">Read</a>
+        <a href="https://docs.rust-embedded.org/book/" class="button button-secondary">Read</a>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="embedonomicon">
         <div class="v-top tc-l">
@@ -36,13 +36,13 @@
         <p class="flex-grow-1">
           Look under the hood of foundational embedded libraries.
         </p>
-        <a href="https://docs.rust-embedded.org/embedonomicon/" target="_blank" rel="noopener" class="button button-secondary">Read</a>
+        <a href="https://docs.rust-embedded.org/embedonomicon/" class="button button-secondary">Read</a>
       </div>
     </div>
     <hr>
     <div style="text-align: center;">
       <p>
-        <a href="https://docs.rust-embedded.org/" target="_blank" rel="noopener" class="button button-secondary">
+        <a href="https://docs.rust-embedded.org/" class="button button-secondary">
           More Documentation
         </a>
     </div>

--- a/templates/components/what/embedded/pitch.hbs
+++ b/templates/components/what/embedded/pitch.hbs
@@ -15,7 +15,7 @@
           Enforce pin and peripheral configuration at compile time. Guarantee that resources won’t be used by
           unintended parts of your application.
         </p>
-        <a href="https://docs.rust-embedded.org/book/static-guarantees/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/static-guarantees/" class="button button-secondary">Learn more</a>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="flexible-memory-management">
         <div class="v-top tc-l">
@@ -27,7 +27,7 @@
           Dynamic memory allocation is optional. Use a global allocator and dynamic data structures.
           Or leave out the heap altogether and statically allocate everything.
         </p>
-          <a href="https://docs.rust-embedded.org/book/collections/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/collections/" class="button button-secondary">Learn more</a>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="safe-concurrency">
         <div class="v-top tc-l">
@@ -39,7 +39,7 @@
           Rust makes it impossible to accidentally share state between threads.
           Use any concurrency approach you like, and you’ll still get Rust’s strong guarantees.
         </p>
-        <a href="https://docs.rust-embedded.org/book/concurrency/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/concurrency/" class="button button-secondary">Learn more</a>
       </div>
     </div>
     <div class="flex-none flex-l flex-row mt5-l">
@@ -53,7 +53,7 @@
           Integrate Rust into your existing C codebase or leverage an existing SDK to write a Rust
           application.
         </p>
-        <a href="https://docs.rust-embedded.org/book/interoperability/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/interoperability/" class="button button-secondary">Learn more</a>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="portability">
         <div class="v-top tc-l">
@@ -65,7 +65,7 @@
           Write a library or driver once, and use it with a variety of systems, ranging
           from very small microcontrollers to powerful SBCs.
         </p>
-        <a href="https://docs.rust-embedded.org/book/portability/" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+        <a href="https://docs.rust-embedded.org/book/portability/" class="button button-secondary">Learn more</a>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="community-driven">
         <div class="v-top tc-l">
@@ -76,7 +76,7 @@
         <p class="flex-grow-1">
           As part of the Rust open source project, support for embedded systems is driven by a best-in-class open source community, with support from commercial partners.
         </p>
-        <a href="https://github.com/rust-embedded/wg" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+        <a href="https://github.com/rust-embedded/wg" class="button button-secondary">Learn more</a>
       </div>
     </div>
   </div>

--- a/templates/components/what/embedded/showcase.hbs
+++ b/templates/components/what/embedded/showcase.hbs
@@ -10,11 +10,11 @@
 
         <p>&ndash; Jonathan Pallant, Senior Consultant, Cambridge Consultants
 
-        <p><a href="https://github.com/rust-embedded/awesome-embedded-rust" target="_blank" rel="noopener" class="button button-secondary">See More</a>
+        <p><a href="https://github.com/rust-embedded/awesome-embedded-rust" class="button button-secondary">See More</a>
       </div>
       <div class="six columns">
         <iframe src="https://player.vimeo.com/video/224912526?title=0&byline=0&portrait=0" width="500" height="281"  frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-        <p><a href="https://vimeo.com/224912526" target="_blank" rel="noopener">Securing the future, with Rust</a> from <a href="https://vimeo.com/cambridgeconsultants" target="_blank" rel="noopener">Cambridge Consultants</a> on <a href="https://vimeo.com" target="_blank" rel="noopener">Vimeo</a>.</p>
+        <p><a href="https://vimeo.com/224912526">Securing the future, with Rust</a> from <a href="https://vimeo.com/cambridgeconsultants">Cambridge Consultants</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
       </div>
     </div>
   </div>

--- a/templates/components/what/embedded/testimonials.hbs
+++ b/templates/components/what/embedded/testimonials.hbs
@@ -10,13 +10,13 @@
 
       <div class="testimonial row">
         <div class="four columns">
-          <a href="https://www.sensirion.com/" target="_blank" rel="noopener">
+          <a href="https://www.sensirion.com/">
             <img alt="Sensirion logo" src="/static/images/user-logos/sensirion.png"/>
           </a>
         </div>
         <div class="eight columns" id="Sensirion-testimonial">
           <blockquote>
-            At Sensirion we recently used Rust to create an embedded demonstrator for Sensirion’s <a href="https://sensirion-automotive.com/products#PM2_5" target="_blank" rel="noopener">Particulate Matter Sensor</a>. Due to the easy cross-compilation and the availability of many high quality crates on crates.io <b>we quickly ended up with a fast and robust demonstrator.</b>
+            At Sensirion we recently used Rust to create an embedded demonstrator for Sensirion’s <a href="https://sensirion-automotive.com/products#PM2_5">Particulate Matter Sensor</a>. Due to the easy cross-compilation and the availability of many high quality crates on crates.io <b>we quickly ended up with a fast and robust demonstrator.</b>
           </blockquote>
           <p class="attribution">&ndash; Raphael Nestler, Software Engineer, Sensirion</p>
         </div>
@@ -25,12 +25,12 @@
       <div class="testimonial row">
         <div class="eight columns"id="greig-testimonial">
           <blockquote>
-            At Airborne Engineering Ltd. we recently used Rust to write an Ethernet bootloader, <a href="https://github.com/airborneengineering/blethrs" target="_blank" rel="noopener">blethrs</a>, for our in-house data acquisition system. <b>Rust is a promising language and we’re excited to use it for our future projects, embedded and otherwise.</b>
+            At Airborne Engineering Ltd. we recently used Rust to write an Ethernet bootloader, <a href="https://github.com/airborneengineering/blethrs">blethrs</a>, for our in-house data acquisition system. <b>Rust is a promising language and we’re excited to use it for our future projects, embedded and otherwise.</b>
           </blockquote>
           <p class="attribution">&ndash; Dr. Adam Greig, Instrumentation Engineer, Airborne Engineering Ltd.</p>
         </div>
         <div class="four columns">
-          <a href="http://ael.co.uk" target="_blank" rel="noopener">
+          <a href="http://ael.co.uk">
             <img alt="Airborne Engineering Ltd logo" src="/static/images/user-logos/ael_logo.png"/>
           </a>
         </div>
@@ -38,7 +38,7 @@
 
       <div class="testimonial row">
         <div class="four columns">
-          <a href="https://49nord.de/" target="_blank" rel="noopener">
+          <a href="https://49nord.de/">
             <img alt="49nord logo" src="/static/images/user-logos/49nord.svg"/>
           </a>
         </div>
@@ -60,7 +60,7 @@
           <p class="attribution">&ndash; Aleksei Arbuzov, Senior Software Engineer, Terminal Technologies</p>
         </div>
         <div class="four columns">
-          <a href="http://www.termt.eu/" target="_blank" rel="noopener">
+          <a href="http://www.termt.eu/">
             <img alt="Terminal Technologies logo" src="/static/images/user-logos/terminal-technologies.png"/>
           </a>
         </div>

--- a/templates/components/what/wasm/get-started.hbs
+++ b/templates/components/what/wasm/get-started.hbs
@@ -13,7 +13,7 @@
                     Learn more about the fast, safe, and open virtual machine called
                     WebAssembly, and read its standard.
                 </p>
-                <a href="https://webassembly.org/" target="_blank" rel="noopener" class="button button-secondary">Learn More</a>
+                <a href="https://webassembly.org/" class="button button-secondary">Learn More</a>
             </div>
             <div class="four columns">
                 <div class="domain-icon">
@@ -23,7 +23,7 @@
                     Learn how to build, debug, profile, and deploy WebAssembly
                     applications using Rust!
                 </p>
-                <a href="https://rustwasm.github.io/book" target="_blank" rel="noopener" class="button button-secondary">Read The Book</a>
+                <a href="https://rustwasm.github.io/book" class="button button-secondary">Read The Book</a>
             </div>
             <div class="four columns">
                 <div class="domain-icon">
@@ -32,7 +32,7 @@
                 <p>
                     Learn more about WebAssembly on the Mozilla Developer Network.
                 </p>
-                <a href="https://developer.mozilla.org/en-US/docs/WebAssembly" target="_blank" rel="noopener" class="button button-secondary">Check it out</a>
+                <a href="https://developer.mozilla.org/en-US/docs/WebAssembly" class="button button-secondary">Check it out</a>
             </div>
         </div>
     </div>

--- a/templates/components/what/wasm/js.hbs
+++ b/templates/components/what/wasm/js.hbs
@@ -31,7 +31,7 @@
                 </div>
                 <p>
                     Automatically generate binding code between Rust, WebAssembly, and JavaScript APIs.
-                    Take advantage of libraries like <a href="https://rustwasm.github.io/wasm-bindgen/web-sys/index.html" target="_blank" rel="noopener"><code>web-sys</code></a>
+                    Take advantage of libraries like <a href="https://rustwasm.github.io/wasm-bindgen/web-sys/index.html"><code>web-sys</code></a>
                     that
                     provide pre-packaged bindings for the entire web platform.
                 </p>

--- a/templates/components/what/wasm/production.hbs
+++ b/templates/components/what/wasm/production.hbs
@@ -15,7 +15,7 @@
                     </blockquote>
                     <p class="attribution">
                         &ndash;  Steven Pack,
-                        <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/" target="_blank" rel="noopener">
+                        <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/">
                             Serverless Rust with Cloudflare Workers
                         </a>
 
@@ -32,13 +32,13 @@
                     </blockquote>
                     <p class="attribution">
                         &ndash; Nick Fitzgerald,
-                        <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/" target="_blank" rel="noopener">
+                        <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/">
                             Oxidizing Source Maps with Rust and WebAssembly
                         </a>
                     </p>
                 </div>
                 <div class="four columns">
-                    <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/" target="_blank" rel="noopener" style="display: block;">
+                    <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/" style="display: block;">
                         <img src="/static/images/firefox.png" alt="firefox" />
                     </a>
                 </div>
@@ -54,7 +54,7 @@
                     </blockquote>
                     <p class="attribution">
                         &ndash; Daniel Reiter Horn and Jongmin Baek,
-                        <a href="https://blogs.dropbox.com/tech/2018/06/building-better-compression-together-with-divans/" target="_blank" rel="noopener">
+                        <a href="https://blogs.dropbox.com/tech/2018/06/building-better-compression-together-with-divans/">
                             Building Better Compression Together with DivANS
                         </a>
                     </p>

--- a/templates/governance/group-team.hbs
+++ b/templates/governance/group-team.hbs
@@ -17,7 +17,7 @@
                     </a>
                 {{/if}}
                 {{#if team.website_data.discord}}
-                    <a class="button button-secondary" href="{{team.website_data.discord.url}}" target="_blank" rel="noopener">
+                    <a class="button button-secondary" href="{{team.website_data.discord.url}}">
                         {{team.website_data.discord.channel}} on Discord
                     </a>
                 {{/if}}

--- a/templates/governance/index.hbs
+++ b/templates/governance/index.hbs
@@ -19,14 +19,14 @@
           Everyone is invited to discuss the proposal, to work toward a shared understanding of the tradeoffs.
           Though sometimes arduous, this community deliberation is Rust’s secret sauce for quality.
         </p>
-        <a href="https://github.com/rust-lang/rfcs" target="_blank" rel="noopener" class="button button-secondary">Learn
+        <a href="https://github.com/rust-lang/rfcs" class="button button-secondary">Learn
           more</a>
       </div>
       <div class="mw8 flex flex-column justify-between pt0 bp2 pv3-ns ph3-l">
         <p>The RFC process is also used to establish a yearly roadmap laying out our aspirations for that year.
           This shared vision is essential for keeping the development process focused.
         </p>
-        <a href="https://blog.rust-lang.org/2018/03/12/roadmap.html" target="_blank" rel="noopener" class="button button-secondary">Read
+        <a href="https://blog.rust-lang.org/2018/03/12/roadmap.html" class="button button-secondary">Read
           the 2018
           Roadmap</a>
       </div>

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -14,7 +14,7 @@
       <div class="highlight highlight"></div>
     </header>
     <p>You can try Rust online in the Rust Playground without installing anything on your computer.</p>
-    <a href="https://play.rust-lang.org/" target="_blank" rel="noopener" class="button button-secondary">Try Rust without installing</a>
+    <a href="https://play.rust-lang.org/" class="button button-secondary">Try Rust without installing</a>
     <hr />
 
     <h3>Rustup: the Rust installer and version management tool</h3>
@@ -33,11 +33,11 @@
       <li>run your project with <code>cargo run</code></li>
       <li>test your project with <code>cargo test</code></li>
       <li>build documentation for your project with <code>cargo doc</code></li>
-      <li>publish a library to <a href="https://crates.io" target="_blank" rel="noopener">crates.io</a> with <code>cargo publish</code></li>
+      <li>publish a library to <a href="https://crates.io">crates.io</a> with <code>cargo publish</code></li>
     </ul>
     <p>To test that you have Rust and Cargo installed, you can run this in your terminal of choice:</p>
     <p><code>cargo --version</code></p>
-    <a href="https://doc.rust-lang.org/cargo/index.html" target="_blank" rel="noopener" class="button button-secondary">Read
+    <a href="https://doc.rust-lang.org/cargo/index.html" class="button button-secondary">Read
         the cargo book</a>
     <hr />
 
@@ -87,10 +87,9 @@ Hello, world!</code></pre><p>
       <h2>Adding dependencies</h2>
       <div class="highlight"></div>
     </header>
-    <p>Let’s add a dependency to our application. You can find all sorts of libraries on <a href="https://crates.io"
-        target="_blank" rel="noopener">crates.io</a>, the package registry for Rust. In Rust, we often refer to
+    <p>Let’s add a dependency to our application. You can find all sorts of libraries on <a href="https://crates.io">crates.io</a>, the package registry for Rust. In Rust, we often refer to
       packages as “crates.”</p>
-    <p>In this project, we’ll use a crate called <a href="https://crates.io/crates/ferris-says" target="_blank" rel="noopener"><code>ferris-says</code></a>.
+    <p>In this project, we’ll use a crate called <a href="https://crates.io/crates/ferris-says"><code>ferris-says</code></a>.
       <p>In our <code>Cargo.toml</code> file we’ll add this information (that we got from the crate page):</p>
       <p>
         <pre><code>[dependencies]
@@ -173,7 +172,7 @@ fn main() {
       the pronouns “they,” “them,” etc., rather than with gendered pronouns.</p>
     <p>Ferris is a name playing off of the adjective, “ferrous,” meaning of or pertaining to iron. Since Rust often
       forms on iron, it seemed like a fun origin for our mascot’s name!</p>
-    <p>You can find more images of Ferris on <a href="http://rustacean.net/" target="_blank" rel="noopener">http://rustacean.net/</a>.
+    <p>You can find more images of Ferris on <a href="http://rustacean.net/">http://rustacean.net/</a>.
       <img alt="a gif of ferris scurrying side to side" width="540" height="180"
            src="/static/images/ferris.gif" />
   </div>

--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -59,7 +59,7 @@
 
       <section class="flex flex-column">
         <div class="pt3 flex flex-column flex-row-l">
-          <a href="https://doc.rust-lang.org/std/index.html" target="_blank" rel="noopener"
+          <a href="https://doc.rust-lang.org/std/index.html"
              class="button button-secondary mw6-l w-100">The standard library</a>
           <p class="pl4-l">
             Comprehensive guide to the Rust standard library APIs.
@@ -67,7 +67,7 @@
         </div>
 
         <div class="pt4 pt3-l flex flex-column flex-row-l">
-          <a href="https://doc.rust-lang.org/edition-guide/index.html" target="_blank" rel="noopener"
+          <a href="https://doc.rust-lang.org/edition-guide/index.html"
              class="button button-secondary mw6-l w-100">Edition Guide</a>
           <p class="pl4-l">
             Guide to the Rust editions.
@@ -75,7 +75,7 @@
         </div>
 
         <div class="pt4 pt3-l flex flex-column flex-row-l">
-          <a href="https://doc.rust-lang.org/cargo/index.html" target="_blank" rel="noopener"
+          <a href="https://doc.rust-lang.org/cargo/index.html"
              class="button button-secondary mw6-l w-100">Cargo Book</a>
           <p class="pl4-l">
             A book on Rust’s package manager and build system.
@@ -83,7 +83,7 @@
         </div>
 
         <div class="pt4 pt3-l flex flex-column flex-row-l">
-          <a href="https://doc.rust-lang.org/rustdoc/index.html" target="_blank" rel="noopener"
+          <a href="https://doc.rust-lang.org/rustdoc/index.html"
              class="button button-secondary mw6-l w-100">rustdoc Book</a>
           <p class="pl4-l">
             Learn how to make awesome documentation for your crate.
@@ -91,7 +91,7 @@
         </div>
 
         <div class="pt4 pt3-l flex flex-column flex-row-l">
-          <a href="https://doc.rust-lang.org/rustc/index.html" target="_blank" rel="noopener"
+          <a href="https://doc.rust-lang.org/rustc/index.html"
              class="button button-secondary mw6-l w-100">rustc Book</a>
           <p class="pl4-l">
             Familiarize yourself with the knobs available in the Rust compiler.
@@ -99,7 +99,7 @@
         </div>
 
         <div class="pt4 pt3-l flex flex-column flex-row-l">
-          <a href="https://doc.rust-lang.org/error-index.html" target="_blank" rel="noopener"
+          <a href="https://doc.rust-lang.org/error-index.html"
              class="button button-secondary mw6-l w-100">Compiler Error Index</a>
           <p class="pl4-l">
             In-depth explanations of the errors you may see from the Rust
@@ -113,7 +113,7 @@
       <h3>Build your skills in an application domain</h3>
         <section class="flex flex-column">
           <div class="pt3 flex flex-column flex-row-l">
-            <a href="https://rust-lang-nursery.github.io/cli-wg/" target="_blank" rel="noopener"
+            <a href="https://rust-lang-nursery.github.io/cli-wg/"
                class="button button-secondary mw6-l w-100">
               Command Line Book
             </a>
@@ -123,7 +123,7 @@
           </div>
 
           <div class="pt4 pt3-l flex flex-column flex-row-l">
-            <a href="https://rustwasm.github.io/book/" target="_blank" rel="noopener"
+            <a href="https://rustwasm.github.io/book/"
                class="button button-secondary mw6-l w-100">
               WebAssembly Book
             </a>

--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -24,7 +24,7 @@
       <li>Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a
         fork and see how it works.</li>
       <li>We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We
-        interpret the term “harassment” as including the definition in the <a href="http://citizencodeofconduct.org/" target="_blank" rel="noopener">Citizen
+        interpret the term “harassment” as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen
           Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please
         read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized
         groups.</li>
@@ -81,8 +81,8 @@
       Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of
       conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your
       own moderation policy so as to avoid confusion.</p>
-    <p><i>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling" target="_blank" rel="noopener">Node.js Policy on Trolling</a>
-        as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/" target="_blank" rel="noopener">Contributor Covenant v1.3.0</a>.</i></p>
+    <p><i>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling">Node.js Policy on Trolling</a>
+        as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/">Contributor Covenant v1.3.0</a>.</i></p>
   </div>
 </section>
 

--- a/templates/policies/licenses.hbs
+++ b/templates/policies/licenses.hbs
@@ -14,8 +14,8 @@
     </header>
     <p>The Rust Programming Language and all other official projects, including this website, are generally dual-licensed:</p>
     <ul>
-      <li><a href="http://www.apache.org/licenses/LICENSE-2.0" target="_blank" rel="noopener">Apache License, Version 2.0</a></li>
-      <li><a href="http://opensource.org/licenses/MIT" target="_blank" rel="noopener">MIT license</a></li>
+      <li><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a></li>
+      <li><a href="http://opensource.org/licenses/MIT">MIT license</a></li>
     </ul>
     <p>Specific licensing info for each project can be found in its GitHub Repository.</p>
     <p>Third-party logos may be subject to third-party copyrights and trademarks, and are not available under the same license as the rest of the Rust website.</p>
@@ -30,11 +30,11 @@
       <h2>Attribution</h2>
       <div class="highlight"></div>
     </header>
-    <p>Icons made by <a href="http://www.freepik.com" target="_blank" rel="noopener" title="Freepik">Freepik</a>
-      from <a href="https://www.flaticon.com/" target="_blank" rel="noopener"
+    <p>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a>
+      from <a href="https://www.flaticon.com/"
               title="Flaticon">www.flaticon.com</a>, licensed by
-            <a href="http://creativecommons.org/licenses/by/3.0/" target="_blank" rel="noopener"
-               title="Creative Commons BY 3.0" target="_blank">CC-3.0-BY</a>
+            <a href="http://creativecommons.org/licenses/by/3.0/"
+               title="Creative Commons BY 3.0">CC-3.0-BY</a>
     </p>
 </section>
 

--- a/templates/policies/media-guide.hbs
+++ b/templates/policies/media-guide.hbs
@@ -12,7 +12,7 @@
       <h2>Art license</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust and Cargo logos (bitmap and vector) are owned by Mozilla and distributed under the terms of the <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">Creative Commons Attribution license (CC-BY)</a>. This is the most permissive Creative Commons license, and allows reuse and modifications for any purpose. The restrictions are that distributors must “give appropriate credit, provide a link to the license, and indicate if changes were made.” <strong>Note that use of these logos, and the Rust and Cargo names, is also governed by trademark; our trademark policy is described below</strong>.</p>
+    <p>The Rust and Cargo logos (bitmap and vector) are owned by Mozilla and distributed under the terms of the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution license (CC-BY)</a>. This is the most permissive Creative Commons license, and allows reuse and modifications for any purpose. The restrictions are that distributors must “give appropriate credit, provide a link to the license, and indicate if changes were made.” <strong>Note that use of these logos, and the Rust and Cargo names, is also governed by trademark; our trademark policy is described below</strong>.</p>
   </div>
 </section>
 
@@ -25,7 +25,7 @@
     <p>The Rust and Cargo names and brands make it possible to say what is officially part of the Rust community, and what isn’t. So we’re careful about where we allow them to appear. But at the same time, we want to allow for as much creative use of these brands as we can. The policy laid out here explains how we strike a balance. If you want to use these names or brands, especially in a commercial way, please read this page or feel free to <a href="mailto:trademark@rust-lang.org">reach out</a> and ask us about it!</p>
     <p><b>TL;DR</b>: Most non-commercial uses of the Rust/Cargo names and logos are allowed and do not require permission; most commercial uses require permission. In either case, the most important rule is that uses of the trademarks cannot appear official or imply any endorsement by the Rust project.</p>
     <p>If you have any doubts about whether your intended use of a Rust Trademark requires permission, please contact us at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</p>
-    <p>This document was derived in part from the <a href="https://www.python.org/psf/trademarks/" target="_blank" rel="noopener">Python Software Foundation Trademark Usage Policy</a>. This document is not an official statement of Mozilla trademark policy, but serves to clarify Mozilla’s trademark policy as it relates to Rust.</p>
+    <p>This document was derived in part from the <a href="https://www.python.org/psf/trademarks/">Python Software Foundation Trademark Usage Policy</a>. This document is not an official statement of Mozilla trademark policy, but serves to clarify Mozilla’s trademark policy as it relates to Rust.</p>
   </div>
 </section>
 
@@ -35,7 +35,7 @@
       <h2>The Rust trademarks</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust programming language is an open source, community project governed by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”), which owns and protects the Rust and Cargo trademarks and logos (the “Rust Trademarks”). This document provides information about use of the Rust Trademarks specific to a programming language, as well as examples of common ways people might want to use these trademarks, with explanations as to whether those uses are OK or not or require permission. This document supplements the <a href="https://www.mozilla.org/foundation/trademarks/policy/" target="_blank" rel="noopener">official Mozilla trademark policy</a> which governs use of all Mozilla trademarks.</p>
+    <p>The Rust programming language is an open source, community project governed by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”), which owns and protects the Rust and Cargo trademarks and logos (the “Rust Trademarks”). This document provides information about use of the Rust Trademarks specific to a programming language, as well as examples of common ways people might want to use these trademarks, with explanations as to whether those uses are OK or not or require permission. This document supplements the <a href="https://www.mozilla.org/foundation/trademarks/policy/">official Mozilla trademark policy</a> which governs use of all Mozilla trademarks.</p>
     <p>The Rust Trademarks include two word marks and two logos:</p>
     <ul>
       <li>Rust</li>

--- a/templates/policies/security.hbs
+++ b/templates/policies/security.hbs
@@ -22,13 +22,13 @@ is delivered to a small security team. Your email will be acknowledged within 24
 hours, and you’ll receive a more detailed response to your email within 48
 hours indicating the next steps in handling your report. If you would like, you
 can encrypt your report using <a href="../rust-security-team-key.gpg.ascii">our public key</a>.
-This key is also <a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC" target="_blank" rel="noopener">On
+This key is also <a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC">On
 MIT’s keyserver</a> and <a href="#key">reproduced below</a>.</p>
     <p>This email address receives a large amount of spam, so be sure to use a
 descriptive subject line to avoid having your report be missed. After the
 initial reply to your report, the security team will endeavor to keep you
 informed of the progress being made towards a fix and full announcement. As
-recommended by <a href="https://en.wikipedia.org/wiki/RFPolicy" target="_blank" rel="noopener">RFPolicy</a>,
+recommended by <a href="https://en.wikipedia.org/wiki/RFPolicy">RFPolicy</a>,
 these updates will be sent at least every five days. In reality, this is more
 likely to be every 24-48 hours.</p>
     <p>If you have not received a reply to your email within 48 hours, or have not
@@ -36,10 +36,10 @@ heard from the security team for the past five days, there are a few steps you
 can take (in order):</p>
     <ul>
       <li>Contact the current security coordinator (<a href="mailto:steve@steveklabnik.com">Steve Klabnik</a>
-        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xDAE717EFE9424541" target="_blank" rel="noopener">public key</a>)) directly.</li>
+        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xDAE717EFE9424541">public key</a>)) directly.</li>
       <li>Contact the back-up contact (<a href="mailto:alex@alexcrichton.com">Alex Crichton</a>
-        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0x5D54B6F551FF5E33" target="_blank" rel="noopener">public key</a>)) directly.</li>
-      <li>Post on the <a href="https://internals.rust-lang.org/" target="_blank" rel="noopener">internals forums</a></li>
+        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0x5D54B6F551FF5E33">public key</a>)) directly.</li>
+      <li>Post on the <a href="https://internals.rust-lang.org/">internals forums</a></li>
     </ul>
     <p>Please note that the discussion forums and #rust-internals IRC channel are
 public areas. When escalating in these venues, please do not discuss your
@@ -61,7 +61,7 @@ team.</p>
       <li>The problem is confirmed and a list of all affected versions is determined.</li>
       <li>Code is audited to find any potential similar problems.</li>
       <li>Fixes are prepared for all releases which are still under maintenance. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
-      <li>On the embargo date, the <a href="https://groups.google.com/forum/#!forum/rustlang-security-announcements" target="_blank" rel="noopener"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and new builds are deployed to rust-lang.org.  Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
+      <li>On the embargo date, the <a href="https://groups.google.com/forum/#!forum/rustlang-security-announcements"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and new builds are deployed to rust-lang.org.  Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
     </ol>
     <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
   </div>
@@ -73,9 +73,9 @@ team.</p>
       <h2>Receiving security updates</h2>
       <div class="highlight"></div>
     </header>
-    <p>The best way to receive all the security announcements is to subscribe to the <a href="https://groups.google.com/group/rustlang-security-announcements/subscribe" target="_blank" rel="noopener">Rust security announcements mailing list</a> (alternatively by sending an email to <a href="mailto:rustlang-security-announcements+subscribe@googlegroups.com">rustlang-security-announcements+subscribe@googlegroups.com</a>). The mailing list is very low traffic, and it receives the public notifications the
+    <p>The best way to receive all the security announcements is to subscribe to the <a href="https://groups.google.com/group/rustlang-security-announcements/subscribe">Rust security announcements mailing list</a> (alternatively by sending an email to <a href="mailto:rustlang-security-announcements+subscribe@googlegroups.com">rustlang-security-announcements+subscribe@googlegroups.com</a>). The mailing list is very low traffic, and it receives the public notifications the
 moment the embargo is lifted.</p>
-    <p>We will announce vulnerabilities 72 hours before the embargo is lifted to <a href="https://oss-security.openwall.org/wiki/mailing-lists/distros" target="_blank" rel="noopener">distros@openwall</a>, so that Linux distributions can update their packages.</p>
+    <p>We will announce vulnerabilities 72 hours before the embargo is lifted to <a href="https://oss-security.openwall.org/wiki/mailing-lists/distros">distros@openwall</a>, so that Linux distributions can update their packages.</p>
   </div>
 </section>
 

--- a/templates/production/index.hbs
+++ b/templates/production/index.hbs
@@ -15,19 +15,19 @@
     <div class="flex flex-column flex-row-l">
       <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
         <h3>npm</h3>
-        <p>Read how <a href="https://www.npmjs.com/" target="_blank" rel="noopener">npm</a>, who runs the JavaScript Registry of the same name, found Rust to be boring to deploy.</p>
+        <p>Read how <a href="https://www.npmjs.com/">npm</a>, who runs the JavaScript Registry of the same name, found Rust to be boring to deploy.</p>
         <a class="button button-secondary" href="/static/pdfs/Rust-npm-Whitepaper.pdf">Read the whitepaper</a>
       </div>
       <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
         <h3>Chucklefish</h3>
-        <p><a href="https://chucklefish.org/" target="_blank" rel="noopener">Chucklefish</a>, the video game company that published Stardew Valley and Starbound, is using Rust in their new projects Wargroove and Witchbrook to get safe concurrency and portability.</p>
+        <p><a href="https://chucklefish.org/">Chucklefish</a>, the video game company that published Stardew Valley and Starbound, is using Rust in their new projects Wargroove and Witchbrook to get safe concurrency and portability.</p>
       <a class="button button-secondary" href="/static/pdfs/Rust-Chucklefish-Whitepaper.pdf">Read the whitepaper</a>
       </div>
     </div>
     <div class="flex flex-column flex-row-l">
       <div class="mh2-l pt0 flex flex-column justify-between-l">
         <h3>Tilde</h3>
-        <p>Learn how Rust helps <a href="http://www.tilde.io/" target="_blank" rel="noopener">Tilde</a>, makers of <a href="https://www.skylight.io/" target="_blank" rel="noopener">Skylight</a>, use minimal resources to enable feature-rich performance monitoring of their customers’ applications.</p>
+        <p>Learn how Rust helps <a href="http://www.tilde.io/">Tilde</a>, makers of <a href="https://www.skylight.io/">Skylight</a>, use minimal resources to enable feature-rich performance monitoring of their customers’ applications.</p>
         <a class="button button-secondary" href="/static/pdfs/Rust-Tilde-Whitepaper.pdf">Read the whitepaper</a>
       </div>
     </div>
@@ -46,7 +46,7 @@
         <p>
           Several components of the Dropbox core file-storage system were written in Rust as one step in part of a larger project to pursue greater datacenter efficiency. It’s currently used by all Dropbox storage today, serving >500 million users.
         </p>
-        <a href="https://www.wired.com/2016/03/epic-story-dropboxs-exodus-amazon-cloud-empire/" target="_blank" rel="noopener" class="button button-secondary">Read More</a>
+        <a href="https://www.wired.com/2016/03/epic-story-dropboxs-exodus-amazon-cloud-empire/" class="button button-secondary">Read More</a>
       </div>
       <div class="four columns">
         <img alt="dropbox logo" src="/static/images/dropbox.svg" />
@@ -62,7 +62,7 @@
         <p>
           Yelp has developed a framework in Rust for real-time A/B testing. It’s used across all Yelp websites and apps, and experiment subjects range from UX to internal infrastructure. Rust was chosen because it’s as fast as C (cheap to run) and safer than C (cheap to maintain).
         </p>
-        <a href="https://www.youtube.com/watch?v=u6ZbF4apABk" target="_blank" rel="noopener" class="button button-secondary">Watch the Video</a>
+        <a href="https://www.youtube.com/watch?v=u6ZbF4apABk" class="button button-secondary">Watch the Video</a>
       </div>
     </div>
   </div>

--- a/templates/production/users.hbs
+++ b/templates/production/users.hbs
@@ -13,7 +13,7 @@
         {{#each user_row as |u| ~}}
           <div class="flex flex-column justify-between ba br3 b--black mw-100 w-100-l pa3 ma4 max-width-quarter-l">
             <div class="user-logo">
-              <a href="{{ u.url }}" target="_blank" rel="noopener">
+              <a href="{{ u.url }}">
                 <img src="/static/images/user-logos/{{ u.logo }}" alt="{{ u.logo }}" />
               </a>
             </div>

--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -20,7 +20,7 @@
       <p>Whether you prefer working with code from the command line, or using
         rich graphical editors, there’s a Rust integration available for your
         editor of choice. Or you can build your own using the
-        <a href="https://github.com/rust-lang-nursery/rls" target="_blank" rel="noopener">Rust Language Server</a>.
+        <a href="https://github.com/rust-lang-nursery/rls">Rust Language Server</a>.
       </div>
     </div>
     {{> components/tools/editors }}
@@ -46,7 +46,7 @@
         </h3>
         <p>
           With tens of thousands of packages, there’s a good chance
-          <a href="https://crates.io" target="_blank" rel="noopener">crates.io</a> has the solution you’re
+          <a href="https://crates.io">crates.io</a> has the solution you’re
           looking for. Stand on the shoulders of giants, and move your team from
           repetition to innovation.
         </p>
@@ -100,7 +100,7 @@
           write, and maintain. And most importantly: never debate spacing or
           brace position ever again.
         </p>
-        <a href="https://github.com/rust-lang-nursery/rustfmt" target="_blank" rel="noopener"
+        <a href="https://github.com/rust-lang-nursery/rustfmt"
              class="button button-secondary">Go to repo</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
@@ -112,7 +112,7 @@
           helps developers of all experience levels write idiomatic code, and
           enforce standards.
         </p>
-         <a href="https://github.com/rust-lang-nursery/rust-clippy" target="_blank" rel="noopener"
+         <a href="https://github.com/rust-lang-nursery/rust-clippy"
              class="button button-secondary">Go to repo</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
@@ -122,9 +122,9 @@
         <p class="flex-grow-1">
           Cargo’s doc builder makes it so no API ever goes undocumented. It’s
           available locally through <code>cargo doc</code>, and online for
-          public crates through <a href="https://docs.rs" target="_blank" rel="noopener">docs.rs</a>.
+          public crates through <a href="https://docs.rs">docs.rs</a>.
         </p>
-        <a href="https://docs.rs/" target="_blank" rel="noopener"
+        <a href="https://docs.rs/"
              class="button button-secondary">Go to site</a>
       </div>
     </div>

--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -31,12 +31,12 @@
       <h3>Toolchain management with <code>rustup</code></h3>
       <p>
         Rust is installed and managed by the
-        <a href="https://github.com/rust-lang-nursery/rustup.rs" target="_blank" rel="noopener"><code>rustup</code></a>
+        <a href="https://github.com/rust-lang-nursery/rustup.rs"><code>rustup</code></a>
         tool. Rust has a 6-week
-        <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md" target="_blank" rel="noopener">
+        <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
           rapid release process
         </a> and supports a
-        <a href="https://forge.rust-lang.org/platform-support.html" target="_blank" rel="noopener">
+        <a href="https://forge.rust-lang.org/platform-support.html">
           great number of platforms
         </a>, so there are many builds of Rust available at any time.
         <code>rustup</code> manages these builds in a consistent way on every
@@ -50,7 +50,7 @@
       </p>
       <p>
         For more information see the
-        <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md" target="_blank" rel="noopener"><code>rustup</code>
+        <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md"><code>rustup</code>
         documentation</a>.
       </p>
 
@@ -69,7 +69,7 @@
       <p>
         Accordingly, it is customary for Rust developers to include this
         directory in their
-        <a href="https://en.wikipedia.org/wiki/PATH_(variable)" target="_blank" rel="noopener"><code>PATH</code>
+        <a href="https://en.wikipedia.org/wiki/PATH_(variable)"><code>PATH</code>
         environment variable</a>.  During installation <code>rustup</code>
         will attempt to configure the
         <code>PATH</code>. Because of differences between platforms,
@@ -88,17 +88,17 @@
         On Windows, Rust additionally requires the C++ build tools
         for Visual Studio 2013 or later. The easiest way to acquire the build
         tools is by installing
-        <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017" target="_blank" rel="noopener">
+        <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2017">
           Microsoft Visual C++ Build Tools 2017
         </a>
         which provides just the Visual C++ build tools. Alternately, you
-        can <a href="https://www.visualstudio.com/downloads/" target="_blank" rel="noopener">install</a>
+        can <a href="https://www.visualstudio.com/downloads/">install</a>
         Visual Studio 2017, Visual Studio 2015, or Visual Studio 2013 and during install select
         the “C++ tools.”
       </p>
       <p>
         For further information about configuring Rust on Windows see the
-        <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows" target="_blank" rel="noopener">Windows-specific <code>rustup</code> documentation</a>.
+        <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-specific <code>rustup</code> documentation</a>.
       </p>
     </div>
   </div>
@@ -114,7 +114,7 @@
       The installation described above, via <code>rustup</code>, is the preferred way to install Rust
       for most developers. However, Rust can be installed via other methods as well.
     </p>
-    <a href="https://forge.rust-lang.org/other-installation-methods.html" target="_blank" rel="noopener" class="button button-secondary">Learn more</a>
+    <a href="https://forge.rust-lang.org/other-installation-methods.html" class="button button-secondary">Learn more</a>
   </div>
 </section>
 {{> components/tools/install-script }}


### PR DESCRIPTION
Fixes #706. Essentially reverts #263.

There is no security issue with same-tab links to external websites. (Indeed, most of the Internet uses them.) The issue described in https://mathiasbynens.github.io/rel-noopener/ applies *only* to links that have `target="_blank"`, the mechanism for opening links in new tabs. If the website sticks to the default behavior of opening links in the same tab, it will never run into this security issue, and it will annoy users significantly less.

Particularly egregious is the "blog" link in the header, which opens in a new tab even though it looks like it's an internal link to a different section of the website. More generally, though, the links which open in a new tab are visually indistinguishable from those that don't; this makes the website unpredictable and frustrating to use.

The changes in #263 are time-consuming to maintain, and they haven't been; see, e.g., the ["watch the videos" link](https://github.com/rust-lang/www.rust-lang.org/commit/893f50f23639eaec4b123f1ace3a725fe31c27c0) on the homepage or the ["check website status" link](https://github.com/rust-lang/www.rust-lang.org/commit/c7b1bfab85bb24a9b0c973dc32c73f359f7d703d) in the footer, both of which are same-tab external links added after #263 was merged.

The only link that opened in a new tab prior to https://github.com/rust-lang/www.rust-lang.org/commit/b9cd5f39497d63a89a87b394d391b33ad5317e31 was [a link to the CC 3.0 BY license](https://github.com/rust-lang/www.rust-lang.org/commit/ade6fd226d3c6599f23e01ff85320d5455395d49#diff-584da2ea3fa9f00b298d37da19728355). There doesn't seem to have been much reason for this, so I've made it open in the same tab as well.