### PR TITLE
Alt text of `chip2.svg` doesn't match actual image

### DIFF
--- a/locales/en-US/embedded.ftl
+++ b/locales/en-US/embedded.ftl
@@ -62,7 +62,7 @@ embedded-get-started-discovery-book-heading = The Discovery book
 embedded-get-started-discovery-book-description =
         Learn embedded development from the ground up&mdash;using Rust!
 
-embedded-get-started-embedded-rust-book-alt = TFQP-16 package
+embedded-get-started-embedded-rust-book-alt = QFP-20 package
 embedded-get-started-embedded-rust-book-heading = The Embedded Rust book
 embedded-get-started-embedded-rust-book-description =
         Already familiar with Embedded development? Jump in with Rust and start reaping the benefits.


### PR DESCRIPTION
1. `TFQP` is a typo, should be `TQFP`. Also, the image has 20 pins instead of 16. 
2. `TQFP` (Thin-QFP) is a specific package, but this image is abstract, we simply cannot tell which specific QFP this image is. 

The correct alt text of <https://www.rust-lang.org/static/images/chip2.svg> is "QFP-20 package".