### PR TITLE
fix 'get started' section image/column stretching

### DIFF
--- a/templates/components/what/wasm/get-started.hbs
+++ b/templates/components/what/wasm/get-started.hbs
@@ -6,8 +6,8 @@
         </header>
         <div class="flex flex-column flex-row-l pv4 pv0-l">
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
-                <div class="v-top tc-l h-25-ns">
-                    <img src="/static/images/webassembly-logo.svg" alt="{{text wasm-get-started-wasm-alt}}" class="mw3 mw5-ns h-100-ns" />
+                <div class="v-top tc-l">
+                    <img src="/static/images/webassembly-logo.svg" alt="{{text wasm-get-started-wasm-alt}}" class="mw3 mw-100-ns w5-m h4-l" />
                 </div>
                 <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l pl4-l w-100">
                     <p class="flex-grow-1">
@@ -17,8 +17,8 @@
                 </div>
             </div>
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
-                <div class="v-top tc-l h-25-ns">
-                    <img src="/static/images/wasm-ferris.png" alt="{{text wasm-get-started-book-alt}}" class="mw3 mw5-ns h-100-ns" />
+                <div class="v-top tc-l">
+                    <img src="/static/images/wasm-ferris.png" alt="{{text wasm-get-started-book-alt}}" class="mw3 mw-100-ns w5-m h4-l" />
                 </div>
                 <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l pl4-l w-100">
                     <p class="flex-grow-1">
@@ -28,8 +28,8 @@
                 </div>
             </div>
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">
-                <div class="v-top tc-l h-25-ns">
-                    <img src="/static/images/mdn-logo.svg" alt="{{text wasm-get-started-mdn-alt}}" class="mw3 mw5-ns h-100-ns" />
+                <div class="v-top tc-l">
+                    <img src="/static/images/mdn-logo.svg" alt="{{text wasm-get-started-mdn-alt}}" class="mw3 mw-100-ns w5-m h4-l" />
                 </div>
                 <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l pl4-l w-100">
                     <p class="flex-grow-1">


### PR DESCRIPTION
Resolves #903 by not using percentage heights. An alternative to #904.