### PR TITLE
 Place tools/install.hbs text into .ftl file

### DIFF
--- a/templates/fluent-resource/en-US/tools.ftl
+++ b/templates/fluent-resource/en-US/tools.ftl
@@ -1,4 +1,52 @@
-tools-write-ide-prose = Whether you prefer working with code from the command line, or using
-        rich graphical editors, there’s a Rust integration available for your
-        editor of choice. Or you can build your own using the
+# tools/index.hbs
+tools-editor-support-heading = First-class editor support
+tools-editor-support-description = Whether you prefer working with code from the
+        command line, or using rich graphical editors, there’s a Rust
+        integration available for your editor of choice. Or you can build your
+        own using the
         { $rls-link }
+
+tools-build-heading = Bring calmness to your builds
+tools-build-description = Cargo is the build tool for Rust. It bundles all
+        common actions into a single command. No boilerplate required.
+
+tools-build-install-heading = Install
+tools-build-install-description = With tens of thousands of packages, there’s a
+        good chance <a href="https://crates.io">crates.io</a> has the solution
+        you’re looking for. Stand on the shoulders of giants, and move your team
+        from repetition to innovation.
+
+tools-build-test-heading = Test
+tools-build-test-description = Bring confidence to your code through Rust’s
+        excellent testing tools. <code class="nowrap">cargo test</code> is
+        Rust’s unified solution to testing. Write tests next to your code, or in
+        separate files: it provides a solution for all testing needs.
+
+tools-build-deploy-heading = Deploy
+tools-build-deploy-description = <code class="nowrap">cargo build</code> creates
+        lean binaries for every platform. With a single command your code can
+        target Windows, Linux, OSX, and the web. All part of a modern interface,
+        with no need for bespoke build files.
+
+tools-automation-heading = Velocity through automation
+tools-automation-description = Rust’s industry-grade tools make collaboration
+        fearless, allowing teams to focus on the tasks that matter.
+
+tools-automation-rustfmt-heading = Rustfmt
+tools-automation-rustfmt-description = Rustfmt automatically formats Rust code,
+        making it easier to read, write, and maintain. And most importantly:
+        never debate spacing or brace position ever again.
+tools-automation-rustfmt-link = Go to repo
+
+tools-automation-clippy-heading = Clippy
+tools-automation-clippy-description = <i>“It looks like you’re writing an
+        Iterator.”</i> <br> Clippy helps developers of all experience levels
+        write idiomatic code, and enforce standards.
+tools-automation-clippy-link = Go to repo
+
+tools-automation-cargo-doc-heading = Cargo Doc
+tools-automation-cargo-doc-description = Cargo’s doc builder makes it so no API
+        ever goes undocumented. It’s available locally through
+        <code class="nowrap">cargo doc</code>, and online for public crates
+        through <a href="https://docs.rs">docs.rs</a>.
+tools-automation-cargo-doc-link = Go to site

--- a/templates/fluent-resource/en-US/tools.ftl
+++ b/templates/fluent-resource/en-US/tools.ftl
@@ -50,3 +50,97 @@ tools-automation-cargo-doc-description = Cargo’s doc builder makes it so no AP
         <code class="nowrap">cargo doc</code>, and online for public crates
         through <a href="https://docs.rs">docs.rs</a>.
 tools-automation-cargo-doc-link = Go to site
