### PR TITLE
i18n: only load .ftl files as fluent files

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -385,6 +385,12 @@ pub fn read_from_dir<P: AsRef<Path>>(dirname: P) -> io::Result<Vec<FluentResourc
     let mut result = Vec::new();
     for dir_entry in read_dir(dirname)? {
         let entry = dir_entry?;
+
+        // Prevent loading non-FTL files as translations, such as VIM temporary files.
+        if entry.path().extension().and_then(|e| e.to_str()) != Some("ftl") {
+            continue;
+        }
+
         let resource = read_from_file(entry.path())?;
         result.push(resource);
     }


### PR DESCRIPTION
While I was working on the localization the application kept panicking at startup, because VIM creates temporary files inside the directory containing the originals, and those files are not valid UTF-8.

This commit changes the localization code to only load `.ftl` files from the `locales/` directory, preventing such issues from happening again.

r? @Manishearth 