### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,6 @@
-* @rust-lang/website
+src/ @rust-lang/website
+ci/ @rust-lang/website
+static/ @rust-lang/website
+templates/ @rust-lang/website
+locales/ @rust-lang/website
+*.md @rust-lang/website


### PR DESCRIPTION
Splits the CODEOWNERS so that dependabot PRs don't trigger team review.

r? @pietroalbini 