### PR TITLE
Link to nightly version of the Unstable Book

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -181,7 +181,7 @@
         <div class="v-top pl4 pl0-l pt0 pt3-l measure-wide-l flex-l flex-column-l flex-auto-l justify-between-l">
           <p>{{fluent "learn-unstable"}}</p>
           <a class="button button-secondary"
-             href="https://doc.rust-lang.org/unstable-book/index.html">
+             href="https://doc.rust-lang.org/nightly/unstable-book/index.html">
             {{fluent "learn-unstable-button"}}
           </a>
         </div>


### PR DESCRIPTION
Because users of unstable features have to use the nightly toolchain, and because some unstable features can change frequently, the current nightly docs are more useful than the stable docs (which may be out of date by three or four months).