### PR TITLE
fix(get-started): demo print '<' and '>' instead of '|'

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -101,7 +101,7 @@ fn main() {
     {{/fluentparam}}
     {{#fluentparam "output"}}
     <pre><code class="plaintext">----------------------------
-| Hello fellow Rustaceans! |
+< Hello fellow Rustaceans! >
 ----------------------------
               \
                \


### PR DESCRIPTION
I am a new learner of rust. I started my learning on https://www.rust-lang.org/learn/get-started

I found the second demo named `A small Rust application` should print
```
----------------------------
< Hello fellow Rustaceans! >
----------------------------
```

but not

```
----------------------------
| Hello fellow Rustaceans! |
----------------------------
```

so I raised this pr to fix this.