### PR TITLE
Move Text from Policy Pages into Translation Files

### DIFF
--- a/locales/en-US/code-of-conduct.ftl
+++ b/locales/en-US/code-of-conduct.ftl
@@ -16,8 +16,8 @@ coc-conduct-description =
           <li>Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the { $coc-rust-moderation-team-anchor } immediately. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.</li>
           <li>Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.</li>
         </ul>
-coc-rust-moderation-team-anchor-text = Rust moderation team
-coc-conduct-link = Email The Moderation Team
+coc-conduct-description-team-anchor-text = Rust moderation team
+coc-conduct-email-button = Email The Moderation Team
 
 coc-moderation-heading = Moderation
 coc-moderation-description =
@@ -36,3 +36,5 @@ coc-moderation-description =
         <p>And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could’ve communicated better — remember that it’s your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.</p>
         <p>The enforcement policies listed above apply to all official Rust venues; including Discord channels (https://discord.gg/rust-lang); GitHub repositories under rust-lang, rust-lang-nursery, and rust-lang-deprecated; and all forums under rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your own moderation policy so as to avoid confusion.</p>
         <p><i>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling">Node.js Policy on Trolling</a> as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/">Contributor Covenant v1.3.0</a>.</i></p>
+
+coc-moderation-description-team-anchor-text = Rust moderation team

--- a/locales/en-US/code-of-conduct.ftl
+++ b/locales/en-US/code-of-conduct.ftl
@@ -1,0 +1,38 @@
+### Translation file for page: https://www.rust-lang.org/policies/code-of-conduct
+
+## templates/policies/code-of-conduct.hbs
+
+coc-page-heading = Code of conduct
+
+coc-conduct-heading = Conduct
+coc-conduct-description =
+        <ul>
+          <li>We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of experience, gender identity and expression, sexual orientation, disability, personal appearance, body size, race, ethnicity, age, religion, nationality, or other similar characteristic.</li>
+          <li>Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and welcoming environment for all.</li>
+          <li>Please be kind and courteous. There’s no need to be mean or rude.</li>
+          <li>Respect that people have differences of opinion and that every design or implementation choice carries a trade-off and numerous costs. There is seldom a right answer.</li>
+          <li>Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a fork and see how it works.</li>
+          <li>We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We interpret the term “harassment” as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized groups.</li>
+          <li>Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the { $coc-rust-moderation-team-anchor } immediately. Whether you’re a regular contributor or a newcomer, we care about making this community a safe place for you and we’ve got your back.</li>
+          <li>Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.</li>
+        </ul>
+coc-rust-moderation-team-anchor-text = Rust moderation team
+coc-conduct-link = Email The Moderation Team
+
+coc-moderation-heading = Moderation
+coc-moderation-description =
+        <p>These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs moderation, please contact the { $coc-rust-moderation-team-anchor }.</p>
+        <ol>
+          <li>Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful manner.)</li>
+          <li>Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not allowed.</li>
+          <li>Moderators will first respond to such remarks with a warning.</li>
+          <li>If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool off.</li>
+          <li>If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.</li>
+          <li>Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the offended party a genuine apology.</li>
+          <li>If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with a different moderator, <strong>in private</strong>. Complaints about bans in-channel are not allowed.</li>
+          <li>Moderators are held to a higher standard than other community members. If a moderator creates an inappropriate situation, they should expect less leeway than others.</li>
+        </ol>
+        <p>In the Rust community we strive to go the extra step to look out for each other. Don’t just aim to be technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive issues, particularly if they’re off-topic; this all too often leads to unnecessary fights, hurt feelings, and damaged trust; worse, it can drive people away from the community entirely.</p>
+        <p>And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances are good there was something you could’ve communicated better — remember that it’s your responsibility to make your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as long as you earn their trust.</p>
+        <p>The enforcement policies listed above apply to all official Rust venues; including Discord channels (https://discord.gg/rust-lang); GitHub repositories under rust-lang, rust-lang-nursery, and rust-lang-deprecated; and all forums under rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your own moderation policy so as to avoid confusion.</p>
+        <p><i>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling">Node.js Policy on Trolling</a> as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/">Contributor Covenant v1.3.0</a>.</i></p>

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -1,6 +1,8 @@
-# Translations that appear on most/all pages
+## Translations that appear on most/all pages
 
-# components/nav.hbs
+rust = Rust
+
+## components/nav.hbs
 
 nav-install = Install
 nav-learn = Learn
@@ -13,7 +15,8 @@ choose-language = Language
 
 nav-logo-alt = Rust Logo
 
-# components/footer.hbs
+## components/footer.hbs
+
 footer-doc = Documentation
 footer-ask = Ask a Question on the Users Forum
 footer-status = Check Website Status

--- a/locales/en-US/core.ftl
+++ b/locales/en-US/core.ftl
@@ -1,2 +1,34 @@
 rust = Rust
 rust-language-server = Rust Language Server
+
+-security-at-rust-lang-org-anchor =
+        <a href="mailto:security@rust-lang.org">security@rust-lang.org</a>
+-rust-security-team-key-href =
+        /static/keys/rust-security-team-key.gpg.ascii
+-rust-pgp-key-mit-keyserver-href =
+        https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC"
+-wikipedia-rfpolicy-href =
+        https://en.wikipedia.org/wiki/RFPolicy
+
+## Security coordinator email addreses and links to their public keys
+-security-coordinator-email-anchor =
+        <a href="mailto:steve@steveklabnik.com">Steve Klabnik</a>
+-security-coordinator-public-key-href =
+        https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xDAE717EFE9424541
+-backup-security-contact-email-anchor =
+        <a href="mailto:alex@alexcrichton.com">Alex Crichton</a>
+-backup-security-contact-public-key-href =
+        https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0x5D54B6F551FF5E33
+
+-internals-rust-lang-org-href =
+        https://internals.rust-lang.org/
+
+## Security mailing list links
+-rustlang-security-announcements-google-groups-forum-href =
+        https://groups.google.com/forum/#!forum/rustlang-security-announcements
+-rust-security-announcements-mailing-list-href =
+        https://groups.google.com/group/rustlang-security-announcements/subscribe
+-rustlang-security-announcements-subscribe-anchor =
+        <a href="mailto:rustlang-security-announcements+subscribe@googlegroups.com">rustlang-security-announcements+subscribe@googlegroups.com</a>
+-distros-openwall-email-anchor =
+        <a href="https://oss-security.openwall.org/wiki/mailing-lists/distros">distros@openwall</a>

--- a/locales/en-US/core.ftl
+++ b/locales/en-US/core.ftl
@@ -1,6 +1,3 @@
-rust = Rust
-rust-language-server = Rust Language Server
-
 -security-at-rust-lang-org-anchor =
         <a href="mailto:security@rust-lang.org">security@rust-lang.org</a>
 -rust-security-team-key-href =

--- a/locales/en-US/licenses.ftl
+++ b/locales/en-US/licenses.ftl
@@ -1,0 +1,20 @@
+### Translation file for page: https://www.rust-lang.org/policies/licenses
+
+## templates/policies/licenses.hbs
+
+licenses-page-heading = Licenses
+
+licenses-license-heading = License
+licenses-license-general-description =
+        The Rust Programming Language and all other official projects, including this website, are generally dual-licensed:
+licenses-apache-v-2-0-link = Apache License, Version 2.0
+licenses-mit-link = MIT license
+licenses-license-specific-description =
+        <p>Specific licensing info for each project can be found in its GitHub Repository.</p>
+        <p>Third-party logos may be subject to third-party copyrights and trademarks, and are not available under the same license as the rest of the Rust website.</p>
+        <p>If you have a specific question or concern about how the Rust project or any of its associated projects are licensed, please contact the Rust Core Team.</p>
+licenses-license-email-link = Email The Core Team
+
+licenses-attribution-heading = Attribution
+licenses-attribution-description =
+        Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a>, licensed by <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0">CC-3.0-BY</a>

--- a/locales/en-US/media-guide.ftl
+++ b/locales/en-US/media-guide.ftl
@@ -1,0 +1,80 @@
+### Translation file for page: https://www.rust-lang.org/policies/media-guide
+### templates/policies/media-guide.hbs
+
+## Page title
+media-guide-page-heading = Media guide
+
+## Art license
+media-guide-art-license-heading = Art license
+media-guide-art-license-description = 
+        <p>The Rust and Cargo logos (bitmap and vector) are owned by Mozilla and distributed under the terms of the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution license (CC-BY)</a>. This is the most permissive Creative Commons license, and allows reuse and modifications for any purpose. The restrictions are that distributors must “give appropriate credit, provide a link to the license, and indicate if changes were made.” <strong>Note that use of these logos, and the Rust and Cargo names, is also governed by trademark; our trademark policy is described below</strong>.</p>
+
+## Trademark policy
+media-guide-trademark-policy-heading = Trademark policy
+media-guide-trademark-policy-description = 
+        <p>The Rust and Cargo names and brands make it possible to say what is officially part of the Rust community, and what isn’t. So we’re careful about where we allow them to appear. But at the same time, we want to allow for as much creative use of these brands as we can. The policy laid out here explains how we strike a balance. If you want to use these names or brands, especially in a commercial way, please read this page or feel free to <a href="mailto:trademark@rust-lang.org">reach out</a> and ask us about it!</p>
+        <p><b>TL;DR</b>: Most non-commercial uses of the Rust/Cargo names and logos are allowed and do not require permission; most commercial uses require permission. In either case, the most important rule is that uses of the trademarks cannot appear official or imply any endorsement by the Rust project.</p>
+        <p>If you have any doubts about whether your intended use of a Rust Trademark requires permission, please contact us at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</p>
+        <p>This document was derived in part from the <a href="https://www.python.org/psf/trademarks/">Python Software Foundation Trademark Usage Policy</a>. This document is not an official statement of Mozilla trademark policy, but serves to clarify Mozilla’s trademark policy as it relates to Rust.</p>
+
+## The Rust trademarks
+media-guide-rust-trademarks-heading = The Rust trademarks
+media-guide-rust-trademarks-description = 
+        <p>The Rust programming language is an open source, community project governed by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”), which owns and protects the Rust and Cargo trademarks and logos (the “Rust Trademarks”). This document provides information about use of the Rust Trademarks specific to a programming language, as well as examples of common ways people might want to use these trademarks, with explanations as to whether those uses are OK or not or require permission. This document supplements the <a href="https://www.mozilla.org/foundation/trademarks/policy/">official Mozilla trademark policy</a> which governs use of all Mozilla trademarks.</p>
+        <p>The Rust Trademarks include two word marks and two logos:</p>
+        <ul>
+          <li>Rust</li>
+          <li>Cargo</li>
+          <li><img src="/logos/rust-logo-blk.svg" alt="{ media-guide-rust-trademarks-rust-img-alt }"></li>
+          <li><img src="/logos/cargo.png" alt="{ media-guide-rust-trademarks-cargo-img-alt }"></li>
+        </ul>
+        <p>Trademarks are names and designs that tell the world the source of a good or service. Protecting trademarks for an open source project is particularly important. Anyone can change the source code and produce a product from that code, so it’s important that only the original product, or variations that have been approved by the project, use the project’s trademarks. By limiting use of the Rust Trademarks, Mozilla and the Rust project can help users and developers know they’re getting the product produced by the Rust project and not someone else’s modified version. The trademark assures users and developers of the quality and safety of the product they’re using.</p>
+media-guide-rust-trademarks-rust-img-alt = rust logo
+media-guide-rust-trademarks-cargo-img-alt = cargo logo
+
+
+## Using the trademarks
+media-guide-tm-use-heading = Using the trademarks
+
+media-guide-tm-use-appearance-heading = Appearing official, affiliated, or endorsed
+media-guide-tm-use-appearance-description = 
+        <p>The most basic rule is that the Rust trademarks cannot be used in ways that appear (to a casual observer) official, affiliated, or endorsed by the Rust project or Mozilla, unless you have written permission from the Rust core team. This is the fundamental way we protect users and developers from confusion.</p>
+        <p>Since this rule is about managing perception, it is subjective and somewhat difficult to nail down concretely. There are some obvious ways to avoid problems, like including the word “unofficial” in a very prominent way, but if you have any doubts, we would be more than happy to help; just send an e-mail to <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</p>
+
+media-guide-tm-use-basics-heading = The basics: referring to Rust/Cargo
+media-guide-tm-use-basics-description =
+        <p>As with any trademark, the Rust and Cargo word marks can be used with minimal restriction to refer to the Rust programming language and the Cargo package manager and registry.</p>
+        <p>They may not be used:</p>
+        <ul>
+          <li>to refer to any other programming language;</li>
+          <li>in a way that is misleading or may imply association of unrelated modules, tools, documentation, or other resources with the Rust programming language;</li>
+          <li>in ways that confuse the community as to whether the Rust programming language is open source and free to use.</li>
+        </ul>
+
+media-guide-tm-use-implicit-approval-heading = Uses that do not require explicit approval
+media-guide-tm-use-implicit-approval-description =
+        <p>There are a variety of uses that do not require explicit approval. <strong>However, in all of the cases outlined below, you must ensure that use of the Rust trademarks does not appear official, as explained above.</strong></p>
+        <ul>
+          <li>Stating accurately that software is written in the Rust programming language, that it is compatible with the Rust programming language, or that it contains the Rust programming language, is allowed. In those cases, you may use the Rust trademarks to indicate this, without prior approval. This is true both for non-commercial and commercial uses.</li>
+          <li>Using the Rust trademarks in the names of non-commercial products like RustPostgres or Rustymine, or in the name of code repositories in e.g. GitHub, is allowed when referring to use with or suitability for the Rust programming language. Such uses may also include the Rust logo, even in modified form. For commercial products (including crowdfunded or sponsored ones), please check in at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a> to ensure your use does not appear official.</li>
+          <li>Using the Rust trademarks on t-shirts, hats, and other artwork or merchandise, even in modified form, is allowed for your personal use or for use by a small group of community members, as long as they are not sold. If you want to distribute merchandise with Rust Trademarks at a Rust affiliated event, please contact us for permission at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</li>
+          <li>Using the Rust trademarks (even in modified form) for social events like meetups, tutorials, and the like is allowed for events that are free to attend. For commercial events (including sponsored ones), please check in at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>. However, the words “RustCamp,” “RustCon” or “RustConf” cannot be used without explicit permission. And, as with all of the above uses, the <strong>event cannot appear to be officially endorsed or run by the Rust project</strong> without written permission.</li>
+          <li>Using the Rust trademarks in books or publications like “Rust Journal” or “Rust Cookbook” is allowed.</li>
+          <li>Using of the word “Rust” on websites, brochures, documentation, academic papers, books, and product packaging to refer to the Rust programming language or the Rust project is allowed.</li>
+        </ul>
+
+media-guide-tm-use-explicit-approval-heading = Uses that require explicit approval
+media-guide-tm-use-explicit-approval-description =
+        <ul>
+          <li>Distributing a modified version of the Rust programming language or the Cargo package manager and calling it Rust or Cargo requires explicit, written permission from the Rust core team. We will usually allow these uses as long as the modifications are (1) relatively small and (2) very clearly communicated to end-users.</li>
+          <li>Selling t-shirts, hats, and other artwork or merchandise requires explicit, written permission from the Rust core team. We will usually allow these uses as long as (1) it is clearly communicated that the merchandise is not in any way an official part of the Rust project and (2) it is clearly communicated whether profits benefit the Rust project.</li>
+          <li>Using the Rust trademarks within another trademark requires written permission from the Rust core team except as described above.</li>
+        </ul>
+
+## Helping out
+media-guide-helping-out-heading = Helping out
+media-guide-helping-out-description =
+        <p>As a member of the Rust community, please keep an eye out for questionable uses of the Rust logo and “Rust” word mark. You can report potential misuse to <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>. We will evaluate each case and take appropriate action.</p>
+        <p>Please do not approach users of the trademarks with a complaint. That should be left to Mozilla and its representatives. Thanks!</p>
+        <p>If you have a specific question or concern about promoting Rust or using its trademarks, please contact the Rust Core Team.</p>
+media-guide-helping-out-link = Email The Core Team

