### PR TITLE
Return a 404 instead of a 500 when a sub-page is missing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -236,12 +236,16 @@ fn sponsors_locale(locale: SupportedLocale) -> Template {
 }
 
 #[get("/<category>/<subject>", rank = 4)]
-fn subject(category: Category, subject: String) -> Template {
+fn subject(category: Category, subject: String) -> Result<Template, Status> {
     render_subject(category, subject, ENGLISH.into())
 }
 
 #[get("/<locale>/<category>/<subject>", rank = 14)]
-fn subject_locale(category: Category, subject: String, locale: SupportedLocale) -> Template {
+fn subject_locale(
+    category: Category,
+    subject: String,
+    locale: SupportedLocale,
+) -> Result<Template, Status> {
     render_subject(category, subject, locale.0)
 }
 
@@ -456,12 +460,24 @@ fn render_team(
     }
 }
 
-fn render_subject(category: Category, subject: String, lang: String) -> Template {
+fn render_subject(category: Category, subject: String, lang: String) -> Result<Template, Status> {
+    // Rocket's Template::render method is not really designed to accept arbitrary templates: if a
+    // template is missing, it just returns a Status::InternalServerError, without a way to
+    // distinguish it from a syntax error in the template itself.
+    //
+    // To work around the problem we check whether the template exists beforehand.
+    let path = Path::new("templates")
+        .join(category.name())
+        .join(format!("{}.hbs", subject));
+    if !path.is_file() {
+        return Err(Status::NotFound);
+    }
+
     let page = format!("{}/{}", category.name(), subject.as_str());
     let title_id = format!("{}-{}-page-title", category.name(), subject);
     let context = Context::new(subject, &title_id, false, (), lang);
 
-    Template::render(page, &context)
+    Ok(Template::render(page, &context))
 }
 
 fn main() {


### PR DESCRIPTION
Because of the way Rocket's `Template::render` method is designed, rendering arbitrary templates returns a 500 error if the underlying template file is missing. With our setup though that's not desirable, as we put the URL straight into the template path. The end result of this was that in most cases visiting a missing page returned a 500 instead of 404.

I audited the places where we call `Template::render`, and the one changed in this PR was the only vulnerable one (`/<category>` already did the check in `src/categories.rs`).