### PR TITLE
Fix learn URL

### DIFF
--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -4,7 +4,7 @@
       <div class="flex flex-column mw8 w-100 measure-wide-l pv2 pv5-m pv2-ns ph4-m ph4-l" id="get-help">
         <h4>{{fluent "footer-get-help"}}</h4>
         <ul>
-          <li><a href="{{baseurl}}/learn">{{fluent "footer-doc"}}</a></li>
+          <li><a href="https://www.rust-lang.org/{{lang}}/learn">{{fluent "footer-doc"}}</a></li>
           <li><a href="https://users.rust-lang.org">{{fluent "footer-ask"}}</a></li>
           <li><a href="http://ping.rust-lang.org">{{fluent "footer-status"}}</a></li>
         </ul>


### PR DESCRIPTION
## description

Fix #1039 
Fix #1040 

#1040 is not correctly work
If I visit `https://www.rust-lang.org/ja/tools` , This link will redirect to `https://www.rust-lang.org/ja/tools/learn`

## Remarks

I have not test this PR.
I will test as soon.