### PR TITLE
Adds support for project groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1758,7 +1758,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#37fca09a1707f65507e8204dbbe2590cef7278a0"
+source = "git+https://github.com/rust-lang/team#769f3e259512d59a8588154520029774560ce0af"
 dependencies = [
  "indexmap",
  "serde",

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -23,6 +23,7 @@ pub struct PageData {
     zulip_domain: &'static str,
     subteams: Vec<Team>,
     wgs: Vec<Team>,
+    project_groups: Vec<Team>,
 }
 
 #[derive(Clone)]
@@ -90,6 +91,7 @@ impl Data {
         // Then find all the subteams and wgs
         let mut subteams = Vec::new();
         let mut wgs = Vec::new();
+        let mut project_groups = Vec::new();
         self.teams
             .into_iter()
             .filter(|team| team.website_data.is_some())
@@ -97,6 +99,7 @@ impl Data {
             .for_each(|team| match team.kind {
                 TeamKind::Team => subteams.push(team),
                 TeamKind::WorkingGroup => wgs.push(team),
+                TeamKind::ProjectGroup => project_groups.push(team),
                 _ => {}
             });
 
@@ -105,6 +108,7 @@ impl Data {
             zulip_domain: crate::ZULIP_DOMAIN,
             subteams,
             wgs,
+            project_groups,
         })
     }
 }
@@ -134,6 +138,7 @@ fn kind_to_str(kind: TeamKind) -> &'static str {
     match kind {
         TeamKind::Team => "teams",
         TeamKind::WorkingGroup => "wgs",
+        TeamKind::ProjectGroup => "project-groups",
         _ => "UNSUPPORTED",
     }
 }

--- a/templates/governance/group.hbs
+++ b/templates/governance/group.hbs
@@ -12,6 +12,13 @@
         {{/each}}
     </section>
 {{/if}}
+{{#if data.project_groups}}
+    <section class="green">
+        {{#each data.project_groups as |team|}}
+            {{> governance/group-team}}
+        {{/each}}
+    </section>
+{{/if}}
 {{#if data.wgs}}
     <section class="green">
         {{#each data.wgs as |team|}}


### PR DESCRIPTION
Followup of https://github.com/rust-lang/team/pull/409 to display them on the website (above working groups).