### PR TITLE
Fix syntax highlighting

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -114,7 +114,7 @@ learn-dependencies-steps = <p>Let’s add a dependency to our application. You c
       <p>In our <code>Cargo.toml</code> file we’ll add this information (that we got from the crate page):</p>
       { $cargotoml }
       <p>Now we can run:</p>
-      <code>cargo build</code>
+      <p><code>cargo build</code></p>
       <p>...and Cargo will install our dependency for us.</p>
       <p>You’ll see that running this command created a new file for us, <code>Cargo.lock</code>. This file is a log of the exact versions of the dependencies we are using locally.</p>
       <p>To use this dependency, we can open <code>main.rs</code>, remove everything that’s in there (it’s just another example), and add this line to it:</p>

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -46,13 +46,13 @@
     </header>
     {{#fluent "learn-generating-steps"}}
     {{#fluentparam "tree"}}
-    <pre><code>hello-rust
+    <pre><code class="plaintext">hello-rust
 |- Cargo.toml
 |- src
   |- main.rs</code></pre>
     {{/fluentparam}}
     {{#fluentparam "output"}}
-    <pre><code>$ cargo run
+    <pre><code class="plaintext">$ cargo run
    Compiling hello-rust v0.1.0 (/Users/ag_dubs/rust/hello-rust)
     Finished dev [unoptimized + debuginfo] target(s) in 1.34s
      Running `target/debug/hello-rust`
@@ -100,7 +100,7 @@ fn main() {
     </code></pre>
     {{/fluentparam}}
     {{#fluentparam "output"}}
-    <pre><code>----------------------------
+    <pre><code class="plaintext">----------------------------
 | Hello fellow Rustaceans! |
 ----------------------------
               \


### PR DESCRIPTION
Add the `plaintext` language class to some code blocks that were being
highlighted incorrectly. The `cargo run` one was being highlighted as
Ruby and the `ferris_says` one was being highlighted as Bash!

Also added a missing `p` tag around an inline code block that was on its
own line.