### PR TITLE
changed wasm book link to the published version

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -123,7 +123,7 @@
           </div>
 
           <div class="pt4 pt3-l flex flex-column flex-row-l">
-            <a href="https://rustwasm.github.io/book/"
+            <a href="https://rustwasm.github.io/docs/book/"
                class="button button-secondary mw6-l w-100">
               WebAssembly Book
             </a>


### PR DESCRIPTION
The link to the WebAssembly book should now lead to the published version.

Fixes #723 