### PR TITLE
Allow buttons to grow to accomodate translations

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -79,18 +79,15 @@ pre > code {
 
 .button,
 button {
-  display: block;
-  overflow: hidden;
-  height: 38px;
-  padding: 0 30px;
+  display: inline-block;
+  width: 100%;
+  min-height: 38px;
+  padding: 8px 30px;
   text-align: center;
   font-weight: 600;
-  line-height: 38px;
   letter-spacing: .1rem;
   text-transform: uppercase;
   text-decoration: none;
-  text-overflow: ellipsis;
-  white-space: nowrap;
   border-radius: 4px;
   border: 1px solid;
   cursor: pointer;
@@ -583,6 +580,7 @@ blockquote::before {
   .domain-icon {
     display: block;
     padding-bottom: 0;
+    min-width: 100px;
 
     img {
       max-width: 90px;


### PR DESCRIPTION
The current buttons make use of a fixed height for the text content,
which make them look similar to each other and provide a pleasant visual
connection.

It happens that some translations require more text space, and the
content of the button started to be left out, specially on mobile
screens as it has less width to use.

This commit changes the buttons to allow them to grow vertically as
necessary, while remaining at a similar height when it is not necessary.

It is easier to see the different using the `Governance` or `Community`
content in Portuguese.

Tested visually both on Desktop and Mobile views, and the content
adjusts to the provided width.

A small extra fix has been included on the CLI page, to make a regular
spacing on the text columns when visiting it on a Mobile view.