### PR TITLE
Pass sample code in through rustfmt

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -90,9 +90,9 @@ ferris-says = "0.1"</code></pre>
 use std::io::{stdout, BufWriter};
 
 fn main() {
-    let stdout  = stdout();
+    let stdout = stdout();
     let message = String::from("Hello fellow Rustaceans!");
-    let width   = message.chars().count();
+    let width = message.chars().count();
 
     let mut writer = BufWriter::new(stdout.lock());
     say(message.as_bytes(), width, &mut writer).unwrap();


### PR DESCRIPTION
Some of the sample code in the "Get Started" tutorial aligned stuff around equal signs. This surprised me a bit when I saw it, as someone totally new to Rust - I thought "Oh, I guess there must be a Rust code formatter that does that for you?"

Turns out, yes, there's a formatter - but it wouldn't align around equal signs. :)   