### PR TITLE
Fix localization error on learn/Getting Started

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -64,6 +64,7 @@ learn-unstable-button = Read the unstable book
 
 ## learn/get-started.hbs
 
+learn-setup-heading = Getting started
 learn-setup = Quickly set up a Rust development environment and write a small app!
 
 learn-install-heading = Installing Rust

--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -64,7 +64,6 @@ learn-unstable-button = Read the unstable book
 
 ## learn/get-started.hbs
 
-learn-setup-heading = Getting started
 learn-setup = Quickly set up a Rust development environment and write a small app!
 
 learn-install-heading = Installing Rust

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -2,7 +2,7 @@
 
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <h1>{{text learn-setup-heading}}</h1>
+    <h1>{{text getting-started}}</h1>
     <h2 class="subtitle">{{text learn-setup}}</h2>
   </div>
 </header>

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -3,7 +3,7 @@
 <header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <h1>{{text learn-setup-heading}}</h1>
-    <h2 class="subtitle">{{text getting-started}}</h2>
+    <h2 class="subtitle">{{text learn-setup}}</h2>
   </div>
 </header>
 


### PR DESCRIPTION
One line fix for this problem happening on https://www.rust-lang.org/learn/get-started:

edit: OOPS FIXED SUBTITLE:
![image](https://user-images.githubusercontent.com/34199632/58511521-f8aa4100-8168-11e9-8085-33fdb3066dce.png)

