### PR TITLE
Correct WASM book link on what/wasm page

### DIFF
--- a/templates/components/what/wasm/get-started.hbs
+++ b/templates/components/what/wasm/get-started.hbs
@@ -24,7 +24,7 @@
                     <p class="flex-grow-1">
                         {{fluent "wasm-get-started-book-description"}}
                     </p>
-                    <a href="https://rustwasm.github.io/book" class="button button-secondary">{{fluent "wasm-get-started-book-link"}}</a>
+                    <a href="https://rustwasm.github.io/docs/book" class="button button-secondary">{{fluent "wasm-get-started-book-link"}}</a>
                 </div>
             </div>
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">


### PR DESCRIPTION
The link was pointing to the unpublished version of the book, and is now pointing
to the published one.
Github issue: https://github.com/rust-lang/www.rust-lang.org/issues/1155