### PR TITLE
Tweak installation page

### DIFF
--- a/templates/components/tools/install-script.hbs
+++ b/templates/components/tools/install-script.hbs
@@ -113,7 +113,9 @@ function cycle_platform() {
 
 function set_up_cycle_button() {
     var cycle_button = document.getElementById("platform-button");
-    cycle_button.onclick = cycle_platform;
+    if (cycle_button !== null) {
+        cycle_button.onclick = cycle_platform;
+    }
 
     var key="test";
     var idx=0;
@@ -128,7 +130,9 @@ function set_up_cycle_button() {
             idx += 1;
 
             if (idx == key.length) {
-                cycle_button.style.display = "block";
+                if (cycle_button !== null) {
+                    cycle_button.style.display = "block";
+                }
                 unlocked = true;
                 cycle_platform();
             }

--- a/templates/components/tools/install-script.hbs
+++ b/templates/components/tools/install-script.hbs
@@ -151,7 +151,35 @@ function fill_in_bug_report_values() {
     nav_app.textContent = navigator.appVersion;
 }
 
+var override_map = new Map ([
+    ["unix", "unix"],
+    ["win", "win"],
+    ["linux", "unix"],
+    ["win32", "win"],
+    ["win64", "win"],
+    ["windows", "win"],
+    ["wsl", "win"],
+    ["default", "default"],
+    ["generic", "default"],
+    ["all", "default"],
+]);
+
+function check_initial_override() {
+    var urlParams = new URLSearchParams(location.search);
+    if (urlParams.has('platform_override')) {
+        var override = urlParams.get('platform_override').toLowerCase();
+        // Now normalise in case people pass unusual things in
+        override = override_map.get(override);
+        if (override === undefined) {
+            platform_override = "unknown";
+        } else {
+            platform_override = override;
+        }
+    }
+}
+
 (function () {
+    check_initial_override();
     adjust_for_platform();
     set_up_cycle_button();
     fill_in_bug_report_values();

--- a/templates/components/tools/rustup.hbs
+++ b/templates/components/tools/rustup.hbs
@@ -48,10 +48,11 @@
   <div id="platform-instructions-default" class="instructions" style="display: none;">
     <div>
       <p>
-        To install Rust, if you are running Unix,<br>run the following
+        To install Rust, if you are running a Unix such as WSL, Linux or macOS,<br>
+        run the following
         in your terminal, then follow the on-screen instructions.
       </p>
-      <code>curl https://sh.rustup.rs -sSf | sh</code>
+      <pre><code>curl https://sh.rustup.rs -sSf | sh</code></pre>
     </div>
     <hr>
     <div>


### PR DESCRIPTION
In order that we can link nicely to the installation page for various platforms from the `rustup.rs` documentation (for example, in order to support https://github.com/rust-lang/rustup.rs/pull/1707#discussion_r264291131 and similar) this PR offers up some tweaks to the installation page to do just that.

It is split into three commits.  The first just tweaks the formatting and wording of the "generic" or "default" instructions a little, the second fixes a JS error when the test button is absent from the install page, and the third introduces the query-string based override support.  In theory only the third is needed, but I think the other two are worthwhile tweaks also.