### PR TITLE
Add link tags for locales

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -26,6 +26,35 @@ lazy_static! {
     static ref FALLBACKS: HashMap<String, Vec<String>> = build_fallbacks();
 }
 
+#[derive(Serialize)]
+pub struct LocaleInfo {
+    pub lang: &'static str,
+    pub text: &'static str,
+}
+
+pub const EXPLICIT_LOCALE_INFO: &[LocaleInfo] = &[
+    LocaleInfo {
+        lang: "en-US",
+        text: "English",
+    },
+    LocaleInfo {
+        lang: "zh-CN",
+        text: "简体中文",
+    },
+    LocaleInfo {
+        lang: "zh-TW",
+        text: "正體中文",
+    },
+    LocaleInfo {
+        lang: "pt-BR",
+        text: "Português",
+    },
+    LocaleInfo {
+        lang: "tr",
+        text: "Türkçe",
+    },
+];
+
 pub fn build_fallbacks() -> HashMap<String, Vec<String>> {
     LOCALES
         .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ use sass_rs::{compile_file, Options};
 use category::Category;
 
 use caching::{Cached, Caching};
-use i18n::{I18NHelper, SupportedLocale, TeamHelper};
+use i18n::{I18NHelper, LocaleInfo, SupportedLocale, TeamHelper, EXPLICIT_LOCALE_INFO};
 use rocket::http::hyper::header::CacheDirective;
 
 lazy_static! {
@@ -89,6 +89,7 @@ struct Context<T: ::serde::Serialize> {
     baseurl: String,
     pontoon_enabled: bool,
     assets: AssetFiles,
+    locales: &'static [LocaleInfo],
 }
 
 impl<T: ::serde::Serialize> Context<T> {
@@ -109,6 +110,7 @@ impl<T: ::serde::Serialize> Context<T> {
             lang,
             pontoon_enabled: pontoon_enabled(),
             assets: ASSETS.clone(),
+            locales: EXPLICIT_LOCALE_INFO,
         }
     }
 }

--- a/templates/components/languages-dropdown.hbs
+++ b/templates/components/languages-dropdown.hbs
@@ -1,5 +1,3 @@
-<option title="English (US)" value="en-US">English (en-US)</option>
-<option title="中文 (zh-CN)" value="zh-CN">简体中文 (zh-CN)</option>
-<option title="中文 (zh-TW)" value="zh-TW">正體中文 (zh-TW)</option>
-<option title="Português (pt-BR)" value="pt-BR">Português (pt-BR)</option>
-<option title="Turkish" value="tr">Türkçe (tr)</option>
+{{#each locales as |locale| ~}}
+    <option title="{{locale.text}} ({{locale.lang}})" value="{{locale.lang}}">{{locale.text}} ({{locale.lang}})</option>
+{{/each~}}

--- a/templates/components/layout.hbs
+++ b/templates/components/layout.hbs
@@ -41,6 +41,13 @@
     <link rel="mask-icon" href="/static/images/safari-pinned-tab.svg" color="#5bbad5">
     <meta name="msapplication-TileColor" content="#00aba9">
     <meta name="theme-color" content="#ffffff">
+
+    {{#if is_landing}}
+        <!-- locales -->
+        {{#each locales as |locale| ~}}
+            <link rel="alternate" href="/{{locale.lang}}" hreflang="{{locale.lang}}">
+        {{/each~}}
+    {{/if}}
   </head>
   <body lang="{{lang}}">
     {{> components/nav}}


### PR DESCRIPTION
Add `<link>` tags on landing pages to link different locales. This should help tools like search engines to discover the pages.

To reuse the language info, the list is moved from `languages-dropdown.hbs` into `i18n.rs` and stored structurally.

Ideally we should be able to generate such tags for all pages, but we don't have URL 