### PR TITLE
Update more links that moved away from nursery

### DIFF
--- a/templates/components/tools/editors.hbs
+++ b/templates/components/tools/editors.hbs
@@ -8,7 +8,7 @@
        class="button button-secondary">Sublime Text 3</a>
   </div>
   <div class="three columns">
-    <a href="https://github.com/rust-lang-nursery/atom-ide-rust"
+    <a href="https://github.com/rust-lang/atom-ide-rust"
        class="button button-secondary">Atom</a>
   </div>
   <div class="three columns">

--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -20,7 +20,7 @@
       <p>Whether you prefer working with code from the command line, or using
         rich graphical editors, there’s a Rust integration available for your
         editor of choice. Or you can build your own using the
-        <a href="https://github.com/rust-lang-nursery/rls">Rust Language Server</a>.
+        <a href="https://github.com/rust-lang/rls">Rust Language Server</a>.
       </div>
     </div>
     {{> components/tools/editors }}
@@ -100,7 +100,7 @@
           write, and maintain. And most importantly: never debate spacing or
           brace position ever again.
         </p>
-        <a href="https://github.com/rust-lang-nursery/rustfmt"
+        <a href="https://github.com/rust-lang/rustfmt"
              class="button button-secondary">Go to repo</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
@@ -112,7 +112,7 @@
           helps developers of all experience levels write idiomatic code, and
           enforce standards.
         </p>
-         <a href="https://github.com/rust-lang-nursery/rust-clippy"
+         <a href="https://github.com/rust-lang/rust-clippy"
              class="button button-secondary">Go to repo</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">


### PR DESCRIPTION
I forgot some more links that moved away from nursery (previous pull #743).

It feels great to do my first contributions to Rust documentation this week 🙂.