### PR TITLE
Update footer attribution

### DIFF
--- a/locales/de/common.ftl
+++ b/locales/de/common.ftl
@@ -44,7 +44,7 @@ footer-discord-alt = { discord }
 footer-github-alt = GitHub
 footer-attribution =
     Gepflegt vom Rust-Team. Fehler gefunden?
-    <a href="https://github.com/rust-lang/www.rust-lang.org">Korrektur einreichen</a>!
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Korrektur einreichen!</a>
 footer-old-site = Suchst du die <a href="https://prev.rust-lang.org">vorige Version der Website</a>?
 
 ## what/index.hbs

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -56,8 +56,8 @@ footer-alt-youtube = youtube logo
 footer-discord-alt = { discord }
 footer-github-alt = GitHub
 
-footer-attribution = Maintained by the Rust Team. See a typo?
-        <a href="https://github.com/rust-lang/www.rust-lang.org">Send a fix here</a>!
+footer-attribution = Maintained by the Rust Team. See a bug?
+        <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">File an issue!</a>
 
 footer-old-site = Looking for the <a href="https://prev.rust-lang.org">previous website</a>?
 

--- a/locales/es/common.ftl
+++ b/locales/es/common.ftl
@@ -44,7 +44,7 @@ footer-discord-alt = { discord }
 footer-github-alt = GitHub
 footer-attribution =
     Mantenida por el equipo de Rust. ¿Hay algún error?
-    ¡<a href="https://github.com/rust-lang/www.rust-lang.org">Arréglalo aquí</a>!
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">¡Arréglalo aquí!</a>
 footer-old-site = ¿Buscas la <a href="https://prev.rust-lang.org">web antigua</a>?
 
 ## what/index.hbs

--- a/locales/fr/common.ftl
+++ b/locales/fr/common.ftl
@@ -42,7 +42,7 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = Logo YouTube
 footer-discord-alt = { discord }
 footer-github-alt = GitHub
-footer-attribution = Maintenu par l’équipe de Rust. Vous avez trouvé une erreur ? <a href="https://github.com/rust-lang/www.rust-lang.org">Envoyez-nous une correction</a>!
+footer-attribution = Maintenu par l’équipe de Rust. Vous avez trouvé une erreur ? <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Envoyez-nous une correction!</a>
 footer-old-site = Vous cherchez l'ancien <a href="https://prev.rust-lang.org">site web</a> ?
 
 ## what/index.hbs

--- a/locales/it/common.ftl
+++ b/locales/it/common.ftl
@@ -44,7 +44,7 @@ footer-discord-alt = { discord }
 footer-github-alt = GitHub
 footer-attribution =
     Mantenuto dal Team Rust. Vedi un errore?
-    <a href="https://github.com/rust-lang/www.rust-lang.org">manda una correzione qui</a>!
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">manda una correzione qui!</a>
 footer-old-site = Stavi cercando il <a href="https://prev.rust-lang.org">vecchio sito</a>?
 
 ## what/index.hbs

--- a/locales/ja/common.ftl
+++ b/locales/ja/common.ftl
@@ -42,7 +42,7 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = youtubeのロゴ
 footer-discord-alt = { discord }
 footer-github-alt = GitHub
-footer-attribution = Rustチームによって管理されています。誤字を見つけましたか？<a href="https://github.com/rust-lang/www.rust-lang.org">修正を送ってください</a>！
+footer-attribution = Rustチームによって管理されています。誤字を見つけましたか？<a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">修正を送ってください！</a>
 footer-old-site = <a href="https://prev.rust-lang.org">以前のウェブサイト</a>をお探しですか？
 
 ## what/index.hbs

--- a/locales/pt-BR/common.ftl
+++ b/locales/pt-BR/common.ftl
@@ -44,7 +44,7 @@ footer-discord-alt = { discord }
 footer-github-alt = GitHub
 footer-attribution =
     Mantido pela Equipe Rust. Encontrou algum erro?
