### PR TITLE
Roll Japanese Translations

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -56,6 +56,10 @@ pub const EXPLICIT_LOCALE_INFO: &[LocaleInfo] = &[
         text: "Italiano",
     },
     LocaleInfo {
+        lang: "ja",
+        text: "日本語",
+    },
+    LocaleInfo {
         lang: "pt-BR",
         text: "Português",
     },


### PR DESCRIPTION
Adds Japanese translation deployment, checked it locally. Looks like it is translated mostly.
Let's give it a try.

@rust-lang/community-localization 