### PR TITLE
Change font-display to swap

### DIFF
--- a/src/styles/fonts.scss
+++ b/src/styles/fonts.scss
@@ -95,7 +95,7 @@ $format-names: (
           src: local($font),
                local($filename),
                urls($filename, $range, $formats);
-          font-display: block;
+          font-display: swap;
         }
       }
     }


### PR DESCRIPTION
Changing the [`font-display`](https://css-tricks.com/almanac/properties/f/font-display/#article-header-id-0) property to `swap` instead of `block` improves the time until text is rendered.

Helps (or even closes) #784