### PR TITLE
Update nav.hbs

### DIFF
--- a/templates/components/nav.hbs
+++ b/templates/components/nav.hbs
@@ -1,4 +1,4 @@
-<nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr4-ns pb3">
+<nav class="flex flex-row justify-center justify-end-l items-center flex-wrap ph2 pl3-ns pr3-ns pb3">
   <div class="brand flex-auto w-100 w-auto-l self-start tc tl-l">
     <a href="{{baseurl}}/" class="brand">
       <img class="v-mid ml0-l" alt="{{fluent "nav-logo-alt"}}" src="/static/images/rust-logo-blk.svg">


### PR DESCRIPTION
I don't think the difference between the padding on either side here is intentional. It makes the logo not quite centered.

Before:

<img width="933" alt="before" src="https://user-images.githubusercontent.com/4339582/90785694-f885fa80-e345-11ea-9a9b-961e8cc5c5b6.png">

After:

<img width="932" alt="after" src="https://user-images.githubusercontent.com/4339582/90785862-32ef9780-e346-11ea-9a7a-e6e35580b166.png">
