### PR TITLE
Move CLI page text into translation file

### DIFF
--- a/templates/components/what/cli/example.hbs
+++ b/templates/components/what/cli/example.hbs
@@ -1,28 +1,26 @@
 <section id="cli-use-it" class="red">
     <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
         <header>
-            <h2>Get started!</h2>
+            <h2>{{text cli-example-heading}}</h2>
             <div class="highlight"></div>
         </header>
 
         <div>
-            <p>Writing a command-line app is a great way to learn Rust.
-            </p>
+            <p>{{text cli-example-description}}</p>
         </div>
 
         <div class="row">
             <article class="six columns box">
-                <h3>Define your inputs</h3>
+                <h3>{{text cli-example-inputs-heading}}</h3>
                 <pre><code>{{> components/what/cli/code-inputs }}</code></pre>
             </article>
 
             <article class="six columns box">
-                <h3>Write your tool</h3>
+                <h3>{{text cli-example-main-heading}}</h3>
                 <pre><code>{{> components/what/cli/code-main }}</code></pre>
             </article>
         </div>
 
-        <a href="https://rust-lang-nursery.github.io/cli-wg/" class="button button-secondary">Learn more with the CLI
-            book</a>
+        <a href="https://rust-lang-nursery.github.io/cli-wg/" class="button button-secondary">{{text cli-example-link}}</a>
     </div>
 </section>

--- a/templates/components/what/cli/maintainable.hbs
+++ b/templates/components/what/cli/maintainable.hbs
@@ -1,43 +1,35 @@
 <section id="cli-pitch" class="green">
     <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
         <header>
-            <h2>A maintainable code base</h2>
+            <h2>{{text cli-maintainable-heading}}</h2>
             <div class="highlight highlight-yellow"></div>
         </header>
         <div class="flex flex-column flex-row-l">
             <article class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
                 <header class="domain-icon">
-                    <img src="/static/images/cli-app-structure-2.svg" alt="cli app structure" class="mw3 mw4-ns" />
-                    <h3 class="tc-l">Catch errors <em>now</em></h3>
+                    <img src="/static/images/cli-app-structure-2.svg" alt="{{text cli-maintainable-errors-img-alt}}" class="mw3 mw4-ns" />
+                    <h3 class="tc-l">{{text cli-maintainable-errors-heading}}</h3>
                 </header>
                 <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
                     <p class="flex-grow-1">
-                        What if the config file is missing or corrupt? What if the
-                        content of that one environment variable is empty? These
-                        cases are easy to forget about! But thanks to its approach
-                        to error handling and its library design, Rust will point
-                        out these “what if” situations before you even run your
-                        program.
+                        {{text cli-maintainable-errors-description}}
                     </p>
                     <a href="https://doc.rust-lang.org/book/ch09-00-error-handling.html" class="button button-secondary">
-                        Rust’s error handling
+                        {{text cli-maintainable-errors-link}}
                     </a>
                 </div>
             </article>
             <article class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
                 <header class="domain-icon">
-                    <img src="/static/images/cli-is-no-rocket-science.svg" alt="cli is no rocket science" class="mw3 mw4-ns" />
-                    <h3 class="tc-l">Easily extend later</h3>
+                    <img src="/static/images/cli-is-no-rocket-science.svg" alt="{{text cli-maintainable-refactoring-img-alt}}" class="mw3 mw4-ns" />
+                    <h3 class="tc-l">{{text cli-maintainable-refactoring-heading}}</h3>
                 </header>
                 <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
                     <p class="box-content">
-                        Rust allows you to be flexible in the way you organize your
-                        code. Start with just a single file and, when you need more
-                        features, refactor your application with the confidence that
-                        you aren’t breaking anything.
+                        {{text cli-maintainable-refactoring-description}}
                     </p>
                     <a href="https://doc.rust-lang.org/book/ch12-03-improving-error-handling-and-modularity.html" class="button button-secondary">
-                        Refactoring Rust
+                        {{text cli-maintainable-refactoring-link}}
                     </a>
                 </div>
             </article>

