### PR TITLE
Remove fonts' lines

### DIFF
--- a/templates/components/layout.hbs
+++ b/templates/components/layout.hbs
@@ -21,16 +21,6 @@
     <meta property="og:type" content="website" />
     <meta property="og:locale" content="en_US" />
 
-    <!-- fonts -->
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/AlfaSlabOne-Regular.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-ExtraBold.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-ExtraBoldItalic.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-Italic.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-Italic.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-Regular.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-SemiBold.woff">
-    <link rel="preload" as="font" crossorigin href="/static/fonts/woff/FiraSans-SemiBoldItalic.woff">
-
     <!-- styles -->
     <link rel="stylesheet" href="/static/styles/vendor.css"/>
     <link rel="stylesheet" href="/static/styles/fonts.css"/>


### PR DESCRIPTION
closes #657 

It seems that #626 is already deployed but the issue isn't fixed. And I guess we can remove fonts because we use `fonts.css`.