### PR TITLE
Use a more saturated colour scheme

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -3,14 +3,14 @@
 $body-font: "Fira Sans", Helvetica, Arial, sans-serif;
 $header-font: "Alfa Slab One", serif;
 
-$gray: #454c52;
-$red: #c14566;
-$green: #398277;
-$purple: #403d58;
-$yellow: #ffd45e;
+$gray: #2a3439;
+$red: #a72145;
+$green: #0b7261;
+$purple: #432866;
+$yellow: #ffc832;
 $border-radius: 4px;
-$link-color: #1eaedb;
-$footer-gray: #303030;
+$link-color: #4299bf;
+$footer-gray: $gray;
 
 html {
   font-size: 62.5%;


### PR DESCRIPTION
This PR changes the colour scheme to be more bright and saturated. This should improve some of the legibility issues.

### Screenshots (Original / New Colours)

<img width="1680" alt="Screenshot 2020-01-27 at 21 37 04" src="https://user-images.githubusercontent.com/4464295/73211910-68842780-414d-11ea-95db-5ffff65e515d.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 35 21" src="https://user-images.githubusercontent.com/4464295/73211912-68842780-414d-11ea-817b-584f674cb60a.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 35 16" src="https://user-images.githubusercontent.com/4464295/73211913-691cbe00-414d-11ea-8a35-3de79ecbc336.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 35 03" src="https://user-images.githubusercontent.com/4464295/73211914-691cbe00-414d-11ea-847e-122ed2c2a5fa.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 34 50" src="https://user-images.githubusercontent.com/4464295/73211915-691cbe00-414d-11ea-92fe-2a74cbd6995c.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 34 44" src="https://user-images.githubusercontent.com/4464295/73211916-691cbe00-414d-11ea-887d-9b1128606bc0.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 34 32" src="https://user-images.githubusercontent.com/4464295/73211917-691cbe00-414d-11ea-9637-bed1ae7cd852.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 34 25" src="https://user-images.githubusercontent.com/4464295/73211918-69b55480-414d-11ea-927e-bdab4714e733.png">
<img width="1680" alt="Screenshot 2020-01-27 at 21 34 16" src="https://user-images.githubusercontent.com/4464295/73211920-69b55480-414d-11ea-9084-bc4287892811.png">
 