### PR TITLE
Update conferences to link to the 2019 events post

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -115,8 +115,8 @@
               class="button button-secondary">View Calendar</a>
           </li>
           <li>
-            <a href="https://blog.rust-lang.org/2018/01/31/The-2018-Rust-Event-Lineup.html"
-              class="button button-secondary">Check out the 2018 Conference Lineup</a>
+            <a href="https://blog.rust-lang.org/2019/05/20/The-2019-Rust-Event-Lineup.html"
+              class="button button-secondary">Check out the 2019 Conference Lineup</a>
           </li>
         </ul>
       </div>


### PR DESCRIPTION
I'll probably merge this when CI goes green :)