### PR TITLE
policies/privacy: Remove `#privacy-notice` ID from section element

### DIFF
--- a/templates/policies/privacy.hbs
+++ b/templates/policies/privacy.hbs
@@ -18,7 +18,7 @@
 </section>
 {{/if}}
 
-<section id="privacy-notice" class="purple">
+<section class="purple">
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
     {{fluent "policies-privacy-page-version" version="1.1" date="2020-09-15"}}
 


### PR DESCRIPTION
It turns out that certain adblockers (e.g. uBlock Origin) include the "EasyList Cookies" blocklist, which prevents elements with an `#privacy-notice` ID from rendering, which resulted in us showing a blank page. Since this ID does not seem to be used for anything here this commit just removes it to prevent the adblocker issue.

/cc @pietroalbini 