### PR TITLE
add `extern crate ferris_says` to get started example

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -112,7 +112,8 @@ ferris-says = "0.1"</code></pre>
     </header>
     <p>Now let’s write a small application with our new dependency. In our <code>main.rs</code>, add the following
       code:</p>
-    <pre><code>use ferris_says::say; // from the previous step
+    <pre><code>extern crate ferris_says;
+use ferris_says::say; // from the previous step
 use std::io::{stdout, BufWriter};
 
 fn main() {


### PR DESCRIPTION
add `extern crate ferris_says` to get started example

https://www.rust-lang.org/learn/get-started

At least with rust version 1.34 the existing example errors with the following error:

```
error[E0432]: unresolved import `ferris_says`
 --> src/main.rs:1:5
  |
1 | use ferris_says::say; // from the previous step
  |     ^^^^^^^^^^^ maybe a missing `extern crate ferris_says;`?

error: aborting due to previous error

For more information about this error, try `rustc --explain E0432`.
error: Could not compile `hello-rust`.

To learn more, run the command again with --verbose.
```