### PR TITLE
Fix learn-doc-std-button text

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -16,7 +16,7 @@ learn-doc-heading = Read the core documentation
 learn-doc = All of this documentation is also available locally using the <code>rustup doc</code> command, which will open up these resources for you in your browser without requiring a network connection!
 
 learn-doc-std = Comprehensive guide to the Rust standard library APIs.
-learn-doc-std-button = The standard 
+learn-doc-std-button = The standard library
 
 learn-doc-edition = Guide to the Rust editions.
 learn-doc-edition-button = Edition Guide


### PR DESCRIPTION
Changes the label from "The standard" to "The standard library" to prevent visitors to the site thinking that they'll be taken to a spec of the language

Screenshot of [current page](https://rust-lang.org/learn):

![rust-learn](https://user-images.githubusercontent.com/27889/59004579-2e88ad00-886e-11e9-8365-3296ea315d54.png)
