### PR TITLE
fix for Issue #758 Bad contrast on code examples

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -62,27 +62,18 @@ pre > code {
   white-space: pre;
 }
 
-@mixin code-space-full-width {
-  padding: 1rem 1.5rem;
-  margin: 0 .2rem;
-}
-
-@mixin code-space-inline {
-  padding: .2rem .5rem;
-  margin: 0 .2rem;
-}
 
 @mixin code-highlight-white {
   color: white;
-  background-color: rgba(white, 0.15);
+  background-color: rgba(black, 0.3);
   border: 1px solid #E1E1E1;
   border-radius: $border-radius;
 }
 
 @mixin code-highlight-black {
   color: black;
-  background-color: rgba(69, 76, 82, 0.05);
-  border: 1px solid rgba(69, 76, 82, 0.25);
+  background-color: rgba(black, 0.05);
+  border: 1px solid rgba(black, 0.25);
   border-radius: $border-radius;
 }
 
@@ -290,7 +281,6 @@ a.brand {
   }
   code {
     @include code-highlight-white();
-    @include code-space-inline();
   }
 }
 
@@ -315,7 +305,6 @@ a.brand {
   } 
   code {
     @include code-highlight-white();
-    @include code-space-full-width();
   }
 }
 
@@ -339,7 +328,6 @@ a.brand {
   }
   code {
     @include code-highlight-black();
-    @include code-space-inline();
   }
 }
 
@@ -364,7 +352,6 @@ a.brand {
   }
   code {
     @include code-highlight-white();
-    @include code-space-inline();
   }
 }
 


### PR DESCRIPTION
This change does two things:
- The code blocks are set on a darker background. I've tested a unified color scheme for all color-contexts, but for me it pushed the already noisy site over the edge. There is still no syntax highlighting, but with the darkened background there is enough headroom in terms of contrast to use the link-yellow and a lighter variant of another color in the color schema.
- I unified the paddings of the code blocks so that all inline and full width elements get the same values respectively and i did a small refactoring of the mixins that where used for that.

This is the smallest change to make the code blocks usable without deviating too much from the old design. Imo, larger changes/redesigns of the code blocks should be done in context of the overall design.