### PR TITLE
Move lang attribute to html

### DIFF
--- a/templates/components/layout.hbs
+++ b/templates/components/layout.hbs
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="{{lang}}">
   <head>
     <meta charset="utf-8">
     <title>
@@ -42,7 +42,7 @@
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
   </head>
-  <body lang="{{lang}}">
+  <body>
     {{> components/nav}}
     <div id="main-content">
         {{~> page}}


### PR DESCRIPTION
`lang` attribute on `<html>` would also cover content in `<head>` e.g. `<title>`, which may matter in some context.