### PR TITLE
Parameterize {{baseurl}} in install.hbs file

### DIFF
--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -62,7 +62,7 @@ install-notes-heading = Notes about Rust installation
 install-notes-getting-started-heading = Getting started
 install-notes-getting-started-description = If you're just getting started with
         Rust and would like a more detailed walk-through, see our
-        <a href="{{baseurl}}/learn/get-started">getting started</a> page.
+        <a href="{ $getting-started-href }">getting started</a> page.
 
 install-notes-rustup-heading = Toolchain management with <code>rustup</code>
 install-notes-rustup-description = 

--- a/templates/tools/install.hbs
+++ b/templates/tools/install.hbs
@@ -25,7 +25,11 @@
     <div>
       <h3>{{text install-notes-getting-started-heading}}</h3>
       <p>
-        {{text install-notes-getting-started-description}}
+        {{#text install-notes-getting-started-description}}
+          {{#textparam getting-started-href}}
+            {{baseurl}}/learn/get-started
+          {{/textparam}}
+        {{/text}}
       </p>
 
       <h3>{{text install-notes-rustup-heading}}</h3>


### PR DESCRIPTION
Work for #798 

I `grep`'d for `{{baseurl}}` inside of FTL files, and this was the last instance. It has now been extracted into a `textparam`.