### PR TITLE
Bump the team repo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1515,7 +1515,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#493ec0fc201e09b6eebde443ed621c025398bbb8"
+source = "git+https://github.com/rust-lang/team#8d8902d7d4d3542f131f9dc7e7fde83732d92e88"
 dependencies = [
  "indexmap 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.91 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -60,6 +60,7 @@ impl Data {
             .for_each(|team| match team.team.kind {
                 TeamKind::Team => data.teams.push(team),
                 TeamKind::WorkingGroup => data.wgs.push(team),
+                _ => {}
             });
 
         data.teams.sort_by_key(|index_team| {
@@ -97,6 +98,7 @@ impl Data {
             .for_each(|team| match team.kind {
                 TeamKind::Team => subteams.push(team),
                 TeamKind::WorkingGroup => wgs.push(team),
+                _ => {}
             });
 
         Ok(PageData {
@@ -132,6 +134,7 @@ fn kind_to_str(kind: TeamKind) -> &'static str {
     match kind {
         TeamKind::Team => "teams",
         TeamKind::WorkingGroup => "wgs",
+        _ => "UNSUPPORTED",
     }
 }
 
@@ -166,11 +169,13 @@ mod tests {
                     name: "John Doe".into(),
                     github: "johnd".into(),
                     is_lead: false,
+                    github_id: 1234,
                 },
                 TeamMember {
                     name: "Jane Doe".into(),
                     github: "janed".into(),
                     is_lead: true,
+                    github_id: 1234,
                 },
             ],
             website_data: Some(TeamWebsite {
@@ -182,6 +187,7 @@ mod tests {
                 discord: None,
                 weight: 0,
             }),
+            github: None,
         }
     }
 


### PR DESCRIPTION
This PR bumps the team repo to the latest commit. This is needed because a recent change in the repo added a new kind of team, and unfortunately the enum representing it was not exaustive. The bump both adds support for the new kind of team, and makes the enum not exaustive to avoid future issues like this.

The new variant (marker-team) will not be shown on the website.