### PR TITLE
Remove white from code background

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -47,7 +47,6 @@ code {
   margin: 0 0.2rem;
   font-size: 90%;
   white-space: nowrap;
-  background: #f1f1f1;
   border: 1px solid #e1e1e1;
   border-radius: 4px;
   overflow: auto;


### PR DESCRIPTION
While looking into another issue I noticed the code snippets have a white background that makes them impossible to see, this PR fixes that.
<img width="1668" alt="Screenshot 2020-02-01 at 10 36 28" src="https://user-images.githubusercontent.com/4464295/73590110-e09c7580-44de-11ea-98cd-5004836bb3ba.png">