--- a/locales/en-US/policies.ftl
+++ b/locales/en-US/policies.ftl
@@ -1,0 +1,15 @@
+### Translation file for page: https://www.rust-lang.org/policies/
+
+## templates/policies/index.hbs
+
+policies-page-heading = Policies
+
+policies-page-description = This page links to the comprehensive set of Rust’s policies.
+
+policies-code-of-conduct-link = Code of Conduct
+policies-licenses-link = Licenses
+policies-media-guide-link = Logo Policy and Media Guide
+policies-security-link = Security Disclosures
+
+policies-reach-out-description = Didn’t find what you were looking for? Have a question? Please reach out!
+policies-reach-out-link = Message the Core Team

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -1,0 +1,38 @@
+### Translation file for page: https://www.rust-lang.org/policies/security
+### templates/policies/security.hbs
+
+security-page-heading = Security policy
+
+security-reporting-heading = Reporting
+security-reporting-link = email security@rust-lang.org
+# Anchor text for 
+security-reporting-description =
+        <p>Safety is one of the core principles of Rust, and to that end, we would like to ensure that Rust has a secure implementation. Thank you for taking the time to responsibly disclose any issues you find.</p>
+        <p>All security bugs in the Rust distribution should be reported by email to { -security-at-rust-lang-org-anchor }. This list is delivered to a small security team. Your email will be acknowledged within 24 hours, and you’ll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report. If you would like, you can encrypt your report using <a href="{ -rust-security-team-key-href }">our public key</a>. This key is also <a href="{ -rust-pgp-key-mit-keyserver-href }">On MIT’s keyserver</a> and <a href="#key">reproduced below</a>.</p>
+        <p>This email address receives a large amount of spam, so be sure to use a descriptive subject line to avoid having your report be missed. After the initial reply to your report, the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement. As recommended by <a href="{ -wikipedia-rfpolicy-href }">RFPolicy</a>, these updates will be sent at least every five days. In reality, this is more likely to be every 24-48 hours.</p>
+        <p>If you have not received a reply to your email within 48 hours, or have not heard from the security team for the past five days, there are a few steps you can take (in order):</p>
+        <ul>
+          <li>Contact the current security coordinator ({ -security-coordinator-email-anchor } (<a href="{ -security-coordinator-public-key-href }">public key</a>)) directly.</li>
+          <li>Contact the back-up contact ({ -backup-security-contact-email-anchor } (<a href="{ -backup-security-contact-public-key-href }">public key</a>)) directly.</li>
+          <li>Post on the <a href="{ -internals-rust-lang-org-href }">internals forums</a></li>
+        </ul>
+        <p>Please note that the discussion forums are public areas. When escalating in these venues, please do not discuss your issue. Simply say that you’re trying to get a hold of someone from the security team.</p>
+
+security-disclosure-heading = Disclosure policy
+security-disclosure-description =
+        <p>The Rust project has a 5 step disclosure process.</p>
+        <ol>
+          <li>The security report is received and is assigned a primary handler. This person will coordinate the fix and release process.</li>
+          <li>The problem is confirmed and a list of all affected versions is determined.</li>
+          <li>Code is audited to find any potential similar problems.</li>
+          <li>Fixes are prepared for all releases which are still under maintenance. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
+          <li>On the embargo date, the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and new builds are deployed to rust-lang.org.  Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
+        </ol>
+        <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
+
+security-receiving-heading = Receiving security updates
+security-receiving-description =
+        <p>The best way to receive all the security announcements is to subscribe to the <a href="{ -rust-security-announcements-mailing-list-href }">Rust security announcements mailing list</a> (alternatively by sending an email to { -rustlang-security-announcements-subscribe-anchor }). The mailing list is very low traffic, and it receives the public notifications the moment the embargo is lifted.</p>
+        <p>We will announce vulnerabilities 72 hours before the embargo is lifted to { -distros-openwall-email-anchor }, so that Linux distributions can update their packages.</p>
+
+security-pgp-key-heading = Plaintext PGP key

