### PR TITLE
Feature npm on the homepage

### DIFF
--- a/templates/components/panels/production.hbs
+++ b/templates/components/panels/production.hbs
@@ -14,16 +14,15 @@
     </div>
     <div class="testimonials">
       <div class="testimonial row">
-        <div class="eight columns" id="chucklefish-testimonial">
+        <div class="eight columns" id="npm-testimonial">
           <blockquote class="lh-title-ns">
-            Rust is one of the few languages that really gives you a large amount of confidence that your parallel and
-            concurrent code is anywhere near correct.
+            My biggest compliment to Rust is that it's boring, and this is an amazing compliment.
           </blockquote>
-          <p class="attribution">&ndash; Catherine West, Technical Lead</p>
+          <p class="attribution">&ndash; Chris Dickinson, Engineer at npm, Inc</p>
         </div>
         <div class="four columns">
-          <a href="https://blog.chucklefish.org/about/">
-            <img src="/static/images/user-logos/chucklefish.png" alt="Chucklefish Logo" class="w-33 w-60-ns h-auto" />
+          <a href="https://www.npmjs.com/">
+            <img src="/static/images/user-logos/npm.svg" alt="npm Logo" class="w-33 w-60-ns h-auto" />
           </a>
         </div>
       </div>


### PR DESCRIPTION
The core team decided we should swap out npm for Chucklefish.

This is what it'll look like:

<img width="1210" alt="Screen Shot 2019-03-26 at 4 27 55 PM" src="https://user-images.githubusercontent.com/193874/55031171-5f35a600-4fe4-11e9-9f7f-faa3236cafff.png">

I'm going to merge when CI passes!