### PR TITLE
Link updated for Eclipse Rust (Sep/2019)

### DIFF
--- a/templates/components/tools/editors.hbs
+++ b/templates/components/tools/editors.hbs
@@ -16,7 +16,7 @@
        class="button button-secondary">{{text tools-editor-idea}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://www.eclipse.org/downloads/packages/release/2018-12/r/eclipse-ide-rust-developers-includes-incubating-components"
+    <a href="https://www.eclipse.org/downloads/packages/release/2019-09/r/eclipse-ide-rust-developers-includes-incubating-components"
        class="button button-secondary">{{text tools-editor-eclipse}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">


### PR DESCRIPTION
Just updating the link. Otherwise it would take the user to the full list of downloads available on Eclipse.org.