### PR TITLE
update "get involved" link

### DIFF
--- a/templates/components/panels/get-involved.hbs
+++ b/templates/components/panels/get-involved.hbs
@@ -21,7 +21,7 @@
       <p>
       {{fluent "get-involved-contribute-blurb"}}
       </p>
-      <a href="https://github.com/rust-lang/rust/blob/master/CONTRIBUTING.md" class="button button-secondary">
+      <a href="https://rustc-dev-guide.rust-lang.org/getting-started.html" class="button button-secondary">
         {{fluent "get-involved-contribute-link"}}
       </a>
     </div>


### PR DESCRIPTION
as CONTRIBUTING.md is just a stub link to the rustc-dev-guide, link to the rustc-dev-guide directly to remove a needless indirection,