### PR TITLE
Small changes to alternate links

### DIFF
--- a/templates/components/layout.hbs
+++ b/templates/components/layout.hbs
@@ -49,6 +49,7 @@
         {{#each locales as |locale| ~}}
             <link rel="alternate" href="/{{locale.lang}}" hreflang="{{locale.lang}}">
         {{/each~}}
+        <link rel="alternate" href="/" hreflang="x-default">
     {{/if}}
 
     <!-- Custom Highlight pack with: Rust, Markdown, TOML, Bash, JSON, YAML,

--- a/templates/components/layout.hbs
+++ b/templates/components/layout.hbs
@@ -47,9 +47,9 @@
     {{#if is_landing}}
         <!-- locales -->
         {{#each locales as |locale| ~}}
-            <link rel="alternate" href="/{{locale.lang}}" hreflang="{{locale.lang}}">
+            <link rel="alternate" href="https://www.rust-lang.org/{{locale.lang}}" hreflang="{{locale.lang}}">
         {{/each~}}
-        <link rel="alternate" href="/" hreflang="x-default">
+        <link rel="alternate" href="https://www.rust-lang.org/" hreflang="x-default">
     {{/if}}
 
     <!-- Custom Highlight pack with: Rust, Markdown, TOML, Bash, JSON, YAML,


### PR DESCRIPTION
We've been having localized website for quite a while, but when I search "Rust" in different languages on Google, none of them except Simplified Chinese shows up. So I have a look at Google's document to see whether I made any mistake.

I found this page: [Tell Google about localized versions of your page](https://support.google.com/webmasters/answer/189077?hl=en)

And there are two points which seem to be relevant:
1. If two pages don't both point to each other, the tags will be ignored. This is so that someone on another site can't arbitrarily create a tag naming itself as an alternative version of one of your pages.
2. Alternate URLs must be fully-qualified, including the transport method (http/https), so:
 `https://example.com/foo`, not `//example.com/foo` or `/foo`

The first issue is fixed by the first commit via adding the `x-default` fallback link, which is also recommended in the guidelines above. The second issue is fixed by the second commit by adding the full `https://www.rust-lang.org/` to the `href`. (Please let me know if there is any variable I can use for this. I tried to find but didn't see anything for that.)