### PR TITLE
upgrade function calls to reqwest in issue #1059

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rocket = "0.4.1"
 serde = { version = "1.0", features = ["derive"] }
 serde_yaml = "0.8.7"
 sass-rs = "0.2.1"
-reqwest = "0.9"
+reqwest = { version = "0.10.4", features = ["blocking", "json"] }
 toml = "0.5"
 serde_json = "1.0"
 rust_team_data = { git = "https://github.com/rust-lang/team" }

--- a/src/rust_version.rs
+++ b/src/rust_version.rs
@@ -18,7 +18,10 @@ fn fetch(target: FetchTarget) -> Result<reqwest::blocking::Response, Box<dyn Err
     let client = match proxy_env {
         Some(proxy_env) => {
             let proxy = reqwest::Proxy::https(&proxy_env).unwrap();
-            reqwest::blocking::ClientBuilder::new().proxy(proxy).build().unwrap()
+            reqwest::blocking::ClientBuilder::new()
+                .proxy(proxy)
+                .build()
+                .unwrap()
         }
         None => reqwest::blocking::Client::new(),
     };

--- a/src/rust_version.rs
+++ b/src/rust_version.rs
@@ -10,7 +10,7 @@ enum FetchTarget {
     ReleasesFeed,
 }
 
-fn fetch(target: FetchTarget) -> Result<reqwest::Response, Box<dyn Error>> {
+fn fetch(target: FetchTarget) -> Result<reqwest::blocking::Response, Box<dyn Error>> {
     let proxy_env = env::var("http_proxy")
         .or_else(|_| env::var("HTTPS_PROXY"))
         .ok();
@@ -18,9 +18,9 @@ fn fetch(target: FetchTarget) -> Result<reqwest::Response, Box<dyn Error>> {
     let client = match proxy_env {
         Some(proxy_env) => {
             let proxy = reqwest::Proxy::https(&proxy_env).unwrap();
-            reqwest::ClientBuilder::new().proxy(proxy).build().unwrap()
+            reqwest::blocking::ClientBuilder::new().proxy(proxy).build().unwrap()
         }
-        None => reqwest::Client::new(),
+        None => reqwest::blocking::Client::new(),
     };
 
     let url = match target {

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -116,7 +116,7 @@ pub fn page_data(section: &str, team_name: &str) -> Result<PageData, Box<dyn Err
 }
 
 fn get_teams() -> Result<Box<dyn Any>, Box<dyn Error>> {
-    let resp: Teams = reqwest::get(&format!("{}/teams.json", BASE_URL))?
+    let resp: Teams = reqwest::blocking::get(&format!("{}/teams.json", BASE_URL))?
         .error_for_status()?
         .json()?;
 


### PR DESCRIPTION
bumping reqwest 0.9.24 to 0.10.4 requires use of calls that block. closes #1059 