### PR TITLE
Fix where to talk section buttons to be properly aligned

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -37,37 +37,62 @@
       <div class="highlight"></div>
     </header>
     <div class="flex flex-column flex-row-l">
-      <div class="mw-33-l mh3-l pt0 flex flex-column justify-start" id="users-forum">
-        <div class="flex-grow-1">
+      <div class="w-33-l mh3-l pt0 flex flex-column justify-start" id="users-forum">
+        <div>
           <h3 class="mt0 mb4">{{fluent "community-urlo-header"}}</h3>
           <p>
             {{fluent "community-urlo"}}
           </p>
         </div>
 
-        <a href="https://users.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
+        <span class="dn-l">
+          <a href="https://users.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
+        </span>
       </div>
 
-      <div class="mw-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="internals-forum">
-        <div class="flex-grow-1">
+      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="internals-forum">
+        <div>
           <h3 class="mt0 mb4">{{fluent "community-irlo-header"}}</h3>
           <p>
             {{fluent "community-irlo"}}
           </p>
         </div>
 
-        <a href="https://internals.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
-
+        <span class="dn-l">
+          <a href="https://internals.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
+        </span>
       </div>
 
-      <div class="mw-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
-        <div class="flex-grow-1">
+      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
+        <div>
           <h3 class="mt0 mb4">{{fluent "community-chat-header"}}</h3>
           <p>
             {{fluent "community-chat"}}
           </p>
         </div>
 
+        {{!-- TODO: remove padding and margin once global declarations are gone --}}
+        <ul class="list pa0 ma0 dn-l">
+          <li class="mb3">
+            <a href="https://discord.gg/rust-lang" class="button button-secondary">{{fluent "discord"}}</a>
+          </li>
+          <li class="mb3">
+            <a href="{{baseurl}}/governance" class="button button-secondary">{{fluent "community-teams-learn"}}</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <div class="flex flex-column flex-row-l dn-m">
+      <div class="w-33-l mh3-l pt0 flex flex-column justify-start" id="users-forum">
+        <a href="https://users.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
+      </div>
+
+      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="internals-forum">
+        <a href="https://internals.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
+      </div>
+
+      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
         {{!-- TODO: remove padding and margin once global declarations are gone --}}
         <ul class="list pa0 ma0">
           <li class="mb3">


### PR DESCRIPTION
Fixes #918

I went a little further and ensured that when the content has different lengths, the buttons will still align properly. This did result in duplicating the button content though.

![image](https://user-images.githubusercontent.com/186971/75609797-11b59900-5ad1-11ea-94f5-0756af9205e9.png)

I'm more than happy to revert this and go back to my original approach, but when the content length doesn't match, the buttons will no longer be aligned.