### PR TITLE
Improve section title legibility 

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -115,7 +115,6 @@ code.code-header {
 }
 
 header h1, section h2 {
-  font-family: $header-font;
   z-index: 999999;
   position: relative;
   letter-spacing: 1px;
@@ -123,11 +122,13 @@ header h1, section h2 {
 }
 
 header h1 {
+  font-family: $header-font;
   font-size: 8rem;
   margin-bottom: 0;
   margin-top: 0;
   line-height: 1.2;
   font-weight: 300;
+  letter-spacing: 1px;
 }
 
 header h2 {
@@ -184,7 +185,13 @@ section {
     }
   }
 
+  h2 {
+      font-family: $body-font;
+      font-weight: 800;
+  }
+
   h3 {
+    font-weight: 600;
     line-height: 1.3;
   }
 
@@ -344,7 +351,7 @@ a.brand {
 }
 
 h3 {
-  font-weight: 800; 
+  font-weight: 600;
   font-size: 1.5em;
   letter-spacing: normal;
 }
@@ -356,10 +363,6 @@ h3 {
 .get-involved .media {
   padding-bottom: 20px;
   border-bottom: 1px dotted white;
-}
-
-header h1 {
-  letter-spacing: 1px;
 }
 
 .highlight {
@@ -404,7 +407,7 @@ footer {
 
 footer h4 {
   font-size: 1.2em;
-  font-weight: 800;
+  font-weight: 600;
   margin-top: 0;
   margin-bottom: 2rem;
 }


### PR DESCRIPTION
This PR changes the font for `h2`'s to use Fira Sans Extra Bold, over the Alfa Slab One typeface. The reasoning for this is that I find Alfa Slab One to be hard to read outside of large title type. The spacing is incredibly tight, to the point that it can be hard to read even on high resolution displays. I initially attempted to only change the spacing, however Alfa Slab One looks best when it is compressed, when spaced out the letters feel far from each other.

So I tried changing the typeface to Fira Sans, and I found it to be a significant improvement. In order to maintain a visual hierarchy I also reduced the weight of `h3` and `h4`'s to Semi Bold, so that they were still clearly distinct from both the body text and their headers.

I've included screenshots below of some of the main areas this change impacts. 

### Landing page
![homepage-diff](https://user-images.githubusercontent.com/4464295/64908059-5e601000-d6fb-11e9-89a4-2d01327389ac.jpg)

### CLI feature list
![font-change-list](https://user-images.githubusercontent.com/4464295/64908062-69b33b80-d6fb-11e9-8776-26e0c70b3277.jpg)

### Footer
![footer-diff](https://user-images.githubusercontent.com/4464295/64908063-6e77ef80-d6fb-11e9-9d75-9f02e9bc13f5.jpg)