--- a/templates/components/what/cli/pitch.hbs
+++ b/templates/components/what/cli/pitch.hbs
@@ -2,7 +2,7 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        Why Rust?
+        {{text cli-pitch-heading}}
       </h2>
       <div class="highlight"></div>
     </header>
@@ -10,57 +10,54 @@
     <div class="flex flex-column flex-row-l">
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
         <div class="v-top tc-l">
-          <img src="/static/images/cli-rustc-approved.svg" alt="Shield with a checkmark" class="mw3 mw4-ns"/>
+          <img src="/static/images/cli-rustc-approved.svg" alt="{{text cli-pitch-solid-img-alt}}" class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Solid and quick
+            {{text cli-pitch-solid-heading}}
           </h3>
           <p class="flex-grow-1">
-            Even if you’re just writing a short one-off script, you can be
-            confident it’s fast, easily testable, and gives helpful output.
+            {{text cli-pitch-solid-description}}
           </p>
           <a href="{{baseurl}}/learn" class="button button-secondary">
-            Rust’s guarantees
+            {{text cli-pitch-solid-link}}
           </a>
         </div>
       </div>
 
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
         <div class="v-top tc-l">
-          <img src="/static/images/cli-packaging.svg" alt="box with a checkmark"
+          <img src="/static/images/cli-packaging.svg" alt="{{text cli-pitch-ship-img-alt}}"
                class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Easy distribution
+            {{text cli-pitch-ship-heading}}
           </h3>
           <p class="flex-grow-1">
-            Compile everything down to a single binary&mdash;no need for your
-            users to have a runtime or libraries installed.
+            {{text cli-pitch-ship-description}}
           </p>
           <a href="https://rust-lang-nursery.github.io/cli-wg/tutorial/packaging.html" class="button button-secondary">
-            How to ship Rust code
+            {{text cli-pitch-ship-link}}
           </a>
         </div>
       </div>
 
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
         <div class="v-top tc-l">
-          <img src="/static/images/cli-configs.svg" alt="A note and a gear"
+          <img src="/static/images/cli-configs.svg" alt="{{text cli-pitch-config-img-alt}}"
                class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Robust configuration
+            {{text cli-pitch-config-heading}}
           </h3>
 
           <p class="flex-grow-1">
-            Handle configuration files across platforms with ease.  Rust will
-            deal with namespaces and formats for you.
+            {{text cli-pitch-config-description}}
           </p>
           <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/config-files.html" class="button button-secondary">
-              Start configuring
+              {{text cli-pitch-config-link}}
           </a>
         </div>
       </div>
@@ -68,38 +65,36 @@
     <div class="flex-none flex-l flex-row mt5-l">
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
         <div class="v-top tc-l">
-          <img src="/static/images/cli-man.svg" alt="Help manual"
+          <img src="/static/images/cli-man.svg" alt="{{text cli-pitch-manuals-img-alt}}"
                class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Manuals? done.
+            {{text cli-pitch-manuals-heading}}
           </h3>
           <p class="flex-grow-1">
-            Generate manual pages for your app automatically.  Just package the
-            generated files and you’re done.
+            {{text cli-pitch-manuals-description}}
           </p>
           <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/docs.html" class="button button-secondary">
-            Learn how
+            {{text cli-pitch-manuals-link}}
           </a>
         </div>
       </div>
 
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
         <div class="v-top tc-l">
-          <img src="/static/images/cli-pipe.svg" alt="Pipes"
+          <img src="/static/images/cli-pipe.svg" alt="{{text cli-pitch-machines-img-alt}}"
                class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Data in, data out
+            {{text cli-pitch-machines-heading}}
           </h3>
           <p class="flex-grow-1">
-            In addition to talking to humans, Rust has great tools to help you
-            talk to machines.
+            {{text cli-pitch-machines-description}}
           </p>
           <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/machine-communication.html" class="button button-secondary">
