### PR TITLE
Use the `disc` list style type

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -186,7 +186,7 @@ section {
 }
 
 ul {
-  list-style: circle;
+  list-style: disc;
   padding-left: 1.5em;
 }
 


### PR DESCRIPTION
Fixes #1252.

Previously, it was the `circle` list style type, but it was determined
that the `disc` list style type is in many ways a better match for Rust.