### PR TITLE
Build on Windows with VS2019

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1555,16 +1555,16 @@ dependencies = [
 [[package]]
 name = "sass-rs"
 version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+source = "git+https://github.com/bltavares/sass-rs?branch=compile-on-windows-vs2019#2e8289539fcb2b11812b666b5104d94744fa93b6"
 dependencies = [
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
- "sass-sys 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sass-sys 0.4.10 (git+https://github.com/bltavares/sass-rs?branch=compile-on-windows-vs2019)",
 ]
 
 [[package]]
 name = "sass-sys"
-version = "0.4.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.4.10"
+source = "git+https://github.com/bltavares/sass-rs?branch=compile-on-windows-vs2019#2e8289539fcb2b11812b666b5104d94744fa93b6"
 dependencies = [
  "cc 1.0.37 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.55 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2129,7 +2129,7 @@ dependencies = [
  "rocket 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocket_contrib 0.4.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust_team_data 1.0.0 (git+https://github.com/rust-lang/team)",
- "sass-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sass-rs 0.2.2 (git+https://github.com/bltavares/sass-rs?branch=compile-on-windows-vs2019)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 1.0.39 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2327,8 +2327,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum ryu 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "b96a9549dc8d48f2c283938303c4b5a77aa29bfbc5b54b084fb1630408899a8f"
 "checksum safemem 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8dca453248a96cb0749e36ccdfe2b0b4e54a61bfef89fb97ec621eb8e0a93dd9"
 "checksum same-file 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8f20c4be53a8a1ff4c1f1b2bd14570d2f634628709752f0702ecdd2b3f9a5267"
-"checksum sass-rs 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "cabcf7c6e55053f359911187ac401409aad2dc14338cae972dec266fee486abd"
-"checksum sass-sys 0.4.9 (registry+https://github.com/rust-lang/crates.io-index)" = "2166010e0b24c6ec7c2d7fb64011a01cd8296d3460893265c2007b07ba2c8313"
+"checksum sass-rs 0.2.2 (git+https://github.com/bltavares/sass-rs?branch=compile-on-windows-vs2019)" = "<none>"
+"checksum sass-sys 0.4.10 (git+https://github.com/bltavares/sass-rs?branch=compile-on-windows-vs2019)" = "<none>"
 "checksum schannel 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "f2f6abf258d99c3c1c5c2131d99d064e94b7b3dd5f416483057f308fea253339"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
 "checksum security-framework 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "eee63d0f4a9ec776eeb30e220f0bc1e092c3ad744b2a379e3993070364d3adc2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,17 @@ rocket = "0.4.1"
 serde = "1.0"
 serde_derive = "1.0"
 serde_yaml = "0.8.7"
-sass-rs = "0.2.1"
+# sass-rs = "0.2.1"
 reqwest = "0.9.5"
 toml = "0.4"
 serde_json = "1.0"
 rust_team_data = { git = "https://github.com/rust-lang/team" }
 handlebars = "1.1.0"
 siphasher = "0.2.3"
+
+[dependencies.sass-rs]
+git = "https://github.com/bltavares/sass-rs"
+branch = "compile-on-windows-vs2019"
 
 [dependencies.rocket_contrib]
 version = "*"

--- a/README.md
+++ b/README.md
@@ -12,6 +12,13 @@
 1. To build the app and run the server, run `cargo watch -x run` in your terminal.
 1. Navigate to http://localhost:7878 in your browser. If you make any updates to the styles, or any other project files, `cargo watch` will automatically restart the server for you, all you have to do is refresh your browser to see your changes.
 
+#### Building on Windows
+
+If you have issues comiling `sass-sys` on Windows 10, try the following:
+
+- Upgrade to VS Build Tools 2019
+- Open `x64 Native Developer Console for VS 2019` from the Start menu, and execute the commands there.
+
 ### Where to edit
 
 - If you would like to edit styles, you should edit [`src/styles/app.scss`](src/styles/app.scss). 


### PR DESCRIPTION
This commit contains a temporary fork on `sass-rs` which provides the
necessary chagnes to have the project running on Windows 10.

I expect [the change](https://github.com/compass-rs/sass-rs/pull/49)
to be taken upstream, so we can simply upgrade the dependency instead of
keeping the forked git version, but this is more so to let others
compile the project and document the error, if someone tries to run it
on Windows meanwhile.

The error message in itself, to help with searchs, is:

```
error MSB4019: The imported project "C:\Microsoft.Cpp.Default.props" was
not found. Confirm that the path in the <Import> declaration is correct,
and that the file exists on disk.
```

This also provides a documentation on the README on what to do in case
the error happens.