### PR TITLE
Rename the package to "www-rust-lang-org"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1720,7 +1720,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "wubwub"
+name = "www-rust-lang-org"
 version = "0.1.0"
 dependencies = [
  "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "www-rust-lang-org"
 version = "0.1.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
+edition = "2018"
 
 [dependencies]
 lazy_static = "1.2.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "wubwub"
+name = "www-rust-lang-org"
 version = "0.1.0"
 authors = ["Ashley Williams <ashley666ashley@gmail.com>"]
 

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ROCKET_PORT=$PORT ROCKET_ENV=prod ./target/release/wubwub
+web: ROCKET_PORT=$PORT ROCKET_ENV=prod ./target/release/www-rust-lang-org

--- a/src/rust_version.rs
+++ b/src/rust_version.rs
@@ -24,7 +24,7 @@ fn fetch_rust_release_post() -> Result<Box<Any>, Box<Error>> {
 }
 
 pub fn rust_version() -> Option<String> {
-    match ::cache::get(fetch_rust_version) {
+    match crate::cache::get(fetch_rust_version) {
         Ok(version) => Some(version),
         Err(err) => {
             eprintln!("error while fetching the rust version: {}", err);
@@ -34,7 +34,7 @@ pub fn rust_version() -> Option<String> {
 }
 
 pub fn rust_release_post() -> Option<String> {
-    match ::cache::get(fetch_rust_release_post) {
+    match crate::cache::get(fetch_rust_release_post) {
         Ok(post) => Some(post),
         Err(err) => {
             eprintln!("error while fetching the rust release post: {}", err);

--- a/templates/components/tools/rustup.hbs
+++ b/templates/components/tools/rustup.hbs
@@ -27,7 +27,7 @@
       </div>
     </div>
     <br/>
-    <a href="https://github.com/rust-lang/wubwub/issues/new" class="button button-secondary">Report an Issue</a>
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new" class="button button-secondary">Report an Issue</a>
     <hr/>
     <div>
       <p>


### PR DESCRIPTION
WubWub no more!

Also, activate edition 2018