### PR TITLE
Add security headers

### DIFF
--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,0 +1,29 @@
+use rocket::fairing::{Fairing, Info, Kind};
+use rocket::http::Header;
+use rocket::{Request, Response};
+
+static HEADERS: &[(&str, &str)] = &[
+    ("x-xss-protection", "1; mode=block"),
+    ("strict-transport-security", "max-age=63072000"),
+    ("x-content-type-options", "nosniff"),
+    ("x-frame-options", "DENY"),
+    ("referrer-policy", "no-referrer, strict-origin-when-cross-origin"),
+    ("content-security-policy", "default-src 'none'; script-src 'self'; style-src 'self'; img-src 'self' avatars.githubusercontent.com; font-src 'self'; manifest-src 'self'; frame-src player.vimeo.com"),
+];
+
+pub(crate) struct InjectHeaders;
+
+impl Fairing for InjectHeaders {
+    fn info(&self) -> Info {
+        Info {
+            name: "HTTP headers injector",
+            kind: Kind::Response,
+        }
+    }
+
+    fn on_response(&self, _request: &Request, response: &mut Response) {
+        for (key, value) in HEADERS {
+            response.set_header(Header::new(*key, *value));
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,7 @@ extern crate serde_derive;
 
 mod cache;
 mod category;
+mod headers;
 mod production;
 mod redirect;
 mod rust_version;
@@ -284,6 +285,7 @@ fn main() {
 
     rocket::ignite()
         .attach(Template::fairing())
+        .attach(headers::InjectHeaders)
         .mount(
             "/",
             routes![

--- a/static/scripts/tools-install.js
+++ b/static/scripts/tools-install.js
@@ -1,5 +1,14 @@
-<script type="text/javascript">
-      var platform_override = null;
+var platform_override = null;
+
+function vis(elem, apply) {
+    ["db", "di", "dn"].forEach(c => {
+        if (c === apply) {
+            elem.classList.add(c);
+        } else {
+            elem.classList.remove(c);
+        }
+    });
+}
 
 function detect_platform() {
     "use strict";
@@ -34,7 +43,7 @@ function detect_platform() {
         // rust-www/#692 - FreeBSD epiphany!
         if (navigator.appVersion.indexOf("FreeBSD")!=-1) {os = "unix";}
     }
-    
+
     // Firefox Quantum likes to hide platform and appVersion but oscpu works
     if (navigator.oscpu) {
         if (navigator.oscpu.indexOf("Windows")!=-1) {os = "win";}
@@ -57,40 +66,40 @@ function adjust_for_platform() {
     var unknown_div = document.getElementById("platform-instructions-unknown");
     var default_div = document.getElementById("platform-instructions-default");
 
-    unix_div.style.display = "none";
-    win_div.style.display = "none";
-    unknown_div.style.display = "none";
-    default_div.style.display = "none";
+    vis(unix_div, "dn");
+    vis(win_div, "dn");
+    vis(unknown_div, "dn");
+    vis(default_div, "dn");
 
     if (platform == "unix") {
-        unix_div.style.display = "block";
+        vis(unix_div, "db");
     } else if (platform == "win") {
-        win_div.style.display = "block";
+        vis(win_div, "db");
     } else if (platform == "unknown") {
-        unknown_div.style.display = "block";
+        vis(unknown_div, "db");
     } else {
-        default_div.style.display = "block";
+        vis(default_div, "db");
     }
 
     var platform_specific = document.getElementsByClassName("platform-specific");
     for (var el of platform_specific) {
         var el_is_not_win = el.className.indexOf("not-win") !== -1;
         var el_is_inline = el.tagName.toLowerCase() == "span";
-        var el_visible_style = "block";
+        var el_visible_class = "db";
         if (el_is_inline) {
-            el_visible_style = "inline";
+            el_visible_class = "di";
         }
         if (platform == "win") {
             if (el_is_not_win) {
-                el.style.display = "none";
+                vis(el, "dn");
             } else {
-                el.style.display = el_visible_style;
+                vis(el, el_visible_class);
             }
         } else {
             if (el_is_not_win) {
-                el.style.display = el_visible_style;
+                vis(el, el_visible_class);
             } else {
-                el.style.display = "none";
+                vis(el, "dn");
             }
         }
     }
@@ -131,7 +140,7 @@ function set_up_cycle_button() {
 
             if (idx == key.length) {
                 if (cycle_button !== null) {
-                    cycle_button.style.display = "block";
+                    vis(cycle_button, "db");
                 }
                 unlocked = true;
                 cycle_platform();
@@ -184,5 +193,3 @@ function check_initial_override() {
     set_up_cycle_button();
     fill_in_bug_report_values();
 }());
-
-    </script>

--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -28,7 +28,7 @@
       <div class="four columns mt3 mt0-l">
         <h4>Social</h4>
         <a href="https://twitter.com/rustlang"><img src="/static/images/twitter.svg" alt="twitter logo" title="Twitter"/></a>
-        <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA"><img style="padding-top: 6px; padding-bottom:6px" src="/static/images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
+        <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA"><img class="pv2" src="/static/images/youtube.svg" alt="youtube logo" title="YouTube"/></a>
         <a href="https://discord.gg/rust-lang"><img src="/static/images/discord.svg" alt="discord logo" title="Discord"/></a>
         <a href="https://github.com/rust-lang"><img src="/static/images/github.svg" alt="github logo" title="GitHub"/></a>
       </div>

--- a/templates/components/tools/rustup.hbs
+++ b/templates/components/tools/rustup.hbs
@@ -1,9 +1,9 @@
 <div class="row">
-  <div id="platform-instructions-unix" class="instructions" style="display: block;">
+  <div id="platform-instructions-unix" class="instructions db">
     <p>It looks like you’re running macOS, Linux, or another Unix-like OS. To download Rustup and install Rust, run the following in your terminal, then follow the on-screen instructions.</p>
     <pre><code>curl https://sh.rustup.rs -sSf | sh</code></pre>
   </div>
-  <div id="platform-instructions-win" class="instructions" style="display: none;">
+  <div id="platform-instructions-win" class="instructions dn">
     <p>It looks like you’re running Windows. To install Rust, download and run</p>
     <a href="https://win.rustup.rs" class="button button-secondary">rustup‑init.exe</a>
     <p>...then follow the onscreen instructions.</p>
@@ -11,7 +11,7 @@
     <p>If you’re a Windows Subsystem for Linux user run the following in your terminal, then follow the on-screen instructions to install Rust.</p>
     <pre><code>curl https://sh.rustup.rs -sSf | sh</code></pre>
   </div>
-  <div id="platform-instructions-unknown" class="instructions" style="display: none;">
+  <div id="platform-instructions-unknown" class="instructions dn">
     <!-- unrecognized platform: ask for help -->
     <p>
       Rust runs on Windows, Linux, macOS, FreeBSD and NetBSD. If
@@ -45,7 +45,7 @@
       </p>
     </div>
   </div>
-  <div id="platform-instructions-default" class="instructions" style="display: none;">
+  <div id="platform-instructions-default" class="instructions dn">
     <div>
       <p>
         To install Rust, if you are running a Unix such as WSL, Linux or macOS,<br>
@@ -64,3 +64,5 @@
     </div>
   </div>
 </div>
+
+<script type="text/javascript" src="/static/scripts/tools-install.js"></script>

--- a/templates/components/what/embedded/get-started.hbs
+++ b/templates/components/what/embedded/get-started.hbs
@@ -40,7 +40,7 @@
       </div>
     </div>
     <hr>
-    <div style="text-align: center;">
+    <div class="tc">
       <p>
         <a href="https://docs.rust-embedded.org/" class="button button-secondary">
           More Documentation

--- a/templates/components/what/wasm/production.hbs
+++ b/templates/components/what/wasm/production.hbs
@@ -38,7 +38,7 @@
                     </p>
                 </div>
                 <div class="four columns">
-                    <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/" style="display: block;">
+                    <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/" class="db">
                         <img src="/static/images/firefox.png" alt="firefox" />
                     </a>
                 </div>

--- a/templates/policies/media-guide.hbs
+++ b/templates/policies/media-guide.hbs
@@ -40,8 +40,8 @@
     <ul>
       <li>Rust</li>
       <li>Cargo</li>
-      <li><img src="https://www.rust-lang.org/logos/rust-logo-blk.svg" alt="rust logo"></li>
-      <li><img src="https://www.rust-lang.org/logos/cargo.png" alt="cargo logo"></li>
+      <li><img src="/logos/rust-logo-blk.svg" alt="rust logo"></li>
+      <li><img src="/logos/cargo.png" alt="cargo logo"></li>
     </ul>
     <p>Trademarks are names and designs that tell the world the source of a good or service. Protecting trademarks for an open source project is particularly important. Anyone can change the source code and produce a product from that code, so it’s important that only the original product, or variations that have been approved by the project, use the project’s trademarks. By limiting use of the Rust Trademarks, Mozilla and the Rust project can help users and developers know they’re getting the product produced by the Rust project and not someone else’s modified version. The trademark assures users and developers of the quality and safety of the product they’re using.</p>
   </div>

--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -56,10 +56,10 @@
       <h3>Configuring the <code>PATH</code> environment variable</h3>
       <p>
         In the Rust development environment, all tools are installed to the
-        <span class="platform-specific not-win" style="display: inline;">
+        <span class="platform-specific not-win di">
           <code>~/.cargo/bin</code>
         </span>
-        <span class="platform-specific win" style="display: none;">
+        <span class="platform-specific win dn">
           <code>%USERPROFILE%\.cargo\bin</code>
         </span> directory,
         and this is where you will find the Rust toolchain, including
@@ -81,7 +81,7 @@
         console fails, this is the most likely reason.
       </p>
     </div>
-    <div class="platform-specific win" style="display: none;">
+    <div class="platform-specific win dn">
       <h3>Windows considerations</h3>
       <p>
         On Windows, Rust additionally requires the C++ build tools
@@ -116,7 +116,6 @@
     <a href="https://forge.rust-lang.org/other-installation-methods.html" class="button button-secondary">Learn more</a>
   </div>
 </section>
-{{> components/tools/install-script }}
 
 {{/inline}}
 {{~> (parent)~}}


### PR DESCRIPTION
This PR adds all the security headers needed to reach an A+ grade on the [Mozilla Observatory](https://observatory.mozilla.org), including a Content Security Policy. As part of adding the CSP I visited all the pages locally to make sure nothing legit is blocked -- I hope I didn't miss any of the pages.

Fixes https://github.com/rust-lang/www.rust-lang.org/issues/739
r? @skade 