-            Communicate with machines
+            {{text cli-pitch-machines-link}}
           </a>
         </div>
       </div>
@@ -107,20 +102,19 @@
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l">
         <div class="v-top tc-l">
           <img src="/static/images/cli-logging.svg"
-               alt="3 wood logs stacked on top of each other"
+               alt="{{text cli-pitch-logging-img-alt}}"
                class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Flexible logging
+            {{text cli-pitch-logging-heading}}
           </h3>
 
           <p class="flex-grow-1">
-            It’s easy to add logging, and even easier to configure it to
-            different targets and with different styles.
+            {{text cli-pitch-logging-description}}
           </p>
           <a href="https://rust-lang-nursery.github.io/cli-wg/in-depth/human-communication.html" class="button button-secondary">
-            Log, trace, comprehend
+            {{text cli-pitch-logging-link}}
           </a>
         </div>
       </div>

--- a/templates/components/what/cli/production.hbs
+++ b/templates/components/what/cli/production.hbs
@@ -1,22 +1,22 @@
 <section id="production" class="white">
     <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
         <header>
-            <h2>Production use</h2>
+            <h2>{{text cli-production-heading}}</h2>
             <div class="highlight"></div>
         </header>
         <div class="testimonials">
             <div class="testimonial row">
                 <div class="four columns">
-                  <img src="/static/images/sentry-logo-black.svg" alt="sentry logo"/>
+                  <img src="/static/images/sentry-logo-black.svg" alt="{{text cli-production-sentry-img-alt}}"/>
                 </div>
                 <div class="eight columns">
                     <blockquote>
-                        One of the reasons we liked Rust was the crates.io ecosystem. [...] There is a lot of really good already existing infrastructure for building very nice command-line interfaces.
+                        {{text cli-production-sentry-quote}}
                     </blockquote>
                     <p class="attribution">
-                        &ndash; Armin Ronacher,
+                        {{text cli-production-sentry-attribution}}
                         <a href="https://www.youtube.com/watch?v=2Xu6EdEBa5E">
-                            Rust at Sentry &ndash; PolyConf 2017
+                            {{text cli-production-sentry-link}}
                         </a>
                     </p>
                 </div>
@@ -24,17 +24,17 @@
             <div class="testimonial row">
                 <div class="eight columns">
                     <blockquote>
-                        I have zero regrets with living in this code base. […] This was sort of an added bonus for me: Using Rust to make CLI or console based tools. It is very good at compiling for different target systems.
+                        {{text cli-production-habitat-quote}}
                     </blockquote>
                     <p class="attribution">
-                        &ndash; Fletcher Nichol,
+                        {{text cli-production-habitat-attribution}}
                         <a href="https://www.youtube.com/watch?v=zAXbPnfTJg4">
-                            Taking Rust to Production &ndash; RustFest Kyiv
+                            {{text cli-production-habitat-link}}
                         </a>
                     </p>
                 </div>
                 <div class="four columns">
-                  <img src="/static/images/habitat.svg" alt="Habitat logo"/>
+                  <img src="/static/images/habitat.svg" alt="{{text cli-production-habitat-img-alt}}"/>
                 </div>
             </div>
         </div>

