### PR TITLE
Add a privacy notice for all projects managed by Rust teams

### DIFF
--- a/locales/en-US/policies.ftl
+++ b/locales/en-US/policies.ftl
@@ -9,6 +9,7 @@ policies-code-of-conduct-link = Code of Conduct
 policies-licenses-link = Licenses
 policies-media-guide-link = Logo Policy and Media Guide
 policies-security-link = Security Disclosures
+policies-privacy-link = Privacy Notice
 
 policies-reach-out-description = Didn’t find what you were looking for? Have a question? Please reach out!
 policies-reach-out-link = Message the Core Team

--- a/locales/en-US/privacy.ftl
+++ b/locales/en-US/privacy.ftl
@@ -1,0 +1,5 @@
+### Translation file for page: https://www.rust-lang.org/policies/privacy
+
+## templates/policies/privacy.hbs
+
+policies-privacy-page-title = Rust Privacy Notice

--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -22,6 +22,7 @@
           <li><a href="{{baseurl}}/policies/licenses">{{text footer-licenses}}</a></li>
           <li><a href="{{baseurl}}/policies/media-guide">{{text footer-media}}</a></li>
           <li><a href="{{baseurl}}/policies/security">{{text footer-security}}</a></li>
+          <li><a href="{{baseurl}}/policies/privacy">{{text policies-privacy-link}}</a></li>
           <li><a href="{{baseurl}}/policies">{{text footer-policies-all}}</a></li>
         </ul>
       </div>

--- a/templates/policies/index.hbs
+++ b/templates/policies/index.hbs
@@ -14,6 +14,7 @@
       <li><a href="{{baseurl}}/policies/licenses">{{text policies-licenses-link}}</a></li>
       <li><a href="{{baseurl}}/policies/media-guide">{{text policies-media-guide-link}}</a></li>
       <li><a href="{{baseurl}}/policies/security">{{text policies-security-link}}</a></li>
+      <li><a href="{{baseurl}}/policies/privacy">{{text policies-privacy-link}}</a></li>
     </ul>
     <p>{{text policies-reach-out-description}}</p>
     <p><a href="mailto:core@rust-lang.org" class="button button-secondary">{{text policies-reach-out-link}}</a></p>

--- a/templates/policies/privacy.hbs
+++ b/templates/policies/privacy.hbs
@@ -169,7 +169,7 @@
     </p>
 
     <p>
-      Some Rust community members use the Zulip and Discord platforms for
+      Some Rust team members use the Zulip and Discord platforms for
       community collaboration. Zulip’s privacy notice is available
       <a href="https://zulipchat.com/privacy/">here</a>.
       Discord’s privacy notice is available

