### PR TITLE
Update policies

### DIFF
--- a/locales/en-US/policies.ftl
+++ b/locales/en-US/policies.ftl
@@ -13,3 +13,8 @@ policies-privacy-link = Privacy Notice
 
 policies-reach-out-description = Didn’t find what you were looking for? Have a question? Please reach out!
 policies-reach-out-link = Message the Core Team
+
+policies-translation-warning =
+    This policy may be translated by Rust community members. If there is any
+    conflict between the <a href="{ $english }">English version</a> and a
+    translation, the English version will apply.

--- a/locales/en-US/privacy.ftl
+++ b/locales/en-US/privacy.ftl
@@ -31,7 +31,7 @@ policies-privacy-page-rust-lang-org-desc =
       </dd>
     </dl>
 
-policies-privacy-page-crates-io-desc =
+policies-privacy-page-crates-io-desc--2020-09 =
     <p>
       <a href="https://crates.io">Crates.io</a> is managed by members of the
       <a href="{ $baseurl }/governance/teams/crates-io">Crates.io</a> and
@@ -98,24 +98,39 @@ policies-privacy-page-crates-io-desc =
           at the bottom of each crate’s page.
         </p>
       </dd>
+
+      <dt>Error monitoring:</dt>
+      <dd>
+        <p>
+          Crates.io uses Sentry, an error monitoring service, to help the Rust
+          team discover and fix the performance of the code. When there is an
+          error, Sentry receives basic information about how you interacted
+          with the website and the actions that led to the error. Additionally,
+          your IP address may be disclosed to Sentry as part of the error
+          reporting process but we’ve configured Sentry to delete it as soon as
+          it’s received. Read <a href="https://sentry.io/privacy/">Sentry’s
+          Privacy Policy here</a>.
+        </p>
+      </dd>
     </dl>
 
-policies-privacy-page-docs-rs-desc =
+policies-privacy-page-docs-rs-desc--2020-09 =
     <p>
       <a href="https://docs.rs">Docs.rs</a> is managed by the members of the
-      <a href="{ $baseurl }/governance/teams/dev-tools#rustdoc">Rustdoc team</a>
-      and <a href="{ $baseurl }/governance/teams/core">Rust core team</a>. The
-      project collects and uses data as described in this privacy notice.
+      <a href="{ $baseurl }/governance/teams/dev-tools#docs-rs">docs.rs team</a>
+      and <a href="{ $baseurl }/governance/teams/core">Rust core team</a>.
     </p>
 
