### PR TITLE
Add sentence about rustup update on getting started page, (issue #699)

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -74,6 +74,8 @@ learn-play-button = Try Rust without installing
 
 learn-install-rustup-header = Rustup: the Rust installer and version management tool
 learn-install-rustup = The primary way that folks install Rust is through a tool called Rustup, which is a Rust installer and version management tool.
+learn-install-rustup-update-header = Is rustup up to date?
+learn-install-rustup-update = Rust updates very frequently. If you have installed Rustup some time ago, chances are your Rust version is out of date. Get the latest version of Rust by running { $update-command }.
 learn-install-rustup-button = Learn more about installation
 
 

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -20,7 +20,10 @@
     <h3>{{fluent "learn-install-rustup-header"}}</h3>
     <p>{{fluent "learn-install-rustup"}}</p>
     {{> components/tools/rustup }}
-    <br /><br />
+    <br />
+    <h3>{{fluent "learn-install-rustup-update-header"}}</h3>
+    <p>{{#fluent "learn-install-rustup-update"}}{{#fluentparam "update-command"}}<code>rustup update</code>{{/fluentparam}}{{/fluent}}</p>
+    <br />
     <a href="{{baseurl}}/tools/install" class="button button-secondary">{{fluent "learn-install-rustup-button"}}</a>
     <hr />
 
@@ -111,7 +114,7 @@ fn main() {
     </code></pre>
     {{/fluentparam}}
     {{/fluent}}
-    
+
   </div>
 </section>
 


### PR DESCRIPTION
Hello fine people!
I've browsed the issues and found #699.
Here you go!
It looks like this:

![2020-01-27_19-14](https://user-images.githubusercontent.com/1006478/73201729-f6561780-4139-11ea-960d-8d166ae196e0.png)


Let me know what you think or if you want different copy. I could also provide the German locale if desired. 

Edit: updated the screenshot (again)
