### PR TITLE
Style code without skeletons on network page

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -45,6 +45,23 @@ code {
   overflow: auto;
 }
 
+code {
+  padding: .2rem .5rem;
+  margin: 0 .2rem;
+  font-size: 90%;
+  white-space: nowrap;
+  background: #F1F1F1;
+  border: 1px solid #E1E1E1;
+  border-radius: 4px;
+  overflow: auto;
+}
+
+pre > code {
+  display: block;
+  padding: 1rem 1.5rem;
+  white-space: pre;
+}
+
 @mixin code-space-full-width {
   padding: 1rem 1.5rem;
   margin: 0 .2rem;


### PR DESCRIPTION
When removing skeletons, the code styling got lost. I just ported the rules over.