### PR TITLE
fix(editors.hbs): update recommended vscode extension

### DIFF
--- a/templates/components/tools/editors.hbs
+++ b/templates/components/tools/editors.hbs
@@ -1,6 +1,6 @@
 <div class="flex-none flex-m flex-l flex-wrap">
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://marketplace.visualstudio.com/items?itemName=rust-lang.rust"
+    <a href="https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer"
        class="button button-secondary">{{fluent "tools-editor-vscode"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">


### PR DESCRIPTION
It seems like based on this [RFC](https://github.com/rust-lang/rfcs/pull/2912), this [Reddit thread](https://www.reddit.com/r/rust/comments/hf07lk/rls_vs_rustanalyzer_in_2020/), and some feedback I received on a [YouTube video](https://www.youtube.com/watch?v=Yx1Cd0orHM8&list=PLzIwronG0sE56c6hDYOKW3-rPxmIyttoe&index=2) that the recommended extension to use is [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=matklad.rust-analyzer).

I figured if that's the case, then shouldn't the official website reflect that? This PR updates the link.   