--- a/templates/policies/privacy.hbs
+++ b/templates/policies/privacy.hbs
@@ -1,0 +1,203 @@
+{{#*inline "page"}}
+
+<header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
+  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
+    <h1>{{text policies-privacy-page-title}}</h1>
+  </div>
+</header>
+
+<section id="privacy-notice" class="purple">
+  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
+    <p>Version 1.0, dated <time datetime="2019-08-19">2019-08-19</time></p>
+
+    <p>
+      The Rust Project oversees a number of projects, including the
+      <a href="{{baseurl}}/">Rust website</a>,
+      <a href="https://crates.io">crates.io</a>, and
+      <a href="https://docs.rs">docs.rs</a>. This privacy notice explains what
+      we do with personal information.
+    </p>
+
+    <header>
+      <h2 id="rust-www">rust-lang.org</h2>
+      <div class="highlight"></div>
+    </header>
+
+    <p>
+      The Rust website at <a href="{{baseurl}}/">rust-lang.org</a> is a project
+      of the <a href="{{baseurl}}/governance/teams/core">Core team</a> and the
+      <a href="{{baseurl}}/governance/teams/community">Community team.</a>
+    </p>
+
+    <dl>
+      <dt>Visitor logs:</dt>
+      <dd>
+        When you visit rust-lang.org, we receive your IP address as part of
+        our standard server logs. We store these logs for 1 year.
+      </dd>
+    </dl>
+
+    <header>
+      <h2 id="crates-io">crates.io</h2>
+      <div class="highlight"></div>
+    </header>
+
+    <p>
+      <a href="https://crates.io">Crates.io</a> is managed by members of the
+      <a href="{{baseurl}}/governance/teams/crates-io">Crates.io</a> and
+      <a href="{{baseurl}}/governance/teams/core">Rust core</a> teams.
+    </p>
+
+    <dl>
+      <dt>Logging in with GitHub:</dt>
+      <dd>
+        <p>
+          Crates.io requires users to have a
+          <a href="https://www.mozilla.org/firefox/accounts/">GitHub account</a>
+          in order to log in and use the service. When you log-in to Crates.io
+          using a GitHub account, we receive your GitHub username and avatar. If
+          you share a display name or public email address in your GitHub public
+          profile, we also receive that information.
+        </p>
+      </dd>
+
+      <dt>Email addresses:</dt>
+      <dd>
+        <p>
+          You must have a verified email address to publish a crate. We receive
+          any public email address associated with your GitHub account. You can
+          also choose to submit a different address to associate with your
+          Crates.io activity. We will only use your email address to contact you
+          about your account.
+        </p>
+      </dd>
+
+      <dt>Visitor logs:</dt>
+      <dd>
+        <p>
+          When you visit Crates.io, we receive your IP address and user-agent
+          header as part of our standard server logs. We store these logs for 1
+          year.
+        </p>
+      </dd>
+
+      <dt>Information uploaded to crates:</dt>
+      <dd>
+        <p>
+          All crates on Crates.io are public, including the list of crate owners’
+          user names and its upload date. Anyone may view or download a crates’
+          contents. Because of the public nature of Crates.io any personal data
+          you might include in a Cargo.toml file uploaded to a create will be
+          publicly available. For example, if an email address is in the author’s
+          field in the Cargo.toml file, that email address will also be public.
+        </p>
+        <p>
+          Due to its public nature, be aware if you include any private
+          information in a crate that information may be indexed by search
+          engines or used by third parties. Sensitive information should not be
+          included in a crate file.
+        </p>
+      </dd>
+
+      <dt>Publication of site-related data: </dt>
+      <dd>
+        <p>
+          Crates.io uses the Google Visualization API to create graphs for each
+          crate showing downloads over the last 90 days. Those graphs can be seen
+          at the bottom of each crate’s page.
+        </p>
+      </dd>
+    </dl>
+
+    <header>
+      <h2 id="docs-rs">docs.rs</h2>
+      <div class="highlight"></div>
+    </header>
+
+    <p>
+      <a href="https://docs.rs">Docs.rs</a> is managed by the members of the
+      <a href="{{baseurl}}/governance/teams/dev-tools#rustdoc">Rustdoc team</a>
+      and <a href="{{baseurl}}/governance/teams/core">Rust core team</a>. The
+      project collects and uses data as described in this privacy notice.
+    </p>
+
+    <p>
+      Docs.rs is an open source project to host documentation of crates for the
+      Rust Programming Language. It automatically builds crates' documentation
+      released on <a href="https://crates.io">crates.io</a> using the nightly
+      release of the Rust compiler. All information from crates that is
+      published on docs.rs is also available publicly on crates.io.
+    </p>
+
+    <header>
+      <h2 id="forums">Forums</h2>
+      <div class="highlight"></div>
+    </header>
+
+    <p>
+      <a href="{{baseurl}}/governance/teams/community">The Rust Community team</a>
+      administers the
+      <a href="https://users.rust-lang.org">Users Forum</a> and the
+      <a href="https://internals.rust-lang.org">Internals Forum</a>. Posts on
+      these forums are public. If you sign-up to participate in these forums, we
+      collect your email address and name. As administrators of the forum, we
+      have access to usage information regarding your interactions with it, such
+      as posts published and read, and time spent on the site.
+    </p>
+
+    <header>
+      <h2 id="third-party">Third-party Services</h2>
+      <div class="highlight"></div>
+    </header>
+
+    <p>
+      The Users Forum and Internals Forum on rust-lang.org are hosted by
+      <a href="https://www.discourse.org/">Discourse</a> and use its open source
+      discussion platform. Discourse’s privacy policy is available
+      <a href="https://www.discourse.org/privacy">here</a>.
+    </p>
+
+    <p>
+      We use Mailgun to send email. Mailgun’s privacy policy is available
+      <a href="https://www.mailgun.com/privacy-policy">here</a>.
+    </p>
+
+    <p>
+      GitHub login is used for authentication in Crates.io and (optionally) in
+      the forums. GitHub’s Privacy Statement can be found
+      <a href="https://help.github.com/en/articles/github-privacy-statement">here</a>.
+    </p>
+
+    <p>
+      Some Rust community members use the Zulip and Discord platforms for
+      community collaboration. Zulip’s privacy notice is available
+      <a href="https://zulipchat.com/privacy/">here</a>.
+      Discord’s privacy notice is available
+      <a href="https://discordapp.com/privacy">here</a>.
+    </p>
+
+    <header>
+      <h2 id="contact">Contact</h2>
+      <div class="highlight"></div>
+    </header>
+
+    <p>
+      For data subject access requests, or any questions about this privacy
+      notice, please email support at
+      <a href="mailto:privacy@rust-lang.org">privacy@rust-lang.org</a>
+    </p>
+
+    <p>Alternatively, you may contact us at:</p>
+
+    <address>
+      Mozilla Corporation<br>
+      Attn: Legal Notices - Privacy<br>
+      331 E. Evelyn Ave,<br>
+      Mountain View, CA 94041
+    </address>
+
+  </div>
+</section>
+
+{{/inline}}
+{{~> (parent)~}}

--- a/templates/policies/privacy.hbs
+++ b/templates/policies/privacy.hbs
@@ -87,7 +87,7 @@
           All crates on Crates.io are public, including the list of crate owners’
           user names and its upload date. Anyone may view or download a crates’
           contents. Because of the public nature of Crates.io any personal data
-          you might include in a Cargo.toml file uploaded to a create will be
+          you might include in a Cargo.toml file uploaded to a crate will be
           publicly available. For example, if an email address is in the author’s
           field in the Cargo.toml file, that email address will also be public.
         </p>


### PR DESCRIPTION
This adds a new page containing a privacy notice. This notice includes
sections for rust-lang.org, crates.io, docs.rs, the forums, and other
third party services we use but do not manage (such as Discord). The
intention is that we will link to this page from across the org. The
forums will also link to Discourse's privacy policy.

Since this is a legal document, I'm not certain that we can publish
community translations for this (or at least I'd want to confirm with
lawyers that it's safe for us to do so). As such, in the interest of
time, I've opted to leave the markup inline rather than slicing it up.
If this is a blocker for publication, I can take the time to break it
apart -- but we should get this out sooner rather than later.