### PR TITLE
Add .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+locales/* linguist-documentation


### PR DESCRIPTION
This adds a .gitattributes to hide the inaccurate code stats on GitHub, as it counts Fluent files as FreeMarker.