-    <p>
-      Docs.rs is an open source project to host documentation of crates for the
-      Rust Programming Language. It automatically builds crates' documentation
-      released on <a href="https://crates.io">crates.io</a> using the nightly
-      release of the Rust compiler. All information from crates that is
-      published on docs.rs is also available publicly on crates.io.
-    </p>
-
+    <dl>
+      <dt>Visitor logs:</dt>
+      <dd>
+        <p>
+          When you visit docs.rs, we receive your IP address and user-agent
+          header as part of our standard server logs. We store these logs for 1
+          year.
+        </p>
+      </dd>
+    </dl>
 
 policies-privacy-page-forums-title = Forums
 policies-privacy-page-forums-desc =

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,7 @@ struct Context<T: ::serde::Serialize> {
     pontoon_enabled: bool,
     assets: &'static AssetFiles,
     locales: &'static [LocaleInfo],
+    is_translation: bool,
 }
 
 impl<T: ::serde::Serialize> Context<T> {
@@ -110,6 +111,7 @@ impl<T: ::serde::Serialize> Context<T> {
             is_landing,
             data,
             baseurl: baseurl(&lang),
+            is_translation: lang != "en-US",
             lang,
             pontoon_enabled: *PONTOON_ENABLED,
             assets: &ASSETS,

--- a/templates/policies/code-of-conduct.hbs
+++ b/templates/policies/code-of-conduct.hbs
@@ -6,6 +6,19 @@
   </div>
 </header>
 
+{{#if is_translation}}
+<section id="translation-warning" class="green pv4">
+  <div class="w-100 mw-none ph3 pw8-m mw9-l center f3">
+    <p class="mb0">
+      {{#fluent "policies-translation-warning"}}
+        {{#fluentparam "english"}}/policies/code-of-conduct{{/fluentparam}}
+      {{/fluent}}
+    </p>
+  </div>
+</section>
+{{/if}}
+
+
 <section id="code-of-conduct" class="red">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>

--- a/templates/policies/licenses.hbs
+++ b/templates/policies/licenses.hbs
@@ -6,6 +6,18 @@
   </div>
 </header>
 
+{{#if is_translation}}
+<section id="translation-warning" class="green pv4">
+  <div class="w-100 mw-none ph3 pw8-m mw9-l center f3">
+    <p class="mb0">
+      {{#fluent "policies-translation-warning"}}
+        {{#fluentparam "english"}}/policies/licenses{{/fluentparam}}
+      {{/fluent}}
+    </p>
+  </div>
+</section>
+{{/if}}
+
 <section id="license" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>

--- a/templates/policies/media-guide.hbs
+++ b/templates/policies/media-guide.hbs
@@ -6,6 +6,18 @@
   </div>
 </header>
 
+{{#if is_translation}}
+<section id="translation-warning" class="green pv4">
+  <div class="w-100 mw-none ph3 pw8-m mw9-l center f3">
+    <p class="mb0">
+      {{#fluent "policies-translation-warning"}}
+        {{#fluentparam "english"}}/policies/media-guide{{/fluentparam}}
+      {{/fluent}}
+    </p>
+  </div>
+</section>
+{{/if}}
+
 <section id="art-license" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>

--- a/templates/policies/privacy.hbs
+++ b/templates/policies/privacy.hbs
@@ -8,7 +8,7 @@
 
 <section id="privacy-notice" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    {{fluent "policies-privacy-page-version" version="1.0" date="2019-08-19"}}
+    {{fluent "policies-privacy-page-version" version="1.1" date="2020-09-15"}}
 
     {{#fluent "policies-privacy-page-intro"}}
       {{#fluentparam "baseurl"}}{{baseurl}}{{/fluentparam}}
@@ -28,7 +28,7 @@
       <div class="highlight"></div>
     </header>
 
-    {{#fluent "policies-privacy-page-crates-io-desc"}}
+    {{#fluent "policies-privacy-page-crates-io-desc--2020-09"}}
       {{#fluentparam "baseurl"}}{{baseurl}}{{/fluentparam}}
     {{/fluent}}
 
@@ -37,7 +37,7 @@
       <div class="highlight"></div>
     </header>
 
-    {{#fluent "policies-privacy-page-docs-rs-desc"}}
+    {{#fluent "policies-privacy-page-docs-rs-desc--2020-09"}}
       {{#fluentparam "baseurl"}}{{baseurl}}{{/fluentparam}}
     {{/fluent}}
 

--- a/templates/policies/privacy.hbs
+++ b/templates/policies/privacy.hbs
@@ -6,6 +6,18 @@
   </div>
 </header>
 
+{{#if is_translation}}
+<section id="translation-warning" class="green pv4">
+  <div class="w-100 mw-none ph3 pw8-m mw9-l center f3">
+    <p class="mb0">
+      {{#fluent "policies-translation-warning"}}
+        {{#fluentparam "english"}}/policies/privacy{{/fluentparam}}
+      {{/fluent}}
+    </p>
+  </div>
+</section>
+{{/if}}
+
 <section id="privacy-notice" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     {{fluent "policies-privacy-page-version" version="1.1" date="2020-09-15"}}

--- a/templates/policies/security.hbs
+++ b/templates/policies/security.hbs
@@ -6,6 +6,18 @@
   </div>
 </header>
 
+{{#if is_translation}}
+<section id="translation-warning" class="green pv4">
+  <div class="w-100 mw-none ph3 pw8-m mw9-l center f3">
+    <p class="mb0">
+      {{#fluent "policies-translation-warning"}}
+        {{#fluentparam "english"}}/policies/security{{/fluentparam}}
+      {{/fluent}}
+    </p>
+  </div>
+</section>
+{{/if}}
+
 <section id="security-reporting" class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     <header>


### PR DESCRIPTION
This PR updates the policies section as recommended by Mozilla Legal:

* The Privacy Policy was updated to version 1.1, with the following changes:
  * Added a note about crates.io using Sentry for error reporting.
  * Added a note about docs.rs storing visitor logs for a year.
* A disclaimer was added on top of all translated policies, saying the canonical version is the english one:

![2020-09-25--12-39-54](https://user-images.githubusercontent.com/2299951/94258035-8a2bed80-ff2c-11ea-8b80-fc159647e836.png)
