### PR TITLE
refine highlight's spacing and border-radius

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -626,6 +626,13 @@ blockquote::before {
   font-weight: 600;
 }
 
+@media screen and (max-width: 769px) {
+  .highlight {
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+  }
+}
+
 // Temporary HACK: switch away from this when we switch to using Tachyons for
 // the page titles -- at that time, we should make a simple component class that
 // just composes those classes.
@@ -634,11 +641,6 @@ blockquote::before {
   header {
     h1 {
       font-size: 4rem;
-    }
-
-    .highlight {
-      height: 20px;
-      top: -20px;
     }
 
     h2.subtitle {

--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -344,11 +344,12 @@ h3 {
 .highlight {
   height: 12px;
   position: relative;
-  top: -6px;
+  top: 0;
   left: -10px;
   width: 120%;
   max-width: 90vw;
   line-height: 1.6;
+  border-radius: 2px;
 }
 
 footer {


### PR DESCRIPTION
Updates highlight spacing so it doesn't clash with the descent in some titles and updated the border radius to be visually consistent with the buttons.

### Production

<img width="1179" alt="Screenshot 2020-07-01 at 10 19 06" src="https://user-images.githubusercontent.com/4464295/86221118-c4336080-bb84-11ea-8f2f-42709e928252.png">

### Staging

<img width="1203" alt="Screenshot 2020-07-01 at 10 18 50" src="https://user-images.githubusercontent.com/4464295/86221380-20968000-bb85-11ea-877f-3cc5a4898a43.png">

### Proposed Changes

<img width="1180" alt="Screenshot 2020-07-01 at 10 25 56" src="https://user-images.githubusercontent.com/4464295/86221509-49b71080-bb85-11ea-983e-01b5842bb326.png">