### PR TITLE
feat: Added additional resources to learn.rust-lang.org.

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -64,6 +64,19 @@ learn-unstable-alt = A hand sharing sparkles
 learn-unstable = The Unstable Book has documentation for unstable features that you can only use with nightly Rust.
 learn-unstable-button = Read the unstable book
 
+## Additional resources
+
+learn-additional-resources = Additional, as-yet unofficial, documentation that may be of help to you.
+
+learn-additional-resources-api-guidelines = The <cite>The Rust API Guidelines</cite> provide a concise list of things to do while designing a crate.  Make your crate awesome; follow the guidelines.
+learn-additional-resources-api-guidelines-button = Read the guidelines
+
+learn-additional-resources-design-patterns = Common Rust design patterns.  Ever heard of the builder pattern and wanted to learn more? Ever wondered about idiomatic Rust?  Look here.
+learn-additional-resources-design-patterns-button = Read the design patterns
+
+learn-additional-resources-cookbook = Rust recipes.  You're busy, and you need some good code, right now.  This might have the snippet you need.
+learn-additional-resources-cookbook-button = Read the cookbook
+
 ## learn/get-started.hbs
 
 learn-get-started-page-title = { getting-started }

--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -198,5 +198,40 @@
   </div>
 </section>
 
+<section id="learn-additional-resources" class="white">
+  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
+    <header>
+      <h2>{{fluent "learn-additional-resources"}}</h2>
+      <div class="highlight"></div>
+    </header>
+    <section class="flex flex-column flex-row-l pv0-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb6-ns ph4-l">
+        <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
+          <p class="flex-grow-1">{{fluent "learn-additional-resources-api-guidelines"}}</p>
+          <div class="buttons">
+            <a class="button button-secondary" href="https://rust-lang.github.io/api-guidelines/">{{fluent "learn-additional-resources-api-guidelines-button"}}</a>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb6-ns ph4-l">
+        <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
+          <p class="flex-grow-1">{{fluent "learn-additional-resources-design-patterns"}}</p>
+          <div class="buttons">
+            <a class="button button-secondary" href="https://rust-unofficial.github.io/patterns/">{{fluent "learn-additional-resources-design-patterns-button"}}</a>
+          </div>
+        </div>
+      </div>
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb6-ns ph4-l">
+        <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
+          <p class="flex-grow-1">{{fluent "learn-additional-resources-cookbook"}}</p>
+          <div class="buttons">
+            <a class="button button-secondary" href="https://rust-lang-nursery.github.io/rust-cookbook/">{{fluent "learn-additional-resources-cookbook-button"}}</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</section>
+
 {{/inline}}
 {{~> (parent)~}}


### PR DESCRIPTION
Relates to issue #1433.

Added 3 additional resources to learn.rust-lang.org in their own section:
- https://rust-lang.github.io/api-guidelines
- https://rust-unofficial.github.io/patterns
- https://rust-lang-nursery.github.io/rust-cookbook

**NOTE!** This commit requires additional work; I am not fluent in any
language other than US English, and so haven't attempted to add translations.
native speakers that are able to make the necessary changes are required
here.