### PR TITLE
Fixes #1292 - no-escaping in sponsors handlebars template

### DIFF
--- a/templates/sponsors/index.hbs
+++ b/templates/sponsors/index.hbs
@@ -28,7 +28,7 @@
       <div class="w-100 w-70-l">
         <h3>{{sponsor.name}}</h3>
         <p>
-          {{sponsor.description_i18n}}
+          {{{sponsor.description_i18n}}}
         </p>
       </div>
     </div>


### PR DESCRIPTION
Fixes #1292 enabling no-escaping for sponsors descriptions so that html tag is properly rendered. spanish sponsors file has html in it