### PR TITLE
Switch embedded book to point to doc.rust-lang.org

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -122,7 +122,7 @@
           </div>
 
           <div class="pt4 pt3-l flex flex-column flex-row-l items-center-l mb4-l">
-            <a href="https://rust-embedded.github.io/book/"
+            <a href="https://doc.rust-lang.org/embedded-book"
                class="button button-secondary mw6-l w-100">
               {{fluent "learn-domain-embedded-button"}}
             </a>


### PR DESCRIPTION
Since we now publish the embedded book as a component we should link to it.