### PR TITLE
Minor bugfix on embedded testimonials

### DIFF
--- a/templates/components/what/embedded/testimonials.hbs
+++ b/templates/components/what/embedded/testimonials.hbs
@@ -39,14 +39,14 @@
       <div class="testimonial flex-none flex-l">
         <div class="w-100 w-30-l tc">
           <a href="https://49nord.de/">
-            <img alt="{{fluent "embedded-testimonials-"49nord-alt}}" src="/static/images/user-logos/49nord.svg"/>
+            <img alt="{{fluent "embedded-testimonials-49nord-alt}}" src="/static/images/user-logos/49nord.svg"/>
           </a>
         </div>
         <div class="w-100 w-70-l" id="brinkmann-testimonial">
           <blockquote class="lh-title-ns">
-            {{fluent "embedded-testimonials-"49nord-quote}}
+            {{fluent "embedded-testimonials-49nord-quote}}
           </blockquote>
-          <p class="attribution">{{fluent "embedded-testimonials-"49nord-attribution}}</p>
+          <p class="attribution">{{fluent "embedded-testimonials-49nord-attribution}}</p>
         </div>
       </div>
 

--- a/templates/components/what/embedded/testimonials.hbs
+++ b/templates/components/what/embedded/testimonials.hbs
@@ -39,14 +39,14 @@
       <div class="testimonial flex-none flex-l">
         <div class="w-100 w-30-l tc">
           <a href="https://49nord.de/">
-            <img alt="{{fluent "embedded-testimonials-49nord-alt}}" src="/static/images/user-logos/49nord.svg"/>
+            <img alt="{{fluent "embedded-testimonials-49nord-alt"}}" src="/static/images/user-logos/49nord.svg"/>
           </a>
         </div>
         <div class="w-100 w-70-l" id="brinkmann-testimonial">
           <blockquote class="lh-title-ns">
-            {{fluent "embedded-testimonials-49nord-quote}}
+            {{fluent "embedded-testimonials-49nord-quote"}}
           </blockquote>
-          <p class="attribution">{{fluent "embedded-testimonials-49nord-attribution}}</p>
+          <p class="attribution">{{fluent "embedded-testimonials-49nord-attribution"}}</p>
         </div>
       </div>
 


### PR DESCRIPTION
There was a stray `"` in the fluent strings that was breaking output for one of the testimonials. Saw it on the site and figured it should be an easy fix.

Happy holidays!