-    <a href="https://github.com/rust-lang/www.rust-lang.org">Envie uma correção aqui</a>!
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Envie uma correção aqui!</a>
 footer-old-site = Procurando pelo <a href="https://prev.rust-lang.org">site antigo</a>?
 
 ## what/index.hbs

--- a/locales/ru/common.ftl
+++ b/locales/ru/common.ftl
@@ -43,7 +43,7 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = Логотип youtube
 footer-discord-alt = { discord }
 footer-github-alt = GitHub
-footer-attribution = Поддерживается Rust Team. Увидели опечатку? <a href="https://github.com/rust-lang/www.rust-lang.org">Исправьте здесь</a>!
+footer-attribution = Поддерживается Rust Team. Увидели опечатку? <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Исправьте здесь!</a>
 footer-old-site = Ищете <a href="https://prev.rust-lang.org">предыдущий сайт</a>?
 
 ## what/index.hbs

--- a/locales/tr/common.ftl
+++ b/locales/tr/common.ftl
@@ -44,7 +44,7 @@ footer-discord-alt = { discord }
 footer-github-alt = GitHub
 footer-attribution =
     Rust Ekibi tarafından geliştirilmektedir. Yazım hatasına mı rastladınız?
-    <a href="https://github.com/rust-lang/www.rust-lang.org">Düzeltmeyi buraya gönderin</a>!
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Düzeltmeyi buraya gönderin!</a>
 footer-old-site = <a href="https://prev.rust-lang.org">Önceki siteye</a> mi bakıyorsunuz?
 
 ## what/index.hbs

--- a/locales/xx-AU/common.ftl
+++ b/locales/xx-AU/common.ftl
@@ -31,6 +31,6 @@ footer-youtube-alt = ɹǝʇʇᴉʍ┴
 footer-alt-youtube = oƃol ǝqnʇnoʎ
 footer-discord-alt = pɹoɔsᴉp
 footer-github-alt = qnHʇᴉפ
-footer-attribution = ¡ <a href="https://github.com/rust-lang/www.rust-lang.org">ǝɹǝɥ xᴉɟ ɐ puǝS</a>
+footer-attribution = <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">¡ ǝɹǝɥ xᴉɟ ɐ puǝS</a>
         ¿odʎʇ ɐ ǝǝS ˙ɯɐǝ┴ ʇsnɹ ǝɥʇ ʎq pǝuᴉɐʇuᴉɐW
 footer-old-site = <a href="https://prev.rust-lang.org">ǝʇᴉsqǝʍ snoᴉʌǝɹd</a> ǝɥʇ ɹoɟ ƃuᴉʞoo˥

--- a/locales/zh-CN/common.ftl
+++ b/locales/zh-CN/common.ftl
@@ -44,7 +44,7 @@ footer-discord-alt = { discord }
 footer-github-alt = GitHub
 footer-attribution =
     由 Rust 团队维护。发现了错别字？
-    <a href="https://github.com/rust-lang/www.rust-lang.org">在这里提交修复</a>！
+    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">在这里提交修复！</a>
 footer-old-site = 想要查看<a href="https://prev.rust-lang.org">旧版网站</a>？
 
 ## what/index.hbs

--- a/locales/zh-TW/common.ftl
+++ b/locales/zh-TW/common.ftl
@@ -42,7 +42,7 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = youtube 標誌
 footer-discord-alt = { discord }
 footer-github-alt = GitHub
-footer-attribution = 由 Rust 團隊維護，發現錯字了嗎？<a href="https://github.com/rust-lang/www.rust-lang.org">請在此提交修復</a>！
+footer-attribution = 由 Rust 團隊維護，發現錯字了嗎？<a href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">請在此提交修復！</a>
 footer-old-site = 想查看<a href="https://prev.rust-lang.org">舊版網站</a>嗎？
 
 ## what/index.hbs


### PR DESCRIPTION
This changes the language to be more general, updates the link the new issue page, and removes the "click here", with an active description