### PR TITLE
Escape HTML characters in code examples

### DIFF
--- a/templates/components/what/networking/take-json.hbs
+++ b/templates/components/what/networking/take-json.hbs
@@ -1,8 +1,8 @@
 #[derive(FromForm)]
 struct Task { name: String, completed: bool }
 
-#[post("/", data = "<task>")]
-fn new(task: Form<Task>) -> Flash<Redirect> {
+#[post("/", data = "&lt;task&gt;")]
+fn new(task: Form&lt;Task&gt;) -> Flash&lt;Redirect&gt; {
     if task.name.is_empty() {
         Flash::error(Redirect::to("/"),
             "Cannot be empty.")


### PR DESCRIPTION
Fixes https://github.com/rust-lang/www.rust-lang.org/issues/429 the hard way.

I think that's feasible for now, it's better then leaving the issue open.