### PR TITLE
resizes and aligns wasm images (#830)

### DIFF
--- a/templates/components/what/wasm/get-started.hbs
+++ b/templates/components/what/wasm/get-started.hbs
@@ -6,11 +6,10 @@
         </header>
         <div class="flex flex-column flex-row-l pv4 pv0-l">
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
-                <div class="v-top tc-l">
-                  <img src="/static/images/webassembly-logo.svg" alt="{{text wasm-get-started-wasm-alt}}"
-                       class="mw3 mw4-ns"/>
+                <div class="v-top tc-l h-25-ns">
+                    <img src="/static/images/webassembly-logo.svg" alt="{{text wasm-get-started-wasm-alt}}" class="mw3 mw5-ns h-100-ns" />
                 </div>
-                <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l  pl4-l">
+                <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l pl4-l w-100">
                     <p class="flex-grow-1">
                         {{text wasm-get-started-wasm-description}}
                     </p>
@@ -18,11 +17,10 @@
                 </div>
             </div>
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
-                <div class="v-top tc-l">
-                  <img src="/static/images/wasm-ferris.png" alt="{{text wasm-get-started-book-alt}}"
-                       class="mw3 mw4-ns"/>
+                <div class="v-top tc-l h-25-ns">
+                    <img src="/static/images/wasm-ferris.png" alt="{{text wasm-get-started-book-alt}}" class="mw3 mw5-ns h-100-ns" />
                 </div>
-                <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l  pl4-l">
+                <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l pl4-l w-100">
                     <p class="flex-grow-1">
                         {{text wasm-get-started-book-description}}
                     </p>
@@ -30,11 +28,10 @@
                 </div>
             </div>
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
-                <div class="v-top tc-l">
-                  <img src="/static/images/mdn-logo.svg" alt="{{text wasm-get-started-mdn-alt}}"
-                       class="mw3 mw4-ns"/>
+                <div class="v-top tc-l h-25-ns">
+                    <img src="/static/images/mdn-logo.svg" alt="{{text wasm-get-started-mdn-alt}}" class="mw3 mw5-ns h-100-ns" />
                 </div>
-                <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l  pl4-l">
+                <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l pl4-l w-100">
                     <p class="flex-grow-1">
                         {{text wasm-get-started-mdn-description}}
                     </p>


### PR DESCRIPTION
Hi!

This is a pull request potentially fixing both the alignment and the sizing (#830) issues on the wasm page.

The added classes controlling height seemed appropriate to not have to version images in different crops and aspect ratios.

This is my first time using tachyons, feedback very welcome!

![rust-image-align-fix](https://user-images.githubusercontent.com/919732/59225040-0da6bb80-8bd0-11e9-8e71-a2c28e163864.png)
