### PR TITLE
Simplify contributions and code reviews

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+ports:
+- port: 7878
+  onOpen: open-preview
+tasks:
+- init: cargo build
+  command: cargo run

--- a/README.md
+++ b/README.md
@@ -12,9 +12,15 @@
 1. To build the app and run the server, run `cargo watch -x run` in your terminal.
 1. Navigate to http://localhost:7878 in your browser. If you make any updates to the styles, or any other project files, `cargo watch` will automatically restart the server for you, all you have to do is refresh your browser to see your changes.
 
+### Running the app in browser
+
+Run and edit the app in [Gitpod](https://gitpod.io), a free online dev environment.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/rust-lang/www.rust-lang.org)
+
 ### Where to edit
 
-- If you would like to edit styles, you should edit [`src/styles/app.scss`](src/styles/app.scss). 
+- If you would like to edit styles, you should edit [`src/styles/app.scss`](src/styles/app.scss).
 - If you would like to update group data, you should edit the `yml` files in [`src/data/`](src/data/).
 - If you would like to edit page content, you should edit the `hbs` files in [`templates`](templates).
 


### PR DESCRIPTION
This PR adds a small config to run the app in Gitpod a free online dev environment for GitHub. The idea is to get developers into a working setup immediately without going local.

This PR will make it so that the dev env opens up in a new tab and runs 
 - `cargo build` 
 - `cargo run`

Also the Website will be opened in the preview automatically. See image below.

Also you can enable the [GitHub app](https://github.com/marketplace/gitpod-io) on your repo (also free for open-source) which will automatically run `cargo build` on every PR as well as the master branch. So that when you open a workspace you don't need to wait for cargo downloading and building dependencies. This very useful for code reviews as well (note that you can comment on and approve PRs from within the dev environment).

Please try 
Prebuilt master branch: https://gitpod.io#snapshot/f83b01b3-50c9-4f41-8125-38741a4d13ba
This PR: https://gitpod.io#https://github.com/rust-lang/www.rust-lang.org/pull/749

<img width="1797" alt="Screenshot 2019-04-26 at 13 34 50" src="https://user-images.githubusercontent.com/372735/56805386-2c700f00-6829-11e9-99b0-a8b25e02c1ad.png">