+
+
+# tools/install.hbs
+install-page-heading = Install Rust
+
+install-using-rustup-heading = Using rustup (Recommended)
+
+install-notes-heading = Notes about Rust installation
+
+install-notes-getting-started-heading = Getting started
+install-notes-getting-started-description = If you're just getting started with
+        Rust and would like a more detailed walk-through, see our
+        <a href="{{baseurl}}/learn/get-started">getting started</a> page.
+
+install-notes-rustup-heading = Toolchain management with <code>rustup</code>
+install-notes-rustup-description = 
+        <p>
+          Rust is installed and managed by the
+          <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>
+          tool. Rust has a 6-week
+          <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
+            rapid release process
+          </a> and supports a
+          <a href="https://forge.rust-lang.org/platform-support.html">great
+          number of platforms</a>, so there are many builds of Rust available at
+          any time. <code>rustup</code> manages these builds in a consistent way
+          on every platform that Rust supports, enabling installation of Rust
+          from the beta and nightly release channels as well as support for
+          additional cross-compilation targets.
+        </p>
+        <p>
+          If you've installed <code>rustup</code> in the past, you can update
+          your installation by running <code>rustup update</code>.
+        </p>
+        <p>
+          For more information see the
+          <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+          <code>rustup</code> documentation</a>.
+        </p>
+
+install-notes-path-heading = Configuring the <code>PATH</code> environment
+        variable
+install-notes-path-description = 
+        <p>
+          In the Rust development environment, all tools are installed to the
+          <span class="platform-specific not-win di">
+            <code>~/.cargo/bin</code>
+          </span>
+          <span class="platform-specific win dn">
+            <code>%USERPROFILE%\.cargo\bin</code>
+          </span> directory, and this is where you will find the Rust toolchain,
+          including <code>rustc</code>, <code>cargo</code>, and <code>rustup</code>.
+        </p>
+        <p>
+          Accordingly, it is customary for Rust developers to include this
+          directory in their
+          <a href="https://en.wikipedia.org/wiki/PATH_(variable)">
+          <code>PATH</code> environment variable</a>. During installation
+          <code>rustup</code> will attempt to configure the <code>PATH</code>.
+          Because of differences between platforms, command shells, and bugs in
+          <code>rustup</code>, the modifications to <code>PATH</code> may not
+          take effect until the console is restarted, or the user is logged out,
+          or it may not succeed at all.
+        </p>
+        <p>
+          If, after installation, running <code>rustc --version</code> in the
+          console fails, this is the most likely reason.
+        </p>
+
+install-notes-windows-heading = Windows considerations
+install-notes-windows-description =
+        <p>
+          On Windows, Rust additionally requires the C++ build tools
+          for Visual Studio 2013 or later. The easiest way to acquire the build
+          tools is by installing
+          <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019">
+            Microsoft Visual C++ Build Tools 2019
+          </a>
+          which provides just the Visual C++ build tools. Alternately, you
+          can <a href="https://www.visualstudio.com/downloads/">install</a>
+          Visual Studio 2019, Visual Studio 2017, Visual Studio 2015, or Visual
+          Studio 2013 and during install select the “C++ tools.”
+        </p>
+        <p>
+          For further information about configuring Rust on Windows see the
+          <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+          Windows-specific <code>rustup</code> documentation</a>.
+        </p>
+
+install-other-methods-heading = Other installation methods
+install-other-methods-description = The installation described above, via
+        <code>rustup</code>, is the preferred way to install Rust for most
+        developers. However, Rust can be installed via other methods as well.
+install-other-methods-link = Learn more

--- a/templates/fluent-resource/xx-AU/tools.ftl
+++ b/templates/fluent-resource/xx-AU/tools.ftl
@@ -1,3 +1,4 @@
-tools-write-ide-prose = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ noʎ ɹO ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ        
-        ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ 'sɹoʇᴉpǝ lɐɔᴉɥdɐɹƃ ɥɔᴉɹ        
-        ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ ƃuᴉʞɹoʍ ɹǝɟǝɹd noʎ ɹǝɥʇǝɥM
+tools-editor-support-description = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ
+        noʎ ɹO ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ
+        'sɹoʇᴉpǝ lɐɔᴉɥdɐɹƃ ɥɔᴉɹ ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ
+        ƃuᴉʞɹoʍ ɹǝɟǝɹd noʎ ɹǝɥʇǝɥM

--- a/templates/tools/index.hbs
+++ b/templates/tools/index.hbs
@@ -2,7 +2,7 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Tools</h1>
+    <h1>{{text nav-tools}}</h1>
   </div>
 </header>
 
@@ -10,7 +10,7 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        First-class editor support
+        {{text tools-editor-support-heading}}
       </h2>
       <div class="highlight highlight-yellow"></div>
     </header>
@@ -18,7 +18,7 @@
     <div class="tools-row">
       <div id="tools-write-ide-prose">
       <p>