--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -3,8 +3,7 @@ tools-editor-support-heading = First-class editor support
 tools-editor-support-description = Whether you prefer working with code from the
         command line, or using rich graphical editors, there’s a Rust
         integration available for your editor of choice. Or you can build your
-        own using the
-        { $rls-link }
+        own using the <a href="https://github.com/rust-lang/rls">Rust Language Server,/a>
 
 tools-build-heading = Bring calmness to your builds
 tools-build-description = Cargo is the build tool for Rust. It bundles all

--- a/locales/xx-AU/common.ftl
+++ b/locales/xx-AU/common.ftl
@@ -1,5 +1,7 @@
 # Translations that appear on most/all pages
 
+rust = ʇsnɹ
+
 # components/nav.hbs
 nav-install = llɐʇsuI
 nav-learn = uɹɐǝ˥

--- a/locales/xx-AU/core.ftl
+++ b/locales/xx-AU/core.ftl
@@ -1,2 +1,0 @@
-rust = ʇsnɹ
-rust-language-server = ɹǝʌɹǝS ǝƃɐnƃuɐ˥ ʇsnɹ

--- a/locales/xx-AU/tools.ftl
+++ b/locales/xx-AU/tools.ftl
@@ -1,4 +1,4 @@
-tools-editor-support-description = { $rls-link } ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ
+tools-editor-support-description = <a href="https://github.com/rust-lang/rls">ɹǝʌɹǝS ǝƃɐnƃuɐ˥ ʇsnɹ</a> ǝɥʇ ƃuᴉsn uʍo ɹnoʎ plᴉnq uɐɔ
         noʎ ɹO ˙ǝɔᴉoɥɔ ɟo ɹoʇᴉpǝ ɹnoʎ ɹoɟ ǝlqɐlᴉɐʌɐ uoᴉʇɐɹƃǝʇuᴉ ʇsnɹ ɐ s’ǝɹǝɥʇ
         'sɹoʇᴉpǝ lɐɔᴉɥdɐɹƃ ɥɔᴉɹ ƃuᴉsn ɹo 'ǝuᴉl puɐɯɯoɔ ǝɥʇ ɯoɹɟ ǝpoɔ ɥʇᴉʍ
         ƃuᴉʞɹoʍ ɹǝɟǝɹd noʎ ɹǝɥʇǝɥM

