### PR TITLE
Fix #1166 - Duplicate buttons on small screens

### DIFF
--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -82,28 +82,6 @@
         </ul>
       </div>
     </div>
-
-    <div class="flex flex-column flex-row-l dn-m">
-      <div class="w-33-l mh3-l pt0 flex flex-column justify-start" id="users-forum">
-        <a href="https://users.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
-      </div>
-
-      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="internals-forum">
-        <a href="https://internals.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
-      </div>
-
-      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
-        {{!-- TODO: remove padding and margin once global declarations are gone --}}
-        <ul class="list pa0 ma0">
-          <li class="mb3">
-            <a href="https://discord.gg/rust-lang" class="button button-secondary">{{fluent "discord"}}</a>
-          </li>
-          <li class="mb3">
-            <a href="{{baseurl}}/governance" class="button button-secondary">{{fluent "community-teams-learn"}}</a>
-          </li>
-        </ul>
-      </div>
-    </div>
   </div>
 </section>
 


### PR DESCRIPTION
On a small screen, there seems to be leftover DOM probably from a previous refactor.

Fixes: https://github.com/rust-lang/www.rust-lang.org/issues/1166

# Before:
<img width="357" alt="Screenshot 2020-07-02 at 10 04 49" src="https://user-images.githubusercontent.com/448410/86332977-8d744d80-bc4b-11ea-82f9-51945fce74a6.png">

# After:
<img width="357" alt="Screenshot 2020-07-02 at 10 01 33" src="https://user-images.githubusercontent.com/448410/86332862-6289f980-bc4b-11ea-8cf0-7087c227d903.png">
