### PR TITLE
Update links that moved away from nursery

### DIFF
--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -31,7 +31,7 @@
       <h3>Toolchain management with <code>rustup</code></h3>
       <p>
         Rust is installed and managed by the
-        <a href="https://github.com/rust-lang-nursery/rustup.rs"><code>rustup</code></a>
+        <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>
         tool. Rust has a 6-week
         <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
           rapid release process
@@ -49,7 +49,7 @@
       </p>
       <p>
         For more information see the
-        <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md"><code>rustup</code>
+        <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md"><code>rustup</code>
         documentation</a>.
       </p>
 
@@ -97,7 +97,7 @@
       </p>
       <p>
         For further information about configuring Rust on Windows see the
-        <a href="https://github.com/rust-lang-nursery/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-specific <code>rustup</code> documentation</a>.
+        <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-specific <code>rustup</code> documentation</a>.
       </p>
     </div>
   </div>


### PR DESCRIPTION
https://github.com/rust-lang-nursery/rustup.rs
moved to
https://github.com/rust-lang/rustup.rs

