### PR TITLE
fix video with in embedded showcase section

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -528,13 +528,10 @@ blockquote::before {
   object-fit: none;
 }
 
-#embedded-project-gallery {
+#embedded-showcase-gallery {
   iframe {
     width: 100%;
     height: 250px;
-  }
-  .button.button-secondary {
-    color: $yellow;
   }
 }
 


### PR DESCRIPTION
Hi

I've been browsing the site and noticed that on the embedded page the video is wider than the page and decided to go ahead and fix it. There was already an issue for this (#1308). I'll provide screenshots so you can see the changes. If there's anything that should be done differently please let me know!

<details>
<summary>Before</summary>

<img width="378" alt="Screenshot 2020-11-22 at 16 51 38" src="https://user-images.githubusercontent.com/27497229/99909328-259ccd00-2ce8-11eb-9c12-ba50a8ecb86e.png">
</details>


<details>
<summary>After</summary>

<img width="376" alt="Screenshot 2020-11-22 at 17 29 09" src="https://user-images.githubusercontent.com/27497229/99909347-4b29d680-2ce8-11eb-995f-1ce53d6ea7c8.png">


</details>