### PR TITLE
Use active descriptions for domain buttons

### DIFF
--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -10,6 +10,13 @@ production-use = Production use
 learn-more = Learn More
 discord = Discord
 
+## components/panels/domain.hbs
+
+cli-learn-more = Building Tools
+wasm-learn-more = Writing Web Apps
+net-learn-more = Working On Servers
+embedded-learn-more = Starting With Embedded
+
 ## components/layout.hbs
 
 meta-description = A language empowering everyone to build reliable and efficient software.

--- a/templates/components/panels/domains.hbs
+++ b/templates/components/panels/domains.hbs
@@ -26,7 +26,7 @@
           <p class="flex-grow-1">
             {{fluent "domains-cli-blurb"}}
           </p>
-          <a href="{{baseurl}}/what/cli" class="button button-secondary">{{fluent "learn-more"}}</a>
+          <a href="{{baseurl}}/what/cli" class="button button-secondary">{{fluent "cli-learn-more"}}</a>
         </div>
       </div>
 
@@ -42,7 +42,7 @@
           <p class="flex-grow-1">
           {{fluent "domains-wasm-blurb"}}
           </p>
-          <a href="{{baseurl}}/what/wasm" class="button button-secondary">{{fluent "learn-more"}}</a>
+          <a href="{{baseurl}}/what/wasm" class="button button-secondary">{{fluent "wasm-learn-more"}}</a>
         </div>
       </div>
 
@@ -58,7 +58,7 @@
           <p class="flex-grow-1">
             {{fluent "domains-net-blurb"}}
           </p>
-          <a href="{{baseurl}}/what/networking" class="button button-secondary">{{fluent "learn-more"}}</a>
+          <a href="{{baseurl}}/what/networking" class="button button-secondary">{{fluent "net-learn-more"}}</a>
         </div>
       </div>
 
@@ -74,7 +74,7 @@
           <p class="flex-grow-1">
             {{fluent "domains-embedded-blurb"}}
           </p>
-          <a href="{{baseurl}}/what/embedded" class="button button-secondary">{{fluent "learn-more"}}</a>
+          <a href="{{baseurl}}/what/embedded" class="button button-secondary">{{fluent "embedded-learn-more"}}</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
The current button descriptions are simply "Learn More", which is generic and passive. This PR adds a more active call to action.

<img width="1240" alt="Screenshot 2020-01-28 at 14 50 03" src="https://user-images.githubusercontent.com/4464295/73269644-7f725a80-41dd-11ea-82e2-bc1f2cb8d4ea.png">
<img width="1680" alt="Screenshot 2020-01-28 at 14 49 49" src="https://user-images.githubusercontent.com/4464295/73269645-7f725a80-41dd-11ea-95c4-814be8c5e366.png">