--- a/templates/fluent-resource/en-US/cli.ftl
+++ b/templates/fluent-resource/en-US/cli.ftl
@@ -1,0 +1,101 @@
+### Translation file for page: https://www.rust-lang.org/what/cli
+
+
+## templates/what/cli.hbs
+
+cli-page-heading = Command-line apps
+
+
+## templates/components/what/cli/pitch.hbs
+
+cli-pitch-heading = Why Rust?
+
+cli-pitch-solid-img-alt = Shield with a checkmark
+cli-pitch-solid-heading = Solid and quick
+cli-pitch-solid-description = Even if you’re just writing a short one-off
+        script, you can be confident it’s fast, easily testable, and gives
+        helpful output.
+cli-pitch-solid-link = Rust’s guarantees
+
+cli-pitch-ship-img-alt = box with a checkmark
+cli-pitch-ship-heading = Easy distribution
+cli-pitch-ship-description = Compile everything down to a single binary&mdash;no
+        need for your users to have a runtime or libraries installed.
+cli-pitch-ship-link = How to ship Rust code
+
+cli-pitch-config-img-alt = A note and a gear
+cli-pitch-config-heading = Robust configuration
+cli-pitch-config-description = Handle configuration files across platforms with
+        ease.  Rust will deal with namespaces and formats for you.
+cli-pitch-config-link = Start configuring
+
+cli-pitch-manuals-img-alt = Help manual
+cli-pitch-manuals-heading = Manuals? done.
+cli-pitch-manuals-description = Generate manual pages for your app
+        automatically.  Just package the generated files and you’re done.
+cli-pitch-manuals-link = Learn how
+
+cli-pitch-machines-img-alt = Pipes
+cli-pitch-machines-heading = Data in, data out
+cli-pitch-machines-description = In addition to talking to humans, Rust has
+        great tools to help you talk to machines.
+cli-pitch-machines-link = Communicate with machines
+
+cli-pitch-logging-img-alt = 3 wood logs stacked on top of each other
+cli-pitch-logging-heading = Flexible logging
+cli-pitch-logging-description = It’s easy to add logging, and even easier to
+        configure it to different targets and with different styles.
+cli-pitch-logging-link = Log, trace, comprehend
+
+
+## templates/components/what/cli/maintainable.hbs
+
+cli-maintainable-heading = A maintainable code base
+
+cli-maintainable-errors-img-alt = cli app structure
+cli-maintainable-errors-heading = Catch errors <em>now</em>
+cli-maintainable-errors-description = 
+        What if the config file is missing or corrupt? What if the content of
+        that one environment variable is empty? These cases are easy to forget
+        about! But thanks to its approach to error handling and its library
+        design, Rust will point out these “what if” situations before you even
+        run your program.
+cli-maintainable-errors-link = Rust’s error handling
+
+cli-maintainable-refactoring-img-alt = cli is no rocket science
+cli-maintainable-refactoring-heading = Easily extend later
+cli-maintainable-refactoring-description = 
+        Rust allows you to be flexible in the way you organize your code. Start
+        with just a single file and, when you need more features, refactor your
+        application with the confidence that you aren’t breaking anything.
+cli-maintainable-refactoring-link = Refactoring Rust
+
+
+## templates/components/what/cli/example.hbs
+
+cli-example-heading = Get started!
+cli-example-description = Writing a command-line app is a great way to learn Rust.
+cli-example-inputs-heading = Define your inputs
+cli-example-main-heading = Write your tool
+cli-example-link = Learn more with the CLI book
+
+
+## templates/components/what/cli/production.hbs
+
+cli-production-heading = Production use
+
+cli-production-sentry-img-alt = sentry logo
+cli-production-sentry-quote =
+        One of the reasons we liked Rust was the crates.io ecosystem. [...]
+        There is a lot of really good already existing infrastructure for
+        building very nice command-line interfaces.
+cli-production-sentry-attribution = &ndash; Armin Ronacher,
+cli-production-sentry-link = Rust at Sentry &ndash; PolyConf 2017
+
+cli-production-habitat-quote =
+        I have zero regrets with living in this code base. […] This was sort of
+        an added bonus for me: Using Rust to make CLI or console based tools. It
+        is very good at compiling for different target systems.
+cli-production-habitat-attribution = &ndash; Fletcher Nichol,
+cli-production-habitat-link = Taking Rust to Production &ndash; RustFest Kyiv
+cli-production-habitat-img-alt = Habitat logo

--- a/templates/what/cli.hbs
+++ b/templates/what/cli.hbs
@@ -2,7 +2,7 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Command-line apps</h1>
+    <h1>{{text cli-page-heading}}</h1>
   </div>
 </header>
 


### PR DESCRIPTION
Work on internationalization re: #798 

Extracts all user-facing text (including img alt text) from the CLI page into a Fluent translation file.