### PR TITLE
Fix grammar

### DIFF
--- a/locales/en-US/homepage.ftl
+++ b/locales/en-US/homepage.ftl
@@ -34,7 +34,7 @@ language-values-performance-blurb = Rust is blazingly fast and memory-efficient:
 
 language-values-reliability = Reliability
 language-values-reliability-blurb = Rust’s rich type system and ownership model guarantee memory-safety
-          and thread-safety &mdash; enable you to eliminate many classes of
+          and thread-safety &mdash; enabling you to eliminate many classes of
           bugs at compile-time.
 
 language-values-productivity = Productivity


### PR DESCRIPTION
The PR https://github.com/rust-lang/www.rust-lang.org/pull/996 removed the word "and", but in that case, I think the verb needs to be changed too.