### PR TITLE
Add timetill.rs to the community page.

### DIFF
--- a/locales/en-US/community.ftl
+++ b/locales/en-US/community.ftl
@@ -33,6 +33,7 @@ community-meetup-header = Find a local meetup or conference
 community-meetup = There are more than 90 Meetups and several conferences worldwide in over 35 countries. Rustaceans meet periodically in Rust User Groups. They are a great introduction to the community and a great way to learn and socialize with other people with a similar interest. Meetings are usually informal and open to everyone.
 community-calendar = View Calendar
 community-conference-lineup = Check out the 2019 Conference Lineup
+community-timetill-cta = See conference lineup on timetill.rs
 
 community-event-run-header = Run your own event
 community-event-run =

--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -105,6 +105,11 @@
             <a href="https://blog.rust-lang.org/2019/05/20/The-2019-Rust-Event-Lineup.html"
               class="button button-secondary">{{text community-conference-lineup}}</a>
           </li>
+          <li class="mb3">
+            <a href="https://timetill.rs"
+              target="_blank"
+              class="button button-secondary">{{text community-timetill-cta}}</a>
+          </li>
         </ul>
       </div>
       <div class="mw-50-l mh3-l pt4 pt0-l flex flex-column justify-between" id="conferences">


### PR DESCRIPTION
This adds timetill.rs to list of event call to actions on the community page.

resolves #914 

<img width="1319" alt="Screenshot 2019-09-14 at 14 39 36" src="https://user-images.githubusercontent.com/4464295/64908221-7c2e7480-d6fd-11e9-80c0-e98486e8d72c.png">
