### PR TITLE
Display team alumni in the governance page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1571,7 +1571,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#72484fc50e2bdef3847c31f6f863861f97310ebc"
+source = "git+https://github.com/rust-lang/team#2e7be25063a8e8b9fcca22485b95a88433472a38"
 dependencies = [
  "indexmap 1.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 1.0.104 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -24,3 +24,5 @@ governance-team-discord = { $channel } on Discord
 governance-user-github = GitHub: { $link }
 governance-user-team-leader = Team leader
 governance-members-header = Members
+governance-alumni-header = Alumni
+governance-alumni-thanks = We also want to thank all past members for their invaluable contributions!

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -177,6 +177,7 @@ mod tests {
                     github_id: 1234,
                 },
             ],
+            alumni: Vec::new(),
             website_data: Some(TeamWebsite {
                 name: format!("Team {}", name),
                 description: format!("Description of {}", name),

--- a/templates/governance/group-team.hbs
+++ b/templates/governance/group-team.hbs
@@ -52,5 +52,26 @@
                 </div>
             {{/each}}
         </div>
+        {{#if team.alumni}}
+            <header class="pb3 pt3">
+                <h2 class="f2">{{fluent "governance-alumni-header"}}</h2>
+            </header>
+            <p>{{fluent "governance-alumni-thanks"}}</p>
+            <div class="flex flex-column flex-row-l flex-wrap-l justify-start">
+                {{#each team.alumni as |member|}}
+                <div class="w-100 w-33-l mb3 flex flex-row items-center">
+                    <a class="mr4 w3 h3 flex-no-shrink" href="https://github.com/{{member.github}}">
+                        <img class="w-100 h-100 bg-white br2" src="https://avatars.githubusercontent.com/{{member.github}}">
+                    </a>
+                    <div>
+                        {{member.name}}
+                        <div class="f4">
+                            GitHub: <a href="https://github.com/{{member.github}}">{{member.github}}</a>
+                        </div>
+                    </div>
+                </div>
+                {{/each}}
+            </div>
+        {{/if}}
     {{/if}}
 </div>


### PR DESCRIPTION
This PR implements support in the website for "team alumni", in the effort to move away from the alumni page. This PR displays alumni under each team instead, like this screenshot with dummy data:

![2020-03-04--18-59-39](https://user-images.githubusercontent.com/2299951/75988938-a580ce00-5ef2-11ea-93c6-5d6df126d160.png)

At the moment no actual change will be shown, as nobody is marked as alumni in the team repo yet.

r? @XAMPPRocky 