### PR TITLE
Fix alignements of blocks on several pages

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -55,6 +55,7 @@ code {
 pre > code {
   display: block;
   white-space: pre;
+  width: 100%;
 }
 
 .button,
@@ -722,10 +723,6 @@ section header {
 
 .download-link {
   color: $link-color;
-}
-
-#pb4 {
-  padding-bottom: 3.8em;
 }
 
 .max-height-5rem {

--- a/templates/community/index.hbs
+++ b/templates/community/index.hbs
@@ -94,7 +94,7 @@
         <div class="highlight"></div>
     </header>
     <div class="flex flex-column flex-row-l">
-      <div class="mw-25-l mh2-l min-h-100-l pt0 flex flex-column justify-start">
+      <div class="w-50-l mh2-l min-h-100-l pt0 flex flex-column justify-start">
         <div>
           <h2>{{fluent "community-read-about"}}</h2>
           <p>
@@ -108,7 +108,7 @@
           <a href="https://this-week-in-rust.org/" class="button button-secondary mb3">{{fluent "community-twir-button"}}</a>
         </span>
       </div>
-      <div class="mw-50-l mh2-l min-h-100-l pt0 flex flex-column justify-start">
+      <div class="w-50-l mh2-l min-h-100-l pt0 flex flex-column justify-start">
         <div>
           <h2>{{fluent "community-get-in-contact"}}</h2>
           <p>

--- a/templates/components/what/cli/example.hbs
+++ b/templates/components/what/cli/example.hbs
@@ -10,14 +10,14 @@
         </div>
 
         <div class="flex-l">
-            <article class="w-50-l mr4-l">
+            <article class="flex flex-column w-50-l mr4-l">
                 <h3>{{fluent "cli-example-inputs-heading"}}</h3>
-                <pre><code>{{> components/what/cli/code-inputs }}</code></pre>
+                <pre class="mt0 flex flex-grow-1"><code>{{> components/what/cli/code-inputs }}</code></pre>
             </article>
 
-            <article class="w-50-l ml4-l mt5 mt0-l">
+            <article class="flex flex-column w-50-l ml4-l mt5 mt0-l">
                 <h3>{{fluent "cli-example-main-heading"}}</h3>
-                <pre><code>{{> components/what/cli/code-main }}</code></pre>
+                <pre class="mt0 flex flex-grow-1"><code>{{> components/what/cli/code-main }}</code></pre>
             </article>
         </div>
 

--- a/templates/components/what/networking/get-started.hbs
+++ b/templates/components/what/networking/get-started.hbs
@@ -11,16 +11,16 @@
         </div>
 
         <div class="flex-l">
-            <article class="w-50-l mr4-l">
+            <article class="flex flex-column w-50-l mr4-l">
                 <h3>{{fluent "networking-get-started-post-json"}}</h3>
-                <pre><code>{{> components/what/networking/post-json }}</code></pre>
+                <pre class="mt0 flex flex-grow-1"><code>{{> components/what/networking/post-json }}</code></pre>
 
                 <a href="https://docs.rs/reqwest/" class="button button-secondary">{{fluent "networking-get-started-reqwest"}}</a>
             </article>
 
-            <article class="w-50-l ml4-l mt5 mt0-l">
+            <article class="flex flex-column  w-50-l ml4-l mt5 mt0-l">
                 <h3>{{fluent "networking-get-started-take-json"}}</h3>
-                <pre><code id="pb4">{{> components/what/networking/take-json }}</code></pre>
+                <pre class="mt0 flex flex-grow-1"><code>{{> components/what/networking/take-json }}</code></pre>
 
                 <a href="https://rocket.rs/" class="button button-secondary">{{fluent "networking-get-started-rocket"}}</a>
             </article>


### PR DESCRIPTION
On [Community](https://www.rust-lang.org/community), “Get in contact” section is more to the left than its button underneath.

<details><summary>Screenshots</summary>

## Before
![bildo](https://user-images.githubusercontent.com/2446451/100548382-825e3180-326c-11eb-8579-cb28e43e84fe.png)

## After
![bildo](https://user-images.githubusercontent.com/2446451/100548391-943fd480-326c-11eb-8dd1-311b58845c59.png)

</details>

On [Networking](https://www.rust-lang.org/what/networking), the right code block is not exactly the same size as the right code block because its height is set with a hackish `padding-bottom: 3.8em;`.

<details><summary>Screenshots</summary>

## Before
![bildo](https://user-images.githubusercontent.com/2446451/100548579-b0904100-326d-11eb-966e-8e7f9d55907f.png)


## After
![bildo](https://user-images.githubusercontent.com/2446451/100548532-6d35d280-326d-11eb-841e-ba590388c217.png)
</details>

On [Command-line apps](https://www.rust-lang.org/what/cli), same code was applied to make look a bit better, and to make the code between the two components almost same.

<details><summary>Screenshots</summary>

## Before
![bildo](https://user-images.githubusercontent.com/2446451/100548572-9fdfcb00-326d-11eb-845f-5bce3a9c5a2c.png)

## After
![bildo](https://user-images.githubusercontent.com/2446451/100548561-8fc7eb80-326d-11eb-8d80-d538c523bf73.png)
</details>