-      {{#text tools-write-ide-prose}}
+      {{#text tools-editor-support-description}}
         {{#textparam rls-link}}
           <a href="https://github.com/rust-lang/rls">{{text rust-language-server}}</a>
         {{/textparam}}
@@ -33,46 +33,36 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        Bring calmness to your builds
+        {{text tools-build-heading}}
       </h2>
       <div class="highlight highlight-red"></div>
     </header>
     <p>
-      Cargo is the build tool for Rust. It bundles all common actions into a
-      single command. No boilerplate required.
+      {{text tools-build-description}}
     </p>
     <div class="flex-none flex-l flex-row">
       <div class="mt2 w-100" id="packages">
         <h3 class="code-header">
-          Install
+          {{text tools-build-install-heading}}
         </h3>
         <p>
-          With tens of thousands of packages, there’s a good chance
-          <a href="https://crates.io">crates.io</a> has the solution you’re
-          looking for. Stand on the shoulders of giants, and move your team from
-          repetition to innovation.
+          {{text tools-build-install-description}}
         </p>
       </div>
       <div class="mt2 w-100 ml5-l" id="linting">
         <h3 class="code-header">
-          Test
+          {{text tools-build-test-heading}}
         </h3>
         <p>
-          Bring confidence to your code through Rust’s excellent testing tools.
-          <code class="nowrap">cargo test</code> is Rust’s unified solution to testing. Write
-          tests next to your code, or in separate files: it provides a solution
-          for all testing needs.
+          {{text tools-build-test-description}}
         </p>
       </div>
       <div class="mt2 w-100 ml5-l" id="deployment">
         <h3 class="code-header">
-          Deploy
+          {{text tools-build-deploy-heading}}
         </h3>
         <p>
-          <code class="nowrap">cargo build</code> creates lean binaries for every platform.
-          With a single command your code can target Windows, Linux, OSX, and
-          the web. All part of a modern interface, with no need for bespoke
-          build files.
+          {{text tools-build-deploy-description}}
         </p>
       </div>
     </div>
@@ -83,51 +73,44 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        Velocity through automation
+        {{text tools-automation-heading}}
       </h2>
       <div class="highlight highlight-red"></div>
     </header>
     <br>
     <p>
-      Rust’s industry-grade tools make collaboration fearless, allowing teams to
-      focus on the tasks that matter.
+      {{text tools-automation-description}}
     </p>
     <div class="flex-none flex-l flex-row">
       <div class="mt5 mt2-l flex flex-column w-100">
         <h3 class="code-header">
-          Rustfmt
+          {{text tools-automation-rustfmt-heading}}
         </h3>
         <p class="flex-grow-1">
-          Rustfmt automatically formats Rust code, making it easier to read,
-          write, and maintain. And most importantly: never debate spacing or
-          brace position ever again.
+          {{text tools-automation-rustfmt-description}}
         </p>
         <a href="https://github.com/rust-lang/rustfmt"
-             class="button button-secondary">Go to repo</a>
+             class="button button-secondary">{{text tools-automation-rustfmt-link}}</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
         <h3 class="code-header">
-          Clippy
+          {{text tools-automation-clippy-heading}}
         </h3>
         <p class="flex-grow-1">
-          <i>“It looks like you’re writing an Iterator.”</i> <br> Clippy
-          helps developers of all experience levels write idiomatic code, and
-          enforce standards.
+          {{text tools-automation-clippy-description}}
         </p>
          <a href="https://github.com/rust-lang/rust-clippy"
-             class="button button-secondary">Go to repo</a>
+             class="button button-secondary">{{text tools-automation-clippy-link}}</a>
       </div>
       <div class="mt5 mt2-l flex flex-column w-100 ml5-l">
         <h3 class="code-header">
-          Cargo Doc
+          {{text tools-automation-cargo-doc-heading}}
         </h3>
         <p class="flex-grow-1">
-          Cargo’s doc builder makes it so no API ever goes undocumented. It’s
-          available locally through <code class="nowrap">cargo doc</code>, and online for
-          public crates through <a href="https://docs.rs">docs.rs</a>.
+          {{text tools-automation-cargo-doc-description}}
         </p>
         <a href="https://docs.rs/"
-             class="button button-secondary">Go to site</a>
+             class="button button-secondary">{{text tools-automation-cargo-doc-link}}</a>
       </div>
     </div>
   </div>

--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -2,14 +2,14 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Install Rust</h1>
+    <h1>{{text install-page-heading}}</h1>
   </div>
 </header>
 
 <section id="rustup" class="green">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Using rustup (Recommended)</h2>
+      <h2>{{text install-using-rustup-heading}}</h2>
       <div class="highlight"></div>
     </header>
     {{> components/tools/rustup }}
@@ -19,86 +19,24 @@
 <section id="installation-notes" class="white">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Notes about Rust installation</h2>
+      <h2>{{text install-notes-heading}}</h2>
       <div class="highlight"></div>
     </header>
     <div>
-      <h3>Getting started</h3>
+      <h3>{{text install-notes-getting-started-heading}}</h3>
       <p>
-        If you're just getting started with Rust and would like a more detailed walk-through, see our <a href="{{baseurl}}/learn/get-started">getting started</a> page.
+        {{text install-notes-getting-started-description}}
       </p>
 
-      <h3>Toolchain management with <code>rustup</code></h3>
-      <p>
-        Rust is installed and managed by the
-        <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>
-        tool. Rust has a 6-week
-        <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
-          rapid release process
-        </a> and supports a
-        <a href="https://forge.rust-lang.org/platform-support.html">great number of platforms</a>,
-        so there are many builds of Rust available at any time.
-        <code>rustup</code> manages these builds in a consistent way on every
-        platform that Rust supports, enabling installation of Rust from the beta
-        and nightly release channels as well as support for additional
-        cross-compilation targets.
-      </p>
-      <p>
-        If you've installed <code>rustup</code> in the past, you can update
-        your installation by running <code>rustup update</code>.
-      </p>
-      <p>
-        For more information see the
-        <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md"><code>rustup</code>
-        documentation</a>.
-      </p>
+      <h3>{{text install-notes-rustup-heading}}</h3>
+      {{text install-notes-rustup-description}}
 
-      <h3>Configuring the <code>PATH</code> environment variable</h3>
-      <p>
-        In the Rust development environment, all tools are installed to the
-        <span class="platform-specific not-win di">
-          <code>~/.cargo/bin</code>
-        </span>
-        <span class="platform-specific win dn">
-          <code>%USERPROFILE%\.cargo\bin</code>
-        </span> directory,
-        and this is where you will find the Rust toolchain, including
-        <code>rustc</code>, <code>cargo</code>, and <code>rustup</code>.
-      </p>
-      <p>
-        Accordingly, it is customary for Rust developers to include this
-        directory in their
-        <a href="https://en.wikipedia.org/wiki/PATH_(variable)"><code>PATH</code>
-        environment variable</a>.  During installation <code>rustup</code>
-        will attempt to configure the
-        <code>PATH</code>. Because of differences between platforms,
-        command shells, and bugs in <code>rustup</code>, the modifications
-        to <code>PATH</code> may not take effect until the console is
-        restarted, or the user is logged out, or it may not succeed at all.
-      </p>
-      <p>
-        If, after installation, running <code>rustc --version</code> in the
-        console fails, this is the most likely reason.
-      </p>
+      <h3>{{text install-notes-path-heading}}</h3>
+      {{text install-notes-path-description}}
     </div>
     <div class="platform-specific win dn">
-      <h3>Windows considerations</h3>
-      <p>
-        On Windows, Rust additionally requires the C++ build tools
-        for Visual Studio 2013 or later. The easiest way to acquire the build
-        tools is by installing
-        <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019">
-          Microsoft Visual C++ Build Tools 2019
-        </a>
-        which provides just the Visual C++ build tools. Alternately, you
-        can <a href="https://www.visualstudio.com/downloads/">install</a>
-        Visual Studio 2019, Visual Studio 2017, Visual Studio 2015, or Visual Studio 2013 and during install select
-        the “C++ tools.”
-      </p>
-      <p>
-        For further information about configuring Rust on Windows see the
-        <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows-specific <code>rustup</code> documentation</a>.
-      </p>
+      <h3>{{text install-notes-windows-heading}}</h3>
+      {{text install-notes-windows-description}}
     </div>
   </div>
 </section>
@@ -106,14 +44,15 @@
 <section id="other-methods" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Other installation methods</h2>
+      <h2>{{text install-other-methods-heading}}</h2>
       <div class="highlight"></div>
     </header>
     <p>
-      The installation described above, via <code>rustup</code>, is the preferred way to install Rust
-      for most developers. However, Rust can be installed via other methods as well.
+      {{text install-other-methods-description}}
     </p>
-    <a href="https://forge.rust-lang.org/other-installation-methods.html" class="button button-secondary">Learn more</a>
+    <a href="https://forge.rust-lang.org/other-installation-methods.html" class="button button-secondary">
+      {{text install-other-methods-link}}
+    </a>
   </div>
 </section>
 


### PR DESCRIPTION
Addresses #798 

Factors out English text from [`tools/install.hbs`](https://github.com/rust-lang/www.rust-lang.org/blob/i18n/templates/tools/install.hbs) into translation file [`tools.ftl`](https://github.com/rust-lang/www.rust-lang.org/blob/i18n/templates/fluent-resource/en-US/tools.ftl).

We chose to copy-paste entire `<p></p>` tags directly into the translation file when multiple of them appear next to one another (for example: `install-notes-rustup-description`).