### PR TITLE
Move Text from Embedded page into Translation Files

### DIFF
--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -55,3 +55,26 @@ embedded-showcase-see-more-link = See More
 
 embedded-showcase-video-description =
         <a href="https://vimeo.com/224912526">Securing the future, with Rust</a> from <a href="https://vimeo.com/cambridgeconsultants">Cambridge Consultants</a> on <a href="https://vimeo.com">Vimeo</a>.
+
+
+## Get started! (templates/components/what/embedded/get-started.hbs)
+
+embedded-get-started-heading = Get started!
+
+embedded-get-started-discovery-book-alt = DIP-6 package
+embedded-get-started-discovery-book-heading = The Discovery book
+embedded-get-started-discovery-book-description =
+        Learn embedded development from the ground up&mdash;using Rust!
+
+embedded-get-started-embedded-rust-book-alt = TFQP-16 package
+embedded-get-started-embedded-rust-book-heading = The Embedded Rust book
+embedded-get-started-embedded-rust-book-description =
+        Already familiar with Embedded development? Jump in with Rust and start reaping the benefits.
+
+embedded-get-started-embedonomicon-alt = BGA package
+embedded-get-started-embedonomicon-heading = The Embedonomicon
+embedded-get-started-embedonomicon-description =
+        Look under the hood of foundational embedded libraries.
+
+embedded-get-started-read-link = Read
+embedded-get-started-more-documentation-link = More Documentation

--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -44,3 +44,14 @@ embedded-learn-more-link = Learn more
 
 
 ## Showcase (templates/components/what/showcase.hbs)
+
+embedded-showcase-heading = Showcase
+
+embedded-showcase-quote =
+        “I was so excited when I came across Rust, from Mozilla. Rust is a new programming language, with the tag line ‘safe, fast, concurrent &ndash; pick three.’ It also has an assured future, with a powerful, committed user community.”
+embedded-showcase-quote-attribution =
+        &ndash; Jonathan Pallant, Senior Consultant, Cambridge Consultants
+embedded-showcase-see-more-link = See More
+
+embedded-showcase-video-description =
+        <a href="https://vimeo.com/224912526">Securing the future, with Rust</a> from <a href="https://vimeo.com/cambridgeconsultants">Cambridge Consultants</a> on <a href="https://vimeo.com">Vimeo</a>.

--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -78,3 +78,33 @@ embedded-get-started-embedonomicon-description =
 
 embedded-get-started-read-link = Read
 embedded-get-started-more-documentation-link = More Documentation
+
+
+## Production use (templates/components/what/embedded/testimonials.hbs)
+
+embedded-testimonials-heading = Production use
+
+embedded-testimonials-sensirion-alt = Sensirion logo
+embedded-testimonials-sensirion-quote =
+        At Sensirion we recently used Rust to create an embedded demonstrator for Sensirion’s <a href="https://sensirion-automotive.com/products#PM2_5">Particulate Matter Sensor</a>. Due to the easy cross-compilation and the availability of many high quality crates on crates.io <b>we quickly ended up with a fast and robust demonstrator.</b>
+embedded-testimonials-sensirion-attribution =
+        &ndash; Raphael Nestler, Software Engineer, Sensirion
+
+embedded-testimonials-airborne-alt = Airborne Engineering Ltd logo
+embedded-testimonials-airborne-quote =
+        At Airborne Engineering Ltd. we recently used Rust to write an Ethernet bootloader, <a href="https://github.com/airborneengineering/blethrs">blethrs</a>, for our in-house data acquisition system. <b>Rust is a promising language and we’re excited to use it for our future projects, embedded and otherwise.</b>
+embedded-testimonials-airborne-attribution =
+        &ndash; Dr. Adam Greig, Instrumentation Engineer, Airborne Engineering Ltd.
+
+embedded-testimonials-49nord-alt = 49nord logo
+# "Fluent" requires a square bracket which is the first character of a line to be escaped like this: {"["} See https://projectfluent.org/fluent/guide/special.html
+embedded-testimonials-49nord-quote =
+        {"["}Rust] enables us to ship software faster and more correct than we thought possible. Thanks to Rust, we can take memory safety for granted, while other benefits of a zero-overhead language with a sophisticated type system help us develop maintainable software. <b>Rust makes our customers happy, as well as our engineers.</b>
+embedded-testimonials-49nord-attribution =
+        &ndash; Marc Brinkmann, CEO, 49nord
+
+embedded-testimonials-terminal-tech-alt = Terminal Technologies logo
+embedded-testimonials-terminal-tech-quote =
+        <b>We think it’s really cool that we can use a modern nice language in the embedded space</b> where usually there’s no alternative to C/C++
+embedded-testimonials-terminal-tech-attribution =
+        &ndash; Aleksei Arbuzov, Senior Software Engineer, Terminal Technologies