--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -2,85 +2,36 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Code of conduct</h1>
+    <h1>{{text coc-page-heading}}</h1>
   </div>
 </header>
 
 <section id="code-of-conduct" class="red">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Conduct</h2>
+      <h2>{{text coc-conduct-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <ul>
-      <li>We are committed to providing a friendly, safe and welcoming environment for all, regardless of level of
-        experience, gender identity and expression, sexual orientation, disability, personal appearance, body size,
-        race, ethnicity, age, religion, nationality, or other similar characteristic.</li>
-      <li>Please avoid using overtly sexual aliases or other nicknames that might detract from a friendly, safe and
-        welcoming environment for all.</li>
-      <li>Please be kind and courteous. There’s no need to be mean or rude.</li>
-      <li>Respect that people have differences of opinion and that every design or implementation choice carries a
-        trade-off and numerous costs. There is seldom a right answer.</li>
-      <li>Please keep unstructured critique to a minimum. If you have solid ideas you want to experiment with, make a
-        fork and see how it works.</li>
-      <li>We will exclude you from interaction if you insult, demean or harass anyone. That is not welcome behavior. We
-        interpret the term “harassment” as including the definition in the <a href="http://citizencodeofconduct.org/">Citizen
-          Code of Conduct</a>; if you have any lack of clarity about what might be included in that concept, please
-        read their definition. In particular, we don’t tolerate behavior that excludes people in socially marginalized
-        groups.</li>
-      <li>Private harassment is also unacceptable. No matter who you are, if you feel you have been or are being
-        harassed or made uncomfortable by a community member, please contact one of the channel ops or any of the <a
-          href="{{baseurl}}/governance/teams/moderation">Rust moderation team</a> immediately. Whether you’re a regular contributor
-        or a newcomer, we care about making this community a safe place for you and we’ve got your back.</li>
-      <li>Likewise any spamming, trolling, flaming, baiting or other attention-stealing behavior is not welcome.</li>
-    </ul>
-    <p><a class="button button-secondary" href="mailto:rust-mods@rust-lang.org">Email The Moderation Team</a></p>
+    {{#text coc-conduct-description}}
+      {{#textparam coc-rust-moderation-team-anchor}}
+        <a href="{{baseurl}}/governance/teams/moderation">{{text coc-rust-moderation-team-link}}</a>
+      {{/textparam}}
+    {{/text}}
+    <p><a class="button button-secondary" href="mailto:rust-mods@rust-lang.org">{{text coc-conduct-link}}</a></p>
   </div>
 </section>
 
 <section id="moderation" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Moderation</h2>
+      <h2>{{text coc-moderation-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>These are the policies for upholding our community’s standards of conduct. If you feel that a thread needs
-      moderation, please contact the <a href="{{baseurl}}/governance/teams/moderation">Rust moderation team</a>.</p>
-    <ol>
-      <li>Remarks that violate the Rust standards of conduct, including hateful, hurtful, oppressive, or exclusionary
-        remarks, are not allowed. (Cursing is allowed, but never targeting another user, and never in a hateful
-        manner.)</li>
-      <li>Remarks that moderators find inappropriate, whether listed in the code of conduct or not, are also not
-        allowed.</li>
-      <li>Moderators will first respond to such remarks with a warning.</li>
-      <li>If the warning is unheeded, the user will be “kicked,” i.e., kicked out of the communication channel to cool
-        off.</li>
-      <li>If the user comes back and continues to make trouble, they will be banned, i.e., indefinitely excluded.</li>
-      <li>Moderators may choose at their discretion to un-ban the user if it was a first offense and they offer the
-        offended party a genuine apology.</li>
-      <li>If a moderator bans someone and you think it was unjustified, please take it up with that moderator, or with
-        a different moderator, <strong>in private</strong>. Complaints about bans in-channel are not allowed.</li>
-      <li>Moderators are held to a higher standard than other community members. If a moderator creates an
-        inappropriate situation, they should expect less leeway than others.</li>
-    </ol>
-    <p>In the Rust community we strive to go the extra step to look out for each other. Don’t just aim to be
-      technically unimpeachable, try to be your best self. In particular, avoid flirting with offensive or sensitive
-      issues, particularly if they’re off-topic; this all too often leads to unnecessary fights, hurt feelings, and
-      damaged trust; worse, it can drive people away from the community entirely.</p>
-    <p>And if someone takes issue with something you said or did, resist the urge to be defensive. Just stop doing what
-      it was they complained about and apologize. Even if you feel you were misinterpreted or unfairly accused, chances
-      are good there was something you could’ve communicated better — remember that it’s your responsibility to make
-      your fellow Rustaceans comfortable. Everyone wants to get along and we are all here first and foremost because we
-      want to talk about cool technology. You will find that people will be eager to assume good intent and forgive as
-      long as you earn their trust.</p>
-    <p>The enforcement policies listed above apply to all official Rust venues; including Discord channels (https://discord.gg/rust-lang); GitHub repositories under rust-lang, rust-lang-nursery,
-      and rust-lang-deprecated; and all forums under
-      rust-lang.org (users.rust-lang.org, internals.rust-lang.org). For other projects adopting the Rust Code of
-      Conduct, please contact the maintainers of those projects for enforcement. If you wish to use this code of
-      conduct for your own project, consider explicitly mentioning your moderation policy or making a copy with your
-      own moderation policy so as to avoid confusion.</p>
-    <p><i>Adapted from the <a href="http://blog.izs.me/post/30036893703/policy-on-trolling">Node.js Policy on Trolling</a>
-        as well as the <a href="https://www.contributor-covenant.org/version/1/3/0/">Contributor Covenant v1.3.0</a>.</i></p>
+    {{#text coc-moderation-description}}
+      {{#textparam coc-rust-moderation-team-anchor}}
+        <a href="{{baseurl}}/governance/teams/moderation">{{text coc-rust-moderation-team-anchor-text}}</a>
+      {{/textparam}}
+    {{/text}}
   </div>
 </section>
 

--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -14,10 +14,10 @@
     </header>
     {{#text coc-conduct-description}}
       {{#textparam coc-rust-moderation-team-anchor}}
-        <a href="{{baseurl}}/governance/teams/moderation">{{text coc-rust-moderation-team-link}}</a>
+        <a href="{{baseurl}}/governance/teams/moderation">{{text coc-conduct-description-team-anchor-text}}</a>
       {{/textparam}}
     {{/text}}
-    <p><a class="button button-secondary" href="mailto:rust-mods@rust-lang.org">{{text coc-conduct-link}}</a></p>
+    <p><a class="button button-secondary" href="mailto:rust-mods@rust-lang.org">{{text coc-conduct-email-button}}</a></p>
   </div>
 </section>
 
@@ -29,7 +29,7 @@
     </header>
     {{#text coc-moderation-description}}
       {{#textparam coc-rust-moderation-team-anchor}}
-        <a href="{{baseurl}}/governance/teams/moderation">{{text coc-rust-moderation-team-anchor-text}}</a>
+        <a href="{{baseurl}}/governance/teams/moderation">{{text coc-moderation-description-team-anchor-text}}</a>
       {{/textparam}}
     {{/text}}
   </div>

--- a/templates/policies/index.hbs
+++ b/templates/policies/index.hbs
@@ -2,21 +2,21 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Policies</h1>
+    <h1>{{text policies-page-heading}}</h1>
   </div>
 </header>
 
 <section id="policies-index" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <p>This page links to the comprehensive set of Rust’s policies.</p>
+    <p>{{text policies-page-description}}</p>
     <ul>
-      <li><a href="{{baseurl}}/policies/code-of-conduct">Code of Conduct</a></li>
-      <li><a href="{{baseurl}}/policies/licenses">Licenses</a></li>
-      <li><a href="{{baseurl}}/policies/media-guide">Logo Policy and Media Guide</a></li>
-      <li><a href="{{baseurl}}/policies/security">Security Disclosures</a></li>
+      <li><a href="{{baseurl}}/policies/code-of-conduct">{{text policies-code-of-conduct-link}}</a></li>
+      <li><a href="{{baseurl}}/policies/licenses">{{text policies-licenses-link}}</a></li>
+      <li><a href="{{baseurl}}/policies/media-guide">{{text policies-media-guide-link}}</a></li>
+      <li><a href="{{baseurl}}/policies/security">{{text policies-security-link}}</a></li>
     </ul>
-    <p>Didn’t find what you were looking for? Have a question? Please reach out!</p>
-    <p><a href="mailto:core@rust-lang.org" class="button button-secondary">Message the Core Team</a></p>
+    <p>{{text policies-reach-out-description}}</p>
+    <p><a href="mailto:core@rust-lang.org" class="button button-secondary">{{text policies-reach-out-link}}</a></p>
   </div>
 </section>
 

--- a/templates/policies/licenses.hbs
+++ b/templates/policies/licenses.hbs
@@ -2,40 +2,33 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Licenses</h1>
+    <h1>{{text licenses-page-heading}}</h1>
   </div>
 </header>
 
 <section id="license" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>License</h2>
+      <h2>{{text licenses-license-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust Programming Language and all other official projects, including this website, are generally dual-licensed:</p>
+    <p>{{text licenses-license-general-description}}</p>
     <ul>
-      <li><a href="http://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a></li>
-      <li><a href="http://opensource.org/licenses/MIT">MIT license</a></li>
+      <li><a href="http://www.apache.org/licenses/LICENSE-2.0">{{text licenses-apache-v-2-0-link}}</a></li>
+      <li><a href="http://opensource.org/licenses/MIT">{{text licenses-mit-link}}</a></li>
     </ul>
-    <p>Specific licensing info for each project can be found in its GitHub Repository.</p>
-    <p>Third-party logos may be subject to third-party copyrights and trademarks, and are not available under the same license as the rest of the Rust website.</p>
-    <p>If you have a specific question or concern about how the Rust project or any of its associated projects are licensed, please contact the Rust Core Team.</p>
-    <a href="mailto:core-team@rust-lang.org" class="button button-secondary">Email The Core Team</a>
+    {{text licenses-license-specific-description}}
+    <a href="mailto:core-team@rust-lang.org" class="button button-secondary">{{text licenses-license-email-link}}</a>
   </div>
 </section>
 
 <section id="attribution" class="red">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Attribution</h2>
+      <h2>{{text licenses-attribution-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>Icons made by <a href="http://www.freepik.com" title="Freepik">Freepik</a>
-      from <a href="https://www.flaticon.com/"
-              title="Flaticon">www.flaticon.com</a>, licensed by
-            <a href="http://creativecommons.org/licenses/by/3.0/"
-               title="Creative Commons BY 3.0">CC-3.0-BY</a>
-    </p>
+    <p>{{text licenses-attribution-description}}</p>
 </section>
 
 {{/inline}}

--- a/templates/policies/media-guide.hbs
+++ b/templates/policies/media-guide.hbs
@@ -2,97 +2,65 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Media guide</h1>
+    <h1>{{text media-guide-page-heading}}</h1>
   </div>
 </header>
 
 <section id="art-license" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Art license</h2>
+      <h2>{{text media-guide-art-license-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust and Cargo logos (bitmap and vector) are owned by Mozilla and distributed under the terms of the <a href="https://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution license (CC-BY)</a>. This is the most permissive Creative Commons license, and allows reuse and modifications for any purpose. The restrictions are that distributors must “give appropriate credit, provide a link to the license, and indicate if changes were made.” <strong>Note that use of these logos, and the Rust and Cargo names, is also governed by trademark; our trademark policy is described below</strong>.</p>
+    {{text media-guide-art-license-description}}
   </div>
 </section>
 
 <section id="trademark-policy" class="red">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Trademark policy</h2>
+      <h2>{{text media-guide-trademark-policy-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust and Cargo names and brands make it possible to say what is officially part of the Rust community, and what isn’t. So we’re careful about where we allow them to appear. But at the same time, we want to allow for as much creative use of these brands as we can. The policy laid out here explains how we strike a balance. If you want to use these names or brands, especially in a commercial way, please read this page or feel free to <a href="mailto:trademark@rust-lang.org">reach out</a> and ask us about it!</p>
-    <p><b>TL;DR</b>: Most non-commercial uses of the Rust/Cargo names and logos are allowed and do not require permission; most commercial uses require permission. In either case, the most important rule is that uses of the trademarks cannot appear official or imply any endorsement by the Rust project.</p>
-    <p>If you have any doubts about whether your intended use of a Rust Trademark requires permission, please contact us at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</p>
-    <p>This document was derived in part from the <a href="https://www.python.org/psf/trademarks/">Python Software Foundation Trademark Usage Policy</a>. This document is not an official statement of Mozilla trademark policy, but serves to clarify Mozilla’s trademark policy as it relates to Rust.</p>
+    {{text media-guide-trademark-policy-description}}
   </div>
 </section>
 
 <section id="rust-trademarks" class="white">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>The Rust trademarks</h2>
+      <h2>{{text media-guide-rust-trademarks-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust programming language is an open source, community project governed by a core team. It is also sponsored by the Mozilla Foundation (“Mozilla”), which owns and protects the Rust and Cargo trademarks and logos (the “Rust Trademarks”). This document provides information about use of the Rust Trademarks specific to a programming language, as well as examples of common ways people might want to use these trademarks, with explanations as to whether those uses are OK or not or require permission. This document supplements the <a href="https://www.mozilla.org/foundation/trademarks/policy/">official Mozilla trademark policy</a> which governs use of all Mozilla trademarks.</p>
-    <p>The Rust Trademarks include two word marks and two logos:</p>
-    <ul>
-      <li>Rust</li>
-      <li>Cargo</li>
-      <li><img src="/logos/rust-logo-blk.svg" alt="rust logo"></li>
-      <li><img src="/logos/cargo.png" alt="cargo logo"></li>
-    </ul>
-    <p>Trademarks are names and designs that tell the world the source of a good or service. Protecting trademarks for an open source project is particularly important. Anyone can change the source code and produce a product from that code, so it’s important that only the original product, or variations that have been approved by the project, use the project’s trademarks. By limiting use of the Rust Trademarks, Mozilla and the Rust project can help users and developers know they’re getting the product produced by the Rust project and not someone else’s modified version. The trademark assures users and developers of the quality and safety of the product they’re using.</p>
+    {{text media-guide-rust-trademarks-description}}
   </div>
 </section>
 
 <section id="using-the-trademarks" class="green">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Using the trademarks</h2>
+      <h2>{{text media-guide-tm-use-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <h3 id="appearing-official-affiliated-or-endorsed">Appearing official, affiliated, or endorsed</h3>
-    <p>The most basic rule is that the Rust trademarks cannot be used in ways that appear (to a casual observer) official, affiliated, or endorsed by the Rust project or Mozilla, unless you have written permission from the Rust core team. This is the fundamental way we protect users and developers from confusion.</p>
-    <p>Since this rule is about managing perception, it is subjective and somewhat difficult to nail down concretely. There are some obvious ways to avoid problems, like including the word “unofficial” in a very prominent way, but if you have any doubts, we would be more than happy to help; just send an e-mail to <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</p>
-    <h3 id="the-basics-referring-to-rustcargo">The basics: referring to Rust/Cargo</h3>
-    <p>As with any trademark, the Rust and Cargo word marks can be used with minimal restriction to refer to the Rust programming language and the Cargo package manager and registry.</p>
-    <p>They may not be used:</p>
-    <ul>
-      <li>to refer to any other programming language;</li>
-      <li>in a way that is misleading or may imply association of unrelated modules, tools, documentation, or other resources with the Rust programming language;</li>
-      <li>in ways that confuse the community as to whether the Rust programming language is open source and free to use.</li>
-    </ul>
-    <h3 id="uses-that-do-not-require-explicit-approval">Uses that do not require explicit approval</h3>
-    <p>There are a variety of uses that do not require explicit approval. <strong>However, in all of the cases outlined below, you must ensure that use of the Rust trademarks does not appear official, as explained above.</strong></p>
-    <ul>
-      <li>Stating accurately that software is written in the Rust programming language, that it is compatible with the Rust programming language, or that it contains the Rust programming language, is allowed. In those cases, you may use the Rust trademarks to indicate this, without prior approval. This is true both for non-commercial and commercial uses.</li>
-      <li>Using the Rust trademarks in the names of non-commercial products like RustPostgres or Rustymine, or in the name of code repositories in e.g. GitHub, is allowed when referring to use with or suitability for the Rust programming language. Such uses may also include the Rust logo, even in modified form. For commercial products (including crowdfunded or sponsored ones), please check in at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a> to ensure your use does not appear official.</li>
-      <li>Using the Rust trademarks on t-shirts, hats, and other artwork or merchandise, even in modified form, is allowed for your personal use or for use by a small group of community members, as long as they are not sold. If you want to distribute merchandise with Rust Trademarks at a Rust affiliated event, please contact us for permission at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>.</li>
-      <li>Using the Rust trademarks (even in modified form) for social events like meetups, tutorials, and the like is allowed for events that are free to attend. For commercial events (including sponsored ones), please check in at <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>. However, the words “RustCamp,” “RustCon” or “RustConf” cannot be used without explicit permission. And, as with all of the above uses, the <strong>event cannot appear to be officially endorsed or run by the Rust project</strong> without written permission.</li>
-      <li>Using the Rust trademarks in books or publications like “Rust Journal” or “Rust Cookbook” is allowed.</li>
-      <li>Using of the word “Rust” on websites, brochures, documentation, academic papers, books, and product packaging to refer to the Rust programming language or the Rust project is allowed.</li>
-    </ul>
-    <h3 id="uses-that-require-explicit-approval">Uses that require explicit approval</h3>
-    <ul>
-      <li>Distributing a modified version of the Rust programming language or the Cargo package manager and calling it Rust or Cargo requires explicit, written permission from the Rust core team. We will usually allow these uses as long as the modifications are (1) relatively small and (2) very clearly communicated to end-users.</li>
-      <li>Selling t-shirts, hats, and other artwork or merchandise requires explicit, written permission from the Rust core team. We will usually allow these uses as long as (1) it is clearly communicated that the merchandise is not in any way an official part of the Rust project and (2) it is clearly communicated whether profits benefit the Rust project.</li>
-      <li>Using the Rust trademarks within another trademark requires written permission from the Rust core team except as described above.</li>
-    </ul>
+    <h3 id="appearing-official-affiliated-or-endorsed">{{text media-guide-tm-use-appearance-heading}}</h3>
+    {{text media-guide-tm-use-appearance-description}}
+    <h3 id="the-basics-referring-to-rustcargo">{{text media-guide-tm-use-basics-heading}}</h3>
+    {{text media-guide-tm-use-basics-description}}
+    <h3 id="uses-that-do-not-require-explicit-approval">{{text media-guide-tm-use-implicit-approval-heading}}</h3>
+    {{text media-guide-tm-use-implicit-approval-description}}
+    <h3 id="uses-that-require-explicit-approval">{{text media-guide-tm-use-explicit-approval-heading}}</h3>
+    {{text media-guide-tm-use-explicit-approval-description}}
   </div>
 </section>
 
 <section id="logo-help-out" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Helping out</h2>
+      <h2>{{text media-guide-helping-out-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>As a member of the Rust community, please keep an eye out for questionable uses of the Rust logo and “Rust” word mark. You can report potential misuse to <a href="mailto:trademark@rust-lang.org">trademark@rust-lang.org</a>. We will evaluate each case and take appropriate action.</p>
-    <p>Please do not approach users of the trademarks with a complaint. That should be left to Mozilla and its representatives. Thanks!</p>
-    <p>If you have a specific question or concern about promoting Rust or using its trademarks, please contact the Rust Core Team.</p>
-    <a href="mailto:core-team@rust-lang.org" class="button button-secondary">Email The Core Team</a>
+    {{text media-guide-helping-out-description}}
+    <a href="mailto:core-team@rust-lang.org" class="button button-secondary">{{text media-guide-helping-out-link}}</a>
   </div>
 </section>
 

--- a/templates/policies/security.hbs
+++ b/templates/policies/security.hbs
@@ -2,87 +2,46 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Security policy</h1>
+    <h1>{{text security-page-heading}}</h1>
   </div>
 </header>
 
 <section id="security-reporting" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Reporting</h2>
+      <h2>{{text security-reporting-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p><a class="button button-secondary" href="mailto:security@rust-lang.org">email security@rust-lang.org</a></p>
-    <p>Safety is one of the core principles of Rust, and to that end, we would
-like to ensure that Rust has a secure implementation. Thank you for taking the
-time to responsibly disclose any issues you find.</p>
-    <p>All security bugs in the Rust distribution should be reported by email to
-<a href="mailto:security@rust-lang.org">security@rust-lang.org</a>. This list
-is delivered to a small security team. Your email will be acknowledged within 24
-hours, and you’ll receive a more detailed response to your email within 48
-hours indicating the next steps in handling your report. If you would like, you
-can encrypt your report using <a href="/static/keys/rust-security-team-key.gpg.ascii">our public key</a>.
-This key is also <a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC">On
-MIT’s keyserver</a> and <a href="#key">reproduced below</a>.</p>
-    <p>This email address receives a large amount of spam, so be sure to use a
-descriptive subject line to avoid having your report be missed. After the
-initial reply to your report, the security team will endeavor to keep you
-informed of the progress being made towards a fix and full announcement. As
-recommended by <a href="https://en.wikipedia.org/wiki/RFPolicy">RFPolicy</a>,
-these updates will be sent at least every five days. In reality, this is more
-likely to be every 24-48 hours.</p>
-    <p>If you have not received a reply to your email within 48 hours, or have not
-heard from the security team for the past five days, there are a few steps you
-can take (in order):</p>
-    <ul>
-      <li>Contact the current security coordinator (<a href="mailto:steve@steveklabnik.com">Steve Klabnik</a>
-        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xDAE717EFE9424541">public key</a>)) directly.</li>
-      <li>Contact the back-up contact (<a href="mailto:alex@alexcrichton.com">Alex Crichton</a>
-        (<a href="https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0x5D54B6F551FF5E33">public key</a>)) directly.</li>
-      <li>Post on the <a href="https://internals.rust-lang.org/">internals forums</a></li>
-    </ul>
-    <p>Please note that the discussion forums are
-public areas. When escalating in these venues, please do not discuss your
-issue. Simply say that you’re trying to get a hold of someone from the security
-team.</p>
-    <p><a class="button button-secondary" href="mailto:security@rust-lang.org">email security@rust-lang.org</a></p>
+    <p><a class="button button-secondary" href="mailto:security@rust-lang.org">{{text security-reporting-link}}</a></p>
+    {{text security-reporting-description}}
+    <p><a class="button button-secondary" href="mailto:security@rust-lang.org">{{text security-reporting-link}}</a></p>
   </div>
 </section>
 
 <section id="security-disclosure-policy" class="green">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Disclosure policy</h2>
+      <h2>{{text security-disclosure-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>The Rust project has a 5 step disclosure process.</p>
-    <ol>
-      <li>The security report is received and is assigned a primary handler. This person will coordinate the fix and release process.</li>
-      <li>The problem is confirmed and a list of all affected versions is determined.</li>
-      <li>Code is audited to find any potential similar problems.</li>
-      <li>Fixes are prepared for all releases which are still under maintenance. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
-      <li>On the embargo date, the <a href="https://groups.google.com/forum/#!forum/rustlang-security-announcements"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and new builds are deployed to rust-lang.org.  Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
-    </ol>
-    <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
+    {{text security-disclosure-description}}
   </div>
 </section>
 
 <section id="security-receiving" class="white">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Receiving security updates</h2>
+      <h2>{{text security-receiving-heading}}</h2>
       <div class="highlight"></div>
     </header>
-    <p>The best way to receive all the security announcements is to subscribe to the <a href="https://groups.google.com/group/rustlang-security-announcements/subscribe">Rust security announcements mailing list</a> (alternatively by sending an email to <a href="mailto:rustlang-security-announcements+subscribe@googlegroups.com">rustlang-security-announcements+subscribe@googlegroups.com</a>). The mailing list is very low traffic, and it receives the public notifications the
-moment the embargo is lifted.</p>
-    <p>We will announce vulnerabilities 72 hours before the embargo is lifted to <a href="https://oss-security.openwall.org/wiki/mailing-lists/distros">distros@openwall</a>, so that Linux distributions can update their packages.</p>
+    {{text security-receiving-description}}
   </div>
 </section>
 
 <section id="security-pgp-key" class="red">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Plaintext PGP key</h2>
+      <h2>{{text security-pgp-key-heading}}</h2>
       <div class="highlight"></div>
     </header>
     <pre><code>-----BEGIN PGP PUBLIC KEY BLOCK-----


### PR DESCRIPTION
Work done for #798 

## Change List:
User-facing text from the following files was extracted into translation files:
* `templates/policies/index.hbs` extracted into `policies.ftl`
* `templates/policies/code-of-conduct.hbs` extracted into `code-of-conduct.ftl`
* `templates/policies/licenses.hbs` extracted into `licenses.ftl`
* `templates/policies/media-guide.hbs` extracted into `media-guide.ftl`
* `templates/policies/security.hbs` extracted into `security.ftl`

## Changes in my Process
[REMOVED, see [reasoning](https://github.com/rust-lang/www.rust-lang.org/pull/813#issuecomment-496017240)]

## Testing
I have visually inspected all the pages modified, comparing the modified versions to the corresponding live https://www.rust-lang.org pages. I have not spotted any differences, but maybe some sort of HTML diffing tool could be used to verify that nothing has changed?