### PR TITLE
Place tools/index.hbs text into .ftl file

### DIFF
--- a/templates/fluent-resource/en-US/tools.ftl
+++ b/templates/fluent-resource/en-US/tools.ftl
@@ -1,4 +1,52 @@
-tools-write-ide-prose = Whether you prefer working with code from the command line, or using
-        rich graphical editors, there’s a Rust integration available for your
-        editor of choice. Or you can build your own using the
+# index.hbs
+tools-editor-support-heading = First-class editor support
+tools-write-ide-description = Whether you prefer working with code from the
+        command line, or using rich graphical editors, there’s a Rust
+        integration available for your editor of choice. Or you can build your
+        own using the
         { $rls-link }
+
+tools-build-heading = Bring calmness to your builds
+tools-build-description = Cargo is the build tool for Rust. It bundles all
+        common actions into a single command. No boilerplate required.
+
+tools-build-install-heading = Install
+tools-build-install-description = With tens of thousands of packages, there’s a
+        good chance <a href="https://crates.io">crates.io</a> has the solution
+        you’re looking for. Stand on the shoulders of giants, and move your team
+        from repetition to innovation.
+
+tools-build-test-heading = Test
+tools-build-test-description = Bring confidence to your code through Rust’s
+        excellent testing tools. <code class="nowrap">cargo test</code> is
+        Rust’s unified solution to testing. Write tests next to your code, or in
+        separate files: it provides a solution for all testing needs.
+
+tools-build-deploy-heading = Deploy
+tools-build-deploy-description = <code class="nowrap">cargo build</code> creates
+        lean binaries for every platform. With a single command your code can
+        target Windows, Linux, OSX, and the web. All part of a modern interface,
+        with no need for bespoke build files.
+
+tools-automation-heading = Velocity through automation
+tools-automation-description = Rust’s industry-grade tools make collaboration
+        fearless, allowing teams to focus on the tasks that matter.
+
+tools-automation-rustfmt-heading = Rustfmt
+tools-automation-rustfmt-description = Rustfmt automatically formats Rust code,
+        making it easier to read, write, and maintain. And most importantly:
+        never debate spacing or brace position ever again.
+tools-automation-rustfmt-link = Go to repo
+
+tools-automation-clippy-heading = Clippy
+tools-automation-clippy-description = <i>“It looks like you’re writing an
+        Iterator.”</i> <br> Clippy helps developers of all experience levels
+        write idiomatic code, and enforce standards.
+tools-automation-clippy-link = Go to repo
+
+tools-automation-cargo-doc-heading = Cargo Doc
+tools-automation-cargo-doc-description = Cargo’s doc builder makes it so no API
+        ever goes undocumented. It’s available locally through
+        <code class="nowrap">cargo doc</code>, and online for public crates
+        through <a href="https://docs.rs">docs.rs</a>.
+tools-automation-cargo-doc-link = Go to site

--- a/templates/fluent-resource/en-US/tools.ftl
+++ b/templates/fluent-resource/en-US/tools.ftl
@@ -1,6 +1,6 @@
 # tools/index.hbs
 tools-editor-support-heading = First-class editor support
-tools-write-ide-description = Whether you prefer working with code from the
+tools-editor-support-description = Whether you prefer working with code from the
         command line, or using rich graphical editors, there’s a Rust
         integration available for your editor of choice. Or you can build your
         own using the

--- a/templates/fluent-resource/en-US/tools.ftl
+++ b/templates/fluent-resource/en-US/tools.ftl
@@ -1,4 +1,4 @@
-# index.hbs
+# tools/index.hbs
 tools-editor-support-heading = First-class editor support
 tools-write-ide-description = Whether you prefer working with code from the
         command line, or using rich graphical editors, there’s a Rust

--- a/templates/fluent-resource/xx-AU/tools.ftl
+++ b/templates/fluent-resource/xx-AU/tools.ftl
@@ -1,4 +1,4 @@
-tools-write-ide-description = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ noʎ ɹO
-        ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ 'sɹoʇᴉpǝ
-        lɐɔᴉɥdɐɹƃ ɥɔᴉɹ ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ ƃuᴉʞɹoʍ ɹǝɟǝɹd
-        noʎ ɹǝɥʇǝɥM
+tools-editor-support-description = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ
+        noʎ ɹO ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ
+        'sɹoʇᴉpǝ lɐɔᴉɥdɐɹƃ ɥɔᴉɹ ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ
+        ƃuᴉʞɹoʍ ɹǝɟǝɹd noʎ ɹǝɥʇǝɥM

--- a/templates/fluent-resource/xx-AU/tools.ftl
+++ b/templates/fluent-resource/xx-AU/tools.ftl
@@ -1,3 +1,4 @@
-tools-write-ide-prose = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ noʎ ɹO ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ        
-        ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ 'sɹoʇᴉpǝ lɐɔᴉɥdɐɹƃ ɥɔᴉɹ        
-        ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ ƃuᴉʞɹoʍ ɹǝɟǝɹd noʎ ɹǝɥʇǝɥM
+tools-write-ide-description = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ noʎ ɹO
+        ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ 'sɹoʇᴉpǝ
+        lɐɔᴉɥdɐɹƃ ɥɔᴉɹ ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ ƃuᴉʞɹoʍ ɹǝɟǝɹd
+        noʎ ɹǝɥʇǝɥM

--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -18,7 +18,7 @@
     <div class="tools-row">
       <div id="tools-write-ide-prose">
       <p>