--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -5,7 +5,8 @@
 # Page Title
 embedded-page-title = Embedded devices
 
-## components/what/pitch.hbs
+
+## Why Rust? (templates/components/what/pitch.hbs)
 
 embedded-pitch-heading = Why Rust?
 
@@ -40,3 +41,6 @@ embedded-pitch-community-description =
         As part of the Rust open source project, support for embedded systems is driven by a best-in-class open source community, with support from commercial partners.
 
 embedded-learn-more-link = Learn more
+
+
+## Showcase (templates/components/what/showcase.hbs)

--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -1,0 +1,6 @@
+### Translation file for https://www.rust-lang.org/what/embedded
+
+## templates/what/embedded.hbs
+
+# Page Title
+embedded-page-title = Embedded devices

--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -4,3 +4,39 @@
 
 # Page Title
 embedded-page-title = Embedded devices
+
+## components/what/pitch.hbs
+
+embedded-pitch-heading = Why Rust?
+
+embedded-pitch-analysis-alt = A microscope
+embedded-pitch-analysis-heading = Powerful static analysis
+embedded-pitch-analysis-description =
+        Enforce pin and peripheral configuration at compile time. Guarantee that resources won’t be used by unintended parts of your application.
+
+embedded-pitch-memory-alt = A RAM stick
+embedded-pitch-memory-heading = Flexible memory 
+embedded-pitch-memory-description =
+        Dynamic memory allocation is optional. Use a global allocator and dynamic data structures. Or leave out the heap altogether and statically allocate everything.
+
+embedded-pitch-concurrency-alt = Gears
+embedded-pitch-concurrency-heading = Fearless concurrency
+embedded-pitch-concurrency-description =
+        Rust makes it impossible to accidentally share state between threads. Use any concurrency approach you like, and you’ll still get Rust’s strong guarantees.
+
+embedded-pitch-interop-alt = Handshake
+embedded-pitch-interop-heading = Interoperability
+embedded-pitch-interop-description =
+        Integrate Rust into your existing C codebase or leverage an existing SDK to write a Rust application.
+
+embedded-pitch-portability-alt = Luggage trolley
+embedded-pitch-portability-heading = Portability
+embedded-pitch-portability-description =
+        Write a library or driver once, and use it with a variety of systems, ranging from very small microcontrollers to powerful SBCs.
+
+embedded-pitch-community-alt = Shield Logo
+embedded-pitch-community-heading = Community driven
+embedded-pitch-community-description =
+        As part of the Rust open source project, support for embedded systems is driven by a best-in-class open source community, with support from commercial partners.
+
+embedded-learn-more-link = Learn more

--- a/templates/components/what/embedded/get-started.hbs
+++ b/templates/components/what/embedded/get-started.hbs
@@ -1,48 +1,47 @@
 <section id="embedded-get-started" class="red">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Get started!</h2>
+      <h2>{{text embedded-get-started-heading}}</h2>
       <div class="highlight"></div>
     </header>
     <div class="flex flex-column flex-row-l">
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="discovery-book">
         <div class="v-top tc-l">
-          <img src="/static/images/chip1.svg" alt="DIP-6 package"
+          <img src="/static/images/chip1.svg" alt="{{text embedded-get-started-discovery-book-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
-          <h3 class="tc-l">The Discovery book</h3>
+          <h3 class="tc-l">{{text embedded-get-started-discovery-book-heading}}</h3>
           <p class="flex-grow-1">
