### PR TITLE
Re-arrange the community webpage

### DIFF
--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -9,6 +9,7 @@ why-rust = Why Rust?
 production-use = Production use
 learn-more = Learn More
 discord = Discord
+zulip = Zulip
 
 ## components/panels/domain.hbs
 

--- a/locales/en-US/community.ftl
+++ b/locales/en-US/community.ftl
@@ -11,6 +11,7 @@ community-team-contact = We’d like to hear from you! Not sure where or who to 
 community-team-button = email { ENGLISH("community@rust-lang.org") }
 
 community-where = Where to talk
+community-learn = Where to learn
 
 community-urlo-header = Users forum
 community-urlo = The Rust Users Forum is a place for Rust users to communicate about

--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -1,34 +1,10 @@
 {{#*inline "page"}}
 
-<header class="mt3 mt2-ns mb4 mb5-ns tc tl-ns">
+<header class="mt3 mt2-ns tc tl-ns">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <h1>{{fluent "community-page-title"}}</h1>
   </div>
 </header>
-
-<section id="community" class="purple">
-  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3 f2-s">
-    <div class="flex flex-column flex-row-l">
-      <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
-        <p>
-         {{fluent "community-blurb"}}
-        </p>
-        <p>
-          {{fluent "community-twir"}}
-        </p>
-        <a href="https://this-week-in-rust.org/" class="button button-secondary mb3">{{fluent "community-twir-button"}}</a>
-      </div>
-      <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
-        <p>
-          {{fluent "community-team-contact"}}
-        </p>
-
-        <a href="mailto:community@rust-lang.org" class="button button-secondary mb3">{{fluent "community-team-button"}}</a>
-      </div>
-    </div>
-
-  </div>
-</section>
 
 <section id="contribute-talk" class="white">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
@@ -77,6 +53,9 @@
             <a href="https://discord.gg/rust-lang" class="button button-secondary">{{fluent "discord"}}</a>
           </li>
           <li class="mb3">
+            <a href="https://rust-lang.zulipchat.com" class="button button-secondary">{{fluent "zulip"}}</a>
+          </li>
+          <li class="mb3">
             <a href="{{baseurl}}/governance" class="button button-secondary">{{fluent "community-teams-learn"}}</a>
           </li>
         </ul>
@@ -92,17 +71,46 @@
           <a href="https://internals.rust-lang.org" class="button button-secondary">{{fluent "community-discourse-button"}}</a>
         </div>
 
-        <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
-          {{!-- TODO: remove padding and margin once global declarations are gone --}}
-          <ul class="list pa0 ma0">
-            <li class="mb3">
-              <a href="https://discord.gg/rust-lang" class="button button-secondary">{{fluent "discord"}}</a>
-            </li>
-            <li class="mb3">
-              <a href="{{baseurl}}/governance" class="button button-secondary">{{fluent "community-teams-learn"}}</a>
-            </li>
-          </ul>
-        </div>
+      <div class="w-33-l mh3-l pt4 pt0-l flex flex-column justify-start" id="chat-platforms">
+        {{!-- TODO: remove padding and margin once global declarations are gone --}}
+        <ul class="list pa0 ma0">
+          <li class="mb3">
+            <a href="https://discord.gg/rust-lang" class="button button-secondary">{{fluent "discord"}}</a>
+          </li>
+          <li class="mb3">
+            <a href="https://rust-lang.zulipchat.com" class="button button-secondary">{{fluent "zulip"}}</a>
+          </li>
+          <li class="mb3">
+            <a href="{{baseurl}}/governance" class="button button-secondary">{{fluent "community-teams-learn"}}</a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+
+  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3 f2-s">
+    <header>
+        <h2>{{fluent "community-learn"}}</h2>
+        <div class="highlight"></div>
+    </header>
+    <div class="flex flex-column flex-row-l">
+      <div class="mw-25-l mh2-l pt0 flex flex-column justify-between-l">
+        <h2>Read about Rust</h2>
+        <p>
+         {{fluent "community-blurb"}}
+        </p>
+        <p>
+          {{fluent "community-twir"}}
+        </p>
+        <a href="https://this-week-in-rust.org/" class="button button-secondary mb3">{{fluent "community-twir-button"}}</a>
+      </div>
+      <div class="mw-50-l mh2-l pt0 flex flex-column justify-between-l">
+        <h2>Get in contact</h2>
+        <p>
+          {{fluent "community-team-contact"}}
+        </p>
+
+        <a href="mailto:community@rust-lang.org" class="button button-secondary mb3">{{fluent "community-team-button"}}</a>
       </div>
     </div>
   </div>
@@ -186,26 +194,7 @@
   </div>
 </section>
 
-<section id="rustreach" class="red">
-  <div class="w-100 mw-none ph3 mw8-m mw9-l center">
-    <header>
-      <h2>{{fluent "community-irr-header"}}</h2>
-      <div class="highlight"></div>
-    </header>
-    <div class="w-100 flex flex-column flex-row-l">
-      <div class="mw-33-l mh3-l">
-        <img src="/static/images/rustreach.jpg" alt="increasing rust's reach logo"/>
-      </div>
-      <div class="mw-67-l mh3-l">
-        <p> {{fluent "community-irr"}}
-        </p>
-        <a href="http://reach.rust-lang.org/" class="button button-secondary">{{fluent "community-irr-button"}}</a>
-      </div>
-    </div>
-  </div>
-</section>
-
-<section id="conduct" class="green">
+<section id="conduct" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>
       <h2>{{fluent "community-standards-header"}}</h2>


### PR DESCRIPTION
This updates the community webpage to remove the old section on Increasing Rust Reach and re-arranges the top section of the page to reduce the prominance of the Community Team's email as currently it receives a lot of traffic. By moving it below the section on forums this should hopefully steer people to ask their questions on the forums instead.

### Production

![production](https://user-images.githubusercontent.com/4464295/88278138-314c9880-cce2-11ea-9e2c-ed3f516612e3.png)

### Proposed

![localhost](https://user-images.githubusercontent.com/4464295/88278165-41647800-cce2-11ea-8d5e-b8d953996041.png)