### PR TITLE
Fix escaping for Zulip streams

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,7 @@ mod sponsors;
 mod teams;
 
 use production::User;
+use teams::encode_zulip_stream;
 
 use std::collections::hash_map::DefaultHasher;
 use std::env;
@@ -488,6 +489,9 @@ fn main() {
         engine
             .handlebars
             .register_helper("team-text", Box::new(TeamHelper::new()));
+        engine
+            .handlebars
+            .register_helper("encode-zulip-stream", Box::new(encode_zulip_stream));
     });
 
     rocket::ignite()

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -100,13 +100,11 @@ impl Data {
             .into_iter()
             .filter(|team| team.website_data.is_some())
             .filter(|team| team.subteam_of.as_ref() == Some(&main_team.name))
-            .for_each(|team| {
-                match team.kind {
-                    TeamKind::Team => subteams.push(team),
-                    TeamKind::WorkingGroup => wgs.push(team),
-                    TeamKind::ProjectGroup => project_groups.push(team),
-                    _ => {}
-                }
+            .for_each(|team| match team.kind {
+                TeamKind::Team => subteams.push(team),
+                TeamKind::WorkingGroup => wgs.push(team),
+                TeamKind::ProjectGroup => project_groups.push(team),
+                _ => {}
             });
 
         Ok(PageData {
@@ -119,22 +117,26 @@ impl Data {
     }
 }
 
-pub fn encode_zulip_stream (
+pub fn encode_zulip_stream(
     h: &Helper,
     _: &Handlebars,
     _: &Context,
     _: &mut RenderContext,
-    out: &mut dyn Output
+    out: &mut dyn Output,
 ) -> HelperResult {
     let zulip_stream = if let Some(p) = h.param(0) {
         p.value()
     } else {
-        return Err(RenderError::new("{{encode-zulip-stream takes 1 parameter}}"))
+        return Err(RenderError::new(
+            "{{encode-zulip-stream takes 1 parameter}}",
+        ));
     };
     let zulip_stream = if let Some(s) = zulip_stream.as_str() {
         s
     } else {
-        return Err(RenderError::new("{{encode-zulip-stream takes a string parameter}}"))
+        return Err(RenderError::new(
+            "{{encode-zulip-stream takes a string parameter}}",
+        ));
     };
 
     // https://github.com/zulip/zulip/blob/159641bab8c248f5b72a4e736462fb0b48e7fa24/static/js/hash_util.js#L20-L25

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -286,7 +286,7 @@ mod tests {
             .website_data
             .as_ref()
             .and_then(|site| site.zulip_stream.as_deref());
-        assert_eq!(zulip_stream, Some("t-compiler.2Fwg-rls-2.2E0"));
+        assert_eq!(zulip_stream, Some("t-compiler/wg-rls-2.0"));
     }
 
     #[test]

--- a/templates/governance/group-team.hbs
+++ b/templates/governance/group-team.hbs
@@ -31,7 +31,7 @@
                 {{/if}}
                 {{#if team.website_data.zulip_stream}}
                     <div class="pt4 pt3-l flex flex-column flex-row-l items-center-l">
-                        <a class="button button-secondary" href="{{../data.zulip_domain}}/#narrow/stream/{{team.website_data.zulip_stream}}">
+                        <a class="button button-secondary" href="{{../data.zulip_domain}}/#narrow/stream/{{encode-zulip-stream team.website_data.zulip_stream}}">
                         {{#fluent "governance-team-zulip"}}{{#fluentparam "stream"}}#{{team.website_data.zulip_stream}}{{/fluentparam}}{{/fluent}}
                         </a>
                     </div>


### PR DESCRIPTION
This moves the escaping for Zulip streams out of the data pipeline and over to a
Handlebars helper. This in turn allows the group team template to make use of
both the unescaped (for display) and escaped (for the link) variants.

<img width="271" alt="image" src="https://user-images.githubusercontent.com/279572/99037125-092bc280-257b-11eb-8047-57e1035b9c1f.png">

Fixes https://github.com/rust-lang/www.rust-lang.org/issues/1274