-            Learn embedded development from the ground up&mdash;using Rust!
+            {{text embedded-get-started-discovery-book-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/discovery/" class="button button-secondary">Read</a>
+          <a href="https://docs.rust-embedded.org/discovery/" class="button button-secondary">{{text embedded-get-started-read-link}}</a>
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="discovery-book">
         <div class="v-top tc-l">
-          <img src="/static/images/chip2.svg" alt="TFQP-16 package"
+          <img src="/static/images/chip2.svg" alt="{{text embedded-get-started-embedded-rust-book-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
-          <h3 class="tc-l">The Embedded Rust book</h3>
+          <h3 class="tc-l">{{text embedded-get-started-embedded-rust-book-heading}}</h3>
           <p class="flex-grow-1">
-            Already familiar with Embedded development?
-            Jump in with Rust and start reaping the benefits.
+            {{text embedded-get-started-embedded-rust-book-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/book/" class="button button-secondary">Read</a>
+          <a href="https://docs.rust-embedded.org/book/" class="button button-secondary">{{text embedded-get-started-read-link}}</a>
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="embedonomicon">
         <div class="v-top tc-l">
-          <img src="/static/images/chip3.svg" alt="BGA package"
+          <img src="/static/images/chip3.svg" alt="{{text embedded-get-started-embedonomicon-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
-          <h3 class="tc-l">The Embedonomicon</h3>
+          <h3 class="tc-l">{{text embedded-get-started-embedonomicon-heading}}</h3>
           <p class="flex-grow-1">
-            Look under the hood of foundational embedded libraries.
+            {{text embedded-get-started-embedonomicon-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/embedonomicon/" class="button button-secondary">Read</a>
+          <a href="https://docs.rust-embedded.org/embedonomicon/" class="button button-secondary">{{text embedded-get-started-read-link}}</a>
         </div>
       </div>
     </div>
@@ -50,7 +49,7 @@
     <div class="tc pl4-l">
       <p>
         <a href="https://docs.rust-embedded.org/" class="button button-secondary">
-          More Documentation
+          {{text embedded-get-started-more-documentation-link}}
         </a>
     </div>
   </div>

--- a/templates/components/what/embedded/pitch.hbs
+++ b/templates/components/what/embedded/pitch.hbs
@@ -2,7 +2,7 @@
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>
-        Why Rust?
+        {{text embedded-pitch-heading}}
       </h2>
       <div class="highlight"></div>
     </header>
@@ -10,53 +10,51 @@
     <div class="flex-none flex-l flex-row">
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="powerful-static-analysis">
         <div class="v-top tc-l">
-          <img src="/static/images/microscope.svg" alt="A microscope"
+          <img src="/static/images/microscope.svg" alt="{{text embedded-pitch-analysis-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Powerful static analysis
+            {{text embedded-pitch-analysis-heading}}
           </h3>
           <p class="flex-grow-1">
-            Enforce pin and peripheral configuration at compile time. Guarantee that resources won’t be used by unintended parts of your application.
+            {{text embedded-pitch-analysis-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/book/static-guarantees/" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/static-guarantees/" class="button button-secondary">{{text embedded-learn-more-link}}</a>
         </div>
       </div>
 
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="flexible-memory-management">
         <div class="v-top tc-l">
-          <img src="/static/images/ram-memory.svg" alt="A RAM stick"
+          <img src="/static/images/ram-memory.svg" alt="{{text embedded-pitch-memory-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Flexible memory 
+            {{text embedded-pitch-memory-heading}}
           </h3>
           <p class="flex-grow-1">
-            Dynamic memory allocation is optional. Use a global allocator and dynamic data structures.
-            Or leave out the heap altogether and statically allocate everything.
+            {{text embedded-pitch-memory-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/book/collections/" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/collections/" class="button button-secondary">{{text embedded-learn-more-link}}</a>
         </div>
       </div>
 
 
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="flexible-memory-management">
         <div class="v-top tc-l">
-          <img src="/static/images/gears.svg" alt="Gears"
+          <img src="/static/images/gears.svg" alt="{{text embedded-pitch-concurrency-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="v-top tc-l">
-            Fearless concurrency
+            {{text embedded-pitch-concurrency-heading}}
           </h3>
 
           <p class="flex-grow-1">
-            Rust makes it impossible to accidentally share state between threads.
-            Use any concurrency approach you like, and you’ll still get Rust’s strong guarantees.
+            {{text embedded-pitch-concurrency-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/book/concurrency/" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/concurrency/" class="button button-secondary">{{text embedded-learn-more-link}}</a>
         </div>
       </div>
     </div>
@@ -64,46 +62,44 @@
     <div class="flex-none flex-l flex-row mt5-l">
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="interoperability">
         <div class="v-top tc-l">
-          <img src="/static/images/handshake.svg" alt="Handshake"
+          <img src="/static/images/handshake.svg" alt="{{text embedded-pitch-interop-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <h3 class="tc-l">
-            Interoperability
+            {{text embedded-pitch-interop-heading}}
           </h3>
           <p class="flex-grow-1">
-            Integrate Rust into your existing C codebase or leverage an existing SDK to write a Rust
-            application.
+            {{text embedded-pitch-interop-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/book/interoperability/" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/interoperability/" class="button button-secondary">{{text embedded-learn-more-link}}</a>
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="portability">
         <div class="v-top tc-l">
-          <img src="/static/images/luggage.svg" alt="Luggage trolley"
+          <img src="/static/images/luggage.svg" alt="{{text embedded-pitch-portability-alt}}"
             class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
-          <h3 class="tc-l">Portability</h3>
+          <h3 class="tc-l">{{text embedded-pitch-portability-heading}}</h3>
 
           <p class="flex-grow-1">
-            Write a library or driver once, and use it with a variety of systems, ranging
-            from very small microcontrollers to powerful SBCs.
+            {{text embedded-pitch-portability-description}}
           </p>
-          <a href="https://docs.rust-embedded.org/book/portability/" class="button button-secondary">Learn more</a>
+          <a href="https://docs.rust-embedded.org/book/portability/" class="button button-secondary">{{text embedded-learn-more-link}}</a>
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l pl4-l" id="community-driven">
         <div class="v-top tc-l">
-          <img src="/static/images/cli-rustc-approved.svg" alt="Shield Logo" class="mw3 mw4-ns"/>
+          <img src="/static/images/cli-rustc-approved.svg" alt="{{text embedded-pitch-community-alt}}" class="mw3 mw4-ns"/>
         </div>
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
-          <h3 class="tc-l">Community driven</h3>
+          <h3 class="tc-l">{{text embedded-pitch-community-heading}}</h3>
 
           <p class="flex-grow-1">
-            As part of the Rust open source project, support for embedded systems is driven by a best-in-class open source community, with support from commercial partners.
+            {{text embedded-pitch-community-description}}
           </p>
-          <a href="https://github.com/rust-embedded/wg" class="button button-secondary">Learn more</a>
+          <a href="https://github.com/rust-embedded/wg" class="button button-secondary">{{text embedded-learn-more-link}}</a>
         </div>
       </div>
     </div>

--- a/templates/components/what/embedded/showcase.hbs
+++ b/templates/components/what/embedded/showcase.hbs
@@ -1,23 +1,23 @@
 <section id="embedded-showcase-gallery" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
-      <h2>Showcase</h2>
+      <h2>{{text embedded-showcase-heading}}</h2>
       <div class="highlight"></div>
     </header>
       <div class="flex flex-column flex-row-l">
         <div class="mw-50-l mh3-l">
           <div>
-          “I was so excited when I came across Rust, from Mozilla. Rust is a new programming language, with the tag line ‘safe, fast, concurrent &ndash; pick three.’ It also has an assured future, with a powerful, committed user community.”
+          {{text embedded-showcase-quote}}
 
-          <p>&ndash; Jonathan Pallant, Senior Consultant, Cambridge Consultants
+          <p>{{text embedded-showcase-quote-attribution}}
 
-          <p><a href="https://github.com/rust-embedded/awesome-embedded-rust" class="button button-secondary">See More</a>
+          <p><a href="https://github.com/rust-embedded/awesome-embedded-rust" class="button button-secondary">{{text embedded-showcase-see-more-link}}</a>
           </div>
         </div>
         <div class="mw-50-l mh3-l center">
           <div>
           <iframe src="https://player.vimeo.com/video/224912526?title=0&byline=0&portrait=0" width="500" height="281"  frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
-          <p><a href="https://vimeo.com/224912526">Securing the future, with Rust</a> from <a href="https://vimeo.com/cambridgeconsultants">Cambridge Consultants</a> on <a href="https://vimeo.com">Vimeo</a>.</p>
+          <p>{{text embedded-showcase-video-description}}</p>
           </div>
         </div>
       </div>

--- a/templates/components/what/embedded/testimonials.hbs
+++ b/templates/components/what/embedded/testimonials.hbs
@@ -1,7 +1,7 @@
 <section id="production" class="white">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center">
     <header>
-      <h2>Production use</h2>
+      <h2>{{text embedded-testimonials-heading}}</h2>
       <div class="highlight"></div>
     </header>
     <!-- Testimonials section -->
@@ -11,27 +11,27 @@
       <div class="testimonial flex-none flex-l">
         <div class="w-100 w-30-l tc">
           <a href="https://www.sensirion.com/">
-            <img alt="Sensirion logo" src="/static/images/user-logos/sensirion.png"/>
+            <img alt="{{text embedded-testimonials-sensirion-alt}}" src="/static/images/user-logos/sensirion.png"/>
           </a>
         </div>
         <div class="w-100 w-70-l" id="sensiron-testimonial">
           <blockquote class="lh-title-ns">
-            At Sensirion we recently used Rust to create an embedded demonstrator for Sensirion’s <a href="https://sensirion-automotive.com/products#PM2_5">Particulate Matter Sensor</a>. Due to the easy cross-compilation and the availability of many high quality crates on crates.io <b>we quickly ended up with a fast and robust demonstrator.</b>
+            {{text embedded-testimonials-sensirion-quote}}
           </blockquote>
-          <p class="attribution">&ndash; Raphael Nestler, Software Engineer, Sensirion</p>
+          <p class="attribution">{{text embedded-testimonials-sensirion-attribution}}</p>
         </div>
       </div>
 
       <div class="testimonial flex-none flex-l">
         <div class="w-100 w-70-l" id="greig-testimonial">
           <blockquote class="lh-title-ns">
-            At Airborne Engineering Ltd. we recently used Rust to write an Ethernet bootloader, <a href="https://github.com/airborneengineering/blethrs">blethrs</a>, for our in-house data acquisition system. <b>Rust is a promising language and we’re excited to use it for our future projects, embedded and otherwise.</b>
+            {{text embedded-testimonials-airborne-quote}}
           </blockquote>
-          <p class="attribution">&ndash; Dr. Adam Greig, Instrumentation Engineer, Airborne Engineering Ltd.</p>
+          <p class="attribution">{{text embedded-testimonials-airborne-attribution}}</p>
         </div>
         <div class="w-100 w-30-l tc">
           <a href="http://ael.co.uk">
-            <img alt="Airborne Engineering Ltd logo" src="/static/images/user-logos/ael_logo.png"/>
+            <img alt="{{text embedded-testimonials-airborne-alt}}" src="/static/images/user-logos/ael_logo.png"/>
           </a>
         </div>
       </div>
@@ -39,29 +39,27 @@
       <div class="testimonial flex-none flex-l">
         <div class="w-100 w-30-l tc">
           <a href="https://49nord.de/">
-            <img alt="49nord logo" src="/static/images/user-logos/49nord.svg"/>
+            <img alt="{{text embedded-testimonials-49nord-alt}}" src="/static/images/user-logos/49nord.svg"/>
           </a>
         </div>
         <div class="w-100 w-70-l" id="brinkmann-testimonial">
           <blockquote class="lh-title-ns">
-            [Rust] enables us to ship software faster and more correct than we thought possible. Thanks to Rust, we can take memory safety for granted, while other benefits of a zero-overhead language with a sophisticated type system help us develop maintainable software.
-
-            <b>Rust makes our customers happy, as well as our engineers.</b>
+            {{text embedded-testimonials-49nord-quote}}
           </blockquote>
-          <p class="attribution">&ndash; Marc Brinkmann, CEO, 49nord</p>
+          <p class="attribution">{{text embedded-testimonials-49nord-attribution}}</p>
         </div>
       </div>
 
       <div class="testimonial flex-none flex-l">
         <div class="w-100 w-70-l" id="arbuzov-testimonial">
           <blockquote class="lh-title-ns">
-            <b>We think it’s really cool that we can use a modern nice language in the embedded space</b> where usually there’s no alternative to C/C++
+            {{text embedded-testimonials-terminal-tech-quote}}
           </blockquote>
-          <p class="attribution">&ndash; Aleksei Arbuzov, Senior Software Engineer, Terminal Technologies</p>
+          <p class="attribution">{{text embedded-testimonials-terminal-tech-attribution}}</p>
         </div>
         <div class="w-100 w-30-l tc">
           <a href="http://www.termt.eu/">
-            <img alt="Terminal Technologies logo" src="/static/images/user-logos/terminal-technologies.png"/>
+            <img alt="{{text embedded-testimonials-terminal-tech-alt}}" src="/static/images/user-logos/terminal-technologies.png"/>
           </a>
         </div>
       </div>

--- a/templates/what/embedded.hbs
+++ b/templates/what/embedded.hbs
@@ -2,7 +2,7 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>Embedded devices</h1>
+    <h1>{{text embedded-page-title}}</h1>
   </div>
 </header>
 


### PR DESCRIPTION
Work for #798 

The webpage has been visually inspected side-by-side with the live site, and no differences have been found. I compared:
* Link `href`s
* Paragraph wrap and spacing
* Image alt text