### PR TITLE
Remove IRC from our website because Mozilla is shutting the server down.

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -83,9 +83,6 @@
             <a href="https://discord.gg/rust-lang" class="button button-secondary">Discord</a>
           </li>
           <li>
-            <a href="https://chat.mibbit.com/?server=irc.mozilla.org&channel=%23rust" class="button button-secondary">Mozilla IRC</a>
-          </li>
-          <li>
             <a href="/governance" class="button button-secondary">Learn more about teams</a>
           </li>
         </ul>

--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -73,9 +73,7 @@
       your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we
       want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as
       long as you earn their trust.</p>
-    <p>The enforcement policies listed above apply to all official Rust venues; including official IRC channels (#rust,
-      #rust-internals, #rust-tools, #rust-libs, #rustc, #rust-beginners, #rust-docs, #rust-community, #rust-lang, and
-      #cargo); Discord channels (https://discord.gg/rust-lang); GitHub repositories under rust-lang, rust-lang-nursery,
+    <p>The enforcement policies listed above apply to all official Rust venues; including Discord channels (https://discord.gg/rust-lang); GitHub repositories under rust-lang, rust-lang-nursery,
       and rust-lang-deprecated; and all forums under
       rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of
       Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of

--- a/templates/policies/security.hbs
+++ b/templates/policies/security.hbs
@@ -41,7 +41,7 @@ can take (in order):</p>
         (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0x5D54B6F551FF5E33">public key</a>)) directly.</li>
       <li>Post on the <a href="https://internals.rust-lang.org/">internals forums</a></li>
     </ul>
-    <p>Please note that the discussion forums and #rust-internals IRC channel are
+    <p>Please note that the discussion forums are
 public areas. When escalating in these venues, please do not discuss your
 issue. Simply say that you’re trying to get a hold of someone from the security
 team.</p>


### PR DESCRIPTION
See https://blog.rust-lang.org/2019/04/26/Mozilla-IRC-Sunset-and-the-Rust-Channel.html

I'll merge this when CI passes.