### PR TITLE
Make .highlight smaller to avoid splitting text

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -342,9 +342,9 @@ h3 {
 }
 
 .highlight {
-  height: 24px;
+  height: 12px;
   position: relative;
-  top: -24px;
+  top: -6px;
   left: -10px;
   width: 120%;
   max-width: 90vw;


### PR DESCRIPTION
The headlines on the website are unnecessarily difficult to read due to the text being split in half by two different backgrounds with a hard border. This PR makes the highlight a little smaller and a little lower so it looks more like a thick underline. I find that this greatly helps the readability of the headlines.

Before:
<img width="220" alt="before" src="https://user-images.githubusercontent.com/1204698/83758909-045bfd80-a630-11ea-89da-b11c48da6562.png">

After:
<img width="220" alt="after" src="https://user-images.githubusercontent.com/1204698/83758925-0aea7500-a630-11ea-830f-84ca4f14efaa.png">
