### PR TITLE
Fixes #767 - restructuring redirects

### DIFF
--- a/src/data/redirects.yml
+++ b/src/data/redirects.yml
@@ -1,0 +1,82 @@
+---
+
+# Website Redirects setup
+# available keys: from, to, status[optional]
+#
+#   from - is a regex with names & non-named group captures
+#   to - is redirecting to with references to groups as $1 $2 or by name ifi it was captured like (?P<name>.*)
+#   status[optional] - is redirect response status, if not specified default value 302 Found will be used
+#
+# Possible response status values
+#        301 => "Moved Permanently"
+#        302 => "Found"
+#        303 => "See Other"
+#        304 => "Not Modified"
+#        305 => "Use Proxy"
+#        307 => "Temporary Redirect"
+#        308 => "Permanent Redirect"
+
+- from: ^/(en-US/)?pdfs/(?P<file>.*)
+  to: /static/pdfs/$file
+
+- from: ^/(en-US/)?(Rust-npm-Whitepaper|Rust-Chucklefish-Whitepaper|Rust-Tilde-Whitepaper).pdf
+  to: /static/pdfs/$2.pdf
+
+- from: ^/(en-US/)?(community|contribute-bugs|contribute|user-groups)\.html
+  to: /community
+
+- from: ^/(en-US/)?conduct\.html
+  to: /policies/code-of-conduct
+
+- from: ^/(en-US/)?contribute-community.html\.html
+  to: /governance/teams/community
+
+- from: ^/(en-US/)?contribute-compiler\.html
+  to: /governance/teams/language-and-compiler
+
+- from: ^/(en-US/)?contribute-docs\.html
+  to: /governance/teams/documentation
+
+- from: ^/(en-US/)?contribute-libs\.html
+  to: /governance/teams/library
+
+- from: ^/(en-US/)?contribute-tools\.html
+  to: /governance/teams/dev-tools
+
+- from: ^/(en-US/)?documentation\.html
+  to: /learn
+
+- from: ^/(en-US/)?downloads\.html
+  to: /tools/install
+
+- from: ^/(en-US/)?friends\.html
+  to: /production
+
+- from: ^/(en-US/)?install\.html
+  to: /tools/install
+
+- from: ^/(en-US/)?legal\.html
+  to: /policies
+
+- from: ^/(en-US/)?security\.html
+  to: /policies/security
+
+- from: ^/(en-US/)?team\.html
+  to: /governance
+
+- from: ^/(en-US/)?other-installers\.html
+  to: https://forge.rust-lang.org/infra/other-installation-methods.html
+  status: 301
+
+- from: ^/(en-US/)?index\.html
+  to: /
+
+# redirecting en-US to root
+- from: ^/en-US/?$
+  to: /
+  status: 308
+
+# temporary redirect for given locales
+- from: ^/(de-DE|es-ES|fr-FR|id-ID|it-IT|ja-JP|ko-KR|pl-PL|pt-BR|ru-RU|sv-SE|vi-VN)/?(.*)$
+  to: /$2
+  status: 307

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,7 +43,11 @@ use std::path::{Path, PathBuf};
 
 use rand::seq::SliceRandom;
 
-use rocket::{http::{RawStr, Status}, request::{FromParam, Request}, response::{NamedFile, Redirect}};
+use rocket::{
+    http::{RawStr, Status},
+    request::{FromParam, Request},
+    response::{NamedFile, Redirect},
+};
 
 use rocket_contrib::templates::Template;
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,7 +1,7 @@
-use std::error::Error;
-use rocket::http::Status;
 use regex::Regex;
+use rocket::http::Status;
 use rocket::response::Redirect;
+use std::error::Error;
 
 static REDIRECTS_YML_PATH: &str = "src/data/redirects.yml";
 
@@ -13,7 +13,7 @@ lazy_static! {
 pub struct InnerRedirect {
     pub from: String,
     pub to: String,
-    pub status: Option<u16>
+    pub status: Option<u16>,
 }
 
 impl InnerRedirect {
@@ -27,7 +27,7 @@ impl InnerRedirect {
             Status::SeeOther => Redirect::to(to),
             Status::TemporaryRedirect => Redirect::temporary(to),
             Status::PermanentRedirect => Redirect::permanent(to),
-            _ => Redirect::found(to)
+            _ => Redirect::found(to),
         }
     }
 }
@@ -44,9 +44,11 @@ pub fn find_redirect(from: String) -> Result<Redirect, NoRedirectFound> {
         let rex = Regex::new(&inner_redirect.from).unwrap();
         if rex.is_match(&from) {
             let mut redirect_to = String::from("");
-            rex.captures(&from).unwrap().expand(inner_redirect.to.as_str(), &mut redirect_to);
-            return Ok(inner_redirect.redirect(redirect_to))
+            rex.captures(&from)
+                .unwrap()
+                .expand(inner_redirect.to.as_str(), &mut redirect_to);
+            return Ok(inner_redirect.redirect(redirect_to));
         }
     }
-    return Err(NoRedirectFound)
+    return Err(NoRedirectFound);
 }


### PR DESCRIPTION
Fixes #767

- moving redirects into yaml file
- redirects support regex matching and named&non-named group captures. groups can be passed to redirect url
- moved all  previous redirects into yaml
- removed previous routes for redirects which is moved
- redirect logic is moved into 404 catcher before throwing 404 we check if we  have a redirect match else throw 404 with custom template