### PR TITLE
Adjust hero top and bottom padding

### DIFF
--- a/templates/index.hbs
+++ b/templates/index.hbs
@@ -1,9 +1,9 @@
 {{#*inline "page"}}
-<header class="mt3 mt0-ns mb4 w-100 mw-none ph3 mw8-m mw9-l center">
+<header class="mt3 mb6 w-100 mw-none ph3 mw8-m mw9-l center">
   <div class="flex flex-column flex-row-l">
     <div class="w-70-l mw8-l">
       <h1>{{fluent "rust"}}</h1>
-      <h2 class="mt4 f2 f1-ns">
+      <h2 class="mt4 mb0 f2 f1-ns">
         {{fluent "tagline" linebreak="<br class='dn db-ns'>"}}
       </h2>
     </div>


### PR DESCRIPTION
This makes a minor change to the hero's top and bottom spacing to be a bit more inline with how it was before the #1187 


### Staging

<img width="1587" alt="Screenshot 2020-07-22 at 19 43 07" src="https://user-images.githubusercontent.com/4464295/88210364-5e526a00-cc54-11ea-9500-e78c7763bc51.png">


### Proposed

<img width="1610" alt="Screenshot 2020-07-22 at 19 42 51" src="https://user-images.githubusercontent.com/4464295/88210374-627e8780-cc54-11ea-813c-3dd07371a442.png">