-      {{#text tools-write-ide-description}}
+      {{#text tools-editor-support-description}}
         {{#textparam rls-link}}
           <a href="https://github.com/rust-lang/rls">{{text rust-language-server}}</a>
         {{/textparam}}

--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -2,7 +2,7 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Tools</h1>
+    <h1>{{text nav-tools}}</h1>
   </div>
 </header>
 
@@ -10,7 +10,7 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        First-class editor support
+        {{text tools-editor-support-heading}}
       </h2>
       <div class="highlight highlight-yellow"></div>
     </header>
@@ -18,7 +18,7 @@
     <div class="tools-row">
       <div id="tools-write-ide-prose">
       <p>
-      {{#text tools-write-ide-prose}}
+      {{#text tools-write-ide-description}}
         {{#textparam rls-link}}
           <a href="https://github.com/rust-lang/rls">{{text rust-language-server}}</a>
         {{/textparam}}
@@ -33,46 +33,36 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        Bring calmness to your builds
+        {{text tools-build-heading}}
       </h2>
       <div class="highlight highlight-red"></div>
     </header>
     <p>
-      Cargo is the build tool for Rust. It bundles all common actions into a
-      single command. No boilerplate required.
+      {{text tools-build-description}}
     </p>
     <div class="flex-none flex-l flex-row">
       <div class="mt2 w-100" id="packages">
         <h3 class="code-header">
-          Install
+          {{text tools-build-install-heading}}
         </h3>
         <p>
-          With tens of thousands of packages, there’s a good chance
-          <a href="https://crates.io">crates.io</a> has the solution you’re
-          looking for. Stand on the shoulders of giants, and move your team from
-          repetition to innovation.
+          {{text tools-build-install-description}}
         </p>
       </div>
       <div class="mt2 w-100 ml5-l" id="linting">
         <h3 class="code-header">
-          Test
+          {{text tools-build-test-heading}}
         </h3>
         <p>
-          Bring confidence to your code through Rust’s excellent testing tools.
-          <code class="nowrap">cargo test</code> is Rust’s unified solution to testing. Write
-          tests next to your code, or in separate files: it provides a solution
-          for all testing needs.
+          {{text tools-build-test-description}}
         </p>
       </div>
       <div class="mt2 w-100 ml5-l" id="deployment">
         <h3 class="code-header">
-          Deploy
+          {{text tools-build-deploy-heading}}
         </h3>
         <p>
-          <code class="nowrap">cargo build</code> creates lean binaries for every platform.
-          With a single command your code can target Windows, Linux, OSX, and
-          the web. All part of a modern interface, with no need for bespoke
-          build files.
+          {{text tools-build-deploy-description}}
         </p>
       </div>
     </div>
@@ -83,51 +73,44 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        Velocity through automation
+        {{text tools-automation-heading}}
       </h2>
       <div class="highlight highlight-red"></div>
     </header>
     <br>
     <p>
-      Rust’s industry-grade tools make collaboration fearless, allowing teams to
-      focus on the tasks that matter.
+      {{text tools-automation-description}}
     </p>
     <div class="flex-none flex-l flex-row">
       <div class="mt5 mt2-l flex flex-column w-100">
         <h3 class="code-header">
-          Rustfmt
+          {{text tools-automation-rustfmt-heading}}
         </h3>
         <p class="flex-grow-1">
-          Rustfmt automatically formats Rust code, making it easier to read,
-          write, and maintain. And most importantly: never debate spacing or
-          brace position ever again.
+          {{text tools-automation-rustfmt-description}}
         </p>
         <a href="https://github.com/rust-lang/rustfmt"
-             class="button button-secondary">Go to repo</a>
+             class="button button-secondary">{{text tools-automation-rustfmt-link}}</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
         <h3 class="code-header">
-          Clippy
+          {{text tools-automation-clippy-heading}}
         </h3>
         <p class="flex-grow-1">
-          <i>“It looks like you’re writing an Iterator.”</i> <br> Clippy
-          helps developers of all experience levels write idiomatic code, and
-          enforce standards.
+          {{text tools-automation-clippy-description}}
         </p>
          <a href="https://github.com/rust-lang/rust-clippy"
-             class="button button-secondary">Go to repo</a>
+             class="button button-secondary">{{text tools-automation-clippy-link}}</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
         <h3 class="code-header">
-          Cargo Doc
+          {{text tools-automation-cargo-doc-heading}}
         </h3>
         <p class="flex-grow-1">
-          Cargo’s doc builder makes it so no API ever goes undocumented. It’s
-          available locally through <code class="nowrap">cargo doc</code>, and online for
-          public crates through <a href="https://docs.rs">docs.rs</a>.
+          {{text tools-automation-cargo-doc-description}}
         </p>
         <a href="https://docs.rs/"
-             class="button button-secondary">Go to site</a>
+             class="button button-secondary">{{text tools-automation-cargo-doc-link}}</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Part of #798 .

I used `nav-tools` for the page title since that text is already defined in [`common.ftl`](https://github.com/rust-lang/www.rust-lang.org/blob/i18n/templates/fluent-resource/en-US/common.ftl).

Lines in `tools.ftl` have been wrapped at 80 characters.

My naming scheme for localization variable names has been:
* `...-header` for headers/titles (ex: `tools-editor-support-heading`)
* `...-description` for body text
* `...-link` for link/button text