### PR TITLE
Mention installing Windows VS C++ build tools

### DIFF
--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -154,7 +154,7 @@ install-other-methods-link = Learn more
 ## components/tools/rustup.hbs
 
 tools-rustup-unixy = It looks like you’re running macOS, Linux, or another Unix-like OS. To download Rustup and install Rust, run the following in your terminal, then follow the on-screen instructions. See <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Other Installation Methods"</a> if you are on Windows.
-tools-rustup-windows = It looks like you’re running Windows. To start using Rust, download the installer, then run the program and follow the onscreen instructions. See <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Other Installation Methods"</a> if you are not on Windows.
+tools-rustup-windows-2 = It looks like you’re running Windows. To start using Rust, download the installer, then run the program and follow the onscreen instructions. You may need to install the <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">Visual Studio C++ Build tools</a> when prompted to do so. If you are not on Windows see <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Other Installation Methods"</a>.
 tools-rustup-wsl-heading = Windows Subsystem for Linux
 tools-rustup-wsl = If you’re a Windows Subsystem for Linux user run the following in your terminal, then follow the on-screen instructions to install Rust.
 tools-rustup-unknown = Rust runs on Windows, Linux, macOS, FreeBSD and NetBSD. If you are on one of these platforms and are seeing this then please report an issue with the following values:

--- a/templates/components/tools/rustup.hbs
+++ b/templates/components/tools/rustup.hbs
@@ -4,7 +4,7 @@
     <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
   </div>
   <div id="platform-instructions-win" class="instructions dn">
-    <p>{{fluent "tools-rustup-windows"}}</p>
+    <p>{{fluent "tools-rustup-windows-2"}}</p>
     <div class="mw9 center ph3-ns">
     <div class="cf ph2-ns">
       <div class="fl w-100 w-50-ns pa2">


### PR DESCRIPTION
Adds a sentence about the C++ build tools being a prerequisite on Windows.

Alternatively it could link to the instructions in [the book](https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-windows) where we could (potentially) give more detailed install instructions. However, I think it's useful to new users to directly present everything they need to get started in Rust.

EDIT: Updated the language used to directly refer to following the prompts in the rustup installer.