### PR TITLE
Deploy Spanish translation

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -52,6 +52,10 @@ pub const EXPLICIT_LOCALE_INFO: &[LocaleInfo] = &[
         text: "English",
     },
     LocaleInfo {
+        lang: "es",
+        text: "Español",
+    },
+    LocaleInfo {
         lang: "it",
         text: "Italiano",
     },


### PR DESCRIPTION
Adds Spanish translation deployment, checked it locally. Looks like it is translated mostly.
Let's give it a try.

@rust-lang/community-localization 