### PR TITLE
Refactor redirects to be more consistent

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -90,7 +90,7 @@ pub const EXPLICIT_LOCALE_INFO: &[LocaleInfo] = &[
 ];
 
 lazy_static! {
-    static ref SUPPORTED_LOCALES: HashSet<&'static str> =
+    pub static ref SUPPORTED_LOCALES: HashSet<&'static str> =
         EXPLICIT_LOCALE_INFO.iter().map(|x| x.lang).collect();
 }
 pub struct TeamHelper {

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,77 +1,128 @@
-use std::str::Utf8Error;
+use crate::i18n::SUPPORTED_LOCALES;
+use rocket::http::uri::Segments;
+use rocket::response::Redirect;
 
-use rocket::{http::RawStr, request::FromParam};
+static PAGE_REDIRECTS: &[(&str, &str)] = &[
+    // Migrate pre-2018 locale for the index page
+    ("", ""),
+    // Pre-2018 website pages
+    ("community.html", "community"),
+    ("conduct.html", "policies/code-of-conduct"),
+    ("contribute-bugs.html", "community"),
+    ("contribute-community.html", "governance/teams/community"),
+    ("contribute-compiler.html", "governance/teams/compiler"),
+    ("contribute-docs.html", "governance/teams/documentation"),
+    ("contribute-libs.html", "governance/teams/library"),
+    ("contribute-tools.html", "governance/teams/dev-tools"),
+    ("contribute.html", "community"),
+    ("documentation.html", "learn"),
+    ("downloads.html", "tools/install"),
+    ("friends.html", "production"),
+    ("index.html", ""),
+    ("install.html", "tools/install"),
+    ("legal.html", "policies"),
+    ("security.html", "policies/security"),
+    ("team.html", "governance"),
+    ("user-groups.html", "community"),
+];
 
-pub struct Destination {
-    pub uri: &'static str,
-}
+static STATIC_FILES_REDIRECTS: &[(&str, &str)] = &[
+    // Pre-2018 whitepaper locations
+    (
+        "pdfs/Rust-npm-Whitepaper.pdf",
+        "/static/pdfs/Rust-npm-Whitepaper.pdf",
+    ),
+    (
+        "pdfs/Rust-Chucklefish-Whitepaper.pdf",
+        "/static/pdfs/Rust-Chucklefish-Whitepaper.pdf",
+    ),
+    (
+        "pdfs/Rust-Tilde-Whitepaper.pdf",
+        "/static/pdfs/Rust-Tilde-Whitepaper.pdf",
+    ),
+];
 
-impl<'r> FromParam<'r> for Destination {
-    type Error = NoRedirectFound;
+static EXTERNAL_REDIRECTS: &[(&str, &str)] = &[
+    // Pre-2018 website pages
+    (
+        "other-installers.html",
+        "https://forge.rust-lang.org/infra/other-installation-methods.html",
+    ),
+    // Pre-foundation website pages
+    (
+        "policies/privacy",
+        "https://foundation.rust-lang.org/policies/privacy-policy/",
+    ),
+];
 
-    fn from_param(param: &'r RawStr) -> Result<Self, Self::Error> {
-        let uri = match param.percent_decode()?.as_ref() {
-            "Rust-npm-Whitepaper.pdf" => "Rust-npm-Whitepaper.pdf",
-            "Rust-Chucklefish-Whitepaper.pdf" => "Rust-Chucklefish-Whitepaper.pdf",
-            "Rust-Tilde-Whitepaper.pdf" => "Rust-Tilde-Whitepaper.pdf",
-            "community.html" => "/community",
-            "conduct.html" => "/policies/code-of-conduct",
-            "contribute-bugs.html" => "/community",
-            "contribute-community.html" => "/governance/teams/community",
-            "contribute-compiler.html" => "/governance/teams/language-and-compiler",
-            "contribute-docs.html" => "/governance/teams/documentation",
-            "contribute-libs.html" => "/governance/teams/library",
-            "contribute-tools.html" => "/governance/teams/dev-tools",
-            "contribute.html" => "/community",
-            "documentation.html" => "/learn",
-            "downloads.html" => "/tools/install",
-            "friends.html" => "/production",
-            "index.html" => "/",
-            "install.html" => "/tools/install",
-            "legal.html" => "/policies",
-            "other-installers.html" => {
-                "https://forge.rust-lang.org/infra/other-installation-methods.html"
+// Translations present on www.rust-lang.org before the 2018 redesign. If an equivalent translation
+// is present in the current codebase it will be migrated automatically.
+static PRE_2018_LOCALES: &[&str] = &[
+    "de-DE", "en-US", "es-ES", "fr-FR", "id-ID", "it-IT", "ja-JP", "ko-KR", "pl-PL", "pt-BR",
+    "ru-RU", "sv-SE", "vi-VN",
+];
+
+pub(crate) fn maybe_redirect(segments: Segments<'_>) -> Option<Redirect> {
+    let path = segments.into_path_buf(false).ok()?.to_str()?.to_string();
+
+    if let Some((_, dest)) = STATIC_FILES_REDIRECTS.iter().find(|(src, _)| src == &path) {
+        return Some(Redirect::permanent(*dest));
+    }
+
+    let (locale, path) = if let Some((first, rest)) = path.split_once('/') {
+        if SUPPORTED_LOCALES.contains(&first) {
+            (Locale::Present(first), rest)
+        // After the 2018 website redesign some of the locales were removed and some were
+        // renamed (removing the country code). This handles both cases, either calculating the
+        // renamed locale or marking the locale as "specified but missing", which triggers a
+        // temporary redirect instead of a permanent redirect.
+        } else if PRE_2018_LOCALES.contains(&first) {
+            if let Some(locale) = convert_locale_from_pre_2018(first) {
+                (Locale::Present(locale), rest)
+            } else {
+                (Locale::SpecifiedButMissing, rest)
             }
-            "policies/privacy" => "https://foundation.rust-lang.org/policies/privacy-policy/",
-            "security.html" => "/policies/security",
-            "team.html" => "/governance",
-            "user-groups.html" => "/community",
-            _ => return Err(NoRedirectFound),
-        };
-        Ok(Destination { uri })
+        } else {
+            (Locale::NotSpecified, path.as_str())
+        }
+    } else {
+        if PRE_2018_LOCALES.contains(&path.as_str()) {
+            // If the whole path is a pre-2018 locale handle it as a localized index page.
+            if let Some(locale) = convert_locale_from_pre_2018(&path) {
+                (Locale::Present(locale), "")
+            } else {
+                (Locale::SpecifiedButMissing, "")
+            }
+        } else {
+            (Locale::NotSpecified, path.as_str())
+        }
+    };
+
+    if let Some((_, dest)) = EXTERNAL_REDIRECTS.iter().find(|(src, _)| *src == path) {
+        Some(Redirect::permanent(*dest))
+    } else if let Some((_, dest)) = PAGE_REDIRECTS.iter().find(|(src, _)| *src == path) {
+        let dest = format!("/{}", dest);
+        match locale {
+            Locale::Present("en-US") | Locale::NotSpecified => Some(Redirect::permanent(dest)),
+            Locale::Present(locale) => Some(Redirect::permanent(format!("/{}{}", locale, dest))),
+            Locale::SpecifiedButMissing => Some(Redirect::temporary(dest)),
+        }
+    } else {
+        None
     }
 }
 
-pub struct Locale(&'static str);
-
-impl<'r> FromParam<'r> for Locale {
-    type Error = NoRedirectFound;
-
-    fn from_param(param: &'r RawStr) -> Result<Self, Self::Error> {
-        match param.percent_decode()?.as_ref() {
-            "de-DE" => Ok(Locale("de-DE")),
-            "en-US" => Ok(Locale("en-US")),
-            "es-ES" => Ok(Locale("es-ES")),
-            "fr-FR" => Ok(Locale("fr-FR")),
-            "id-ID" => Ok(Locale("id-ID")),
-            "it-IT" => Ok(Locale("it-IT")),
-            "ja-JP" => Ok(Locale("ja-JP")),
-            "ko-KR" => Ok(Locale("ko-KR")),
-            "pl-PL" => Ok(Locale("pl-PL")),
-            "pt-BR" => Ok(Locale("pt-BR")),
-            "ru-RU" => Ok(Locale("ru-RU")),
-            "sv-SE" => Ok(Locale("sv-SE")),
-            "vi-VN" => Ok(Locale("vi-VN")),
-            _ => Err(NoRedirectFound),
+fn convert_locale_from_pre_2018(pre_2018: &str) -> Option<&str> {
+    if let Some(language) = pre_2018.split('-').next() {
+        if SUPPORTED_LOCALES.contains(&language) {
+            return Some(language);
         }
     }
+    None
 }
 
-#[derive(Debug)]
-pub struct NoRedirectFound;
-
-impl From<Utf8Error> for NoRedirectFound {
-    fn from(_: Utf8Error) -> Self {
-        Self
-    }
+enum Locale<'a> {
+    Present(&'a str),
+    SpecifiedButMissing,
+    NotSpecified,
 }


### PR DESCRIPTION
This commit does a complete refactoring of how the website handles redirects, fixing multiple problems with them:

* Redirects didn't handle localizations at all, always redirecting to the English website even when the proper localization exists.
* Redirects didn't work for multiple path segments, only supporting a single segment instead. For example no redirects on `/foo/bar` could have been created.
* Redirects didn't work if another route processed the URL and returned 404. For example this prevented a redirect for `/policies/privacy` as the request was already processed by `/policies/:name`.

The main changes in this commit are:

* Redirects are now handled in the 404 handler instead of dedicated redirect handlers with a lower priority: this allows redirects to be performed even when another handler processes the requests and explicitly returns a 404 status code.
* Redirects now support paths with an arbitrary amount of segments.
* Redirects now properly handle localizations: they work inside existing locales, they convert pre-2018 locales to current locales and only redirect to the English version when a pre-2018 locale does not exist anymore on the current codebase.

Fixes #767 #1504
r? @Manishearth 