### PR TITLE
Remove link to ping.rust-lang.org from footer

### DIFF
--- a/locales/de/common.ftl
+++ b/locales/de/common.ftl
@@ -29,7 +29,6 @@ nav-logo-alt = Rust-Logo
 
 footer-doc = Dokumentation
 footer-ask = Stell deine Frage im Benutzer-Forum
-footer-status = Prüfe den Webseitenstatus
 footer-policies = Bedingungen und Richtlinien
 footer-coc = Verhaltenskodex
 footer-licenses = Lizenzen

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -42,7 +42,6 @@ nav-logo-alt = Rust Logo
 
 footer-doc = Documentation
 footer-ask = Ask a Question on the Users Forum
-footer-status = Check Website Status
 footer-sup-doc = Rust Forge (Contributor Documentation)
 footer-policies = Terms and policies
 footer-coc = Code of Conduct

--- a/locales/es/common.ftl
+++ b/locales/es/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Logo de Rust
 
 footer-doc = Documentación
 footer-ask = Preguntar en el foro de usuarios
-footer-status = Estado del website
 footer-sup-doc = Rust Forge (documentación para contribuidores)
 footer-policies = Términos y políticas
 footer-coc = Código de conducta

--- a/locales/fa/common.ftl
+++ b/locales/fa/common.ftl
@@ -29,7 +29,6 @@ nav-logo-alt = لوگوی Rust
 ## components/footer.hbs
 
 footer-doc = مستندات
-footer-status = وضعیت وب سایت را بررسی کنید
 footer-policies = قوانین و مقررات
 footer-licenses = مجوزها
 footer-security = افشای امنیتی

--- a/locales/fr/common.ftl
+++ b/locales/fr/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Logo de Rust
 
 footer-doc = Documentation
 footer-ask = Poser une question sur le forum utilisateurs
-footer-status = Vérifier le statut du site
 footer-sup-doc = Forge Rust (Documentation pour contributeur)
 footer-policies = Conditions générales d'utilisation
 footer-coc = Code de conduite

--- a/locales/it/common.ftl
+++ b/locales/it/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Logo di Rust
 
 footer-doc = Documentazione
 footer-ask = Chiedi nel Forum Utenti
-footer-status = Controlla lo stato del sito
 footer-sup-doc = Rust Forge (documentazione per i contributor)
 footer-policies = Termini e condizioni
 footer-coc = Codice di Condotta

--- a/locales/ja/common.ftl
+++ b/locales/ja/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Rustのロゴ
 
 footer-doc = ドキュメント
 footer-ask = ユーザーフォーラムで質問する
-footer-status = ウェブサイトのステータスを確認する
 footer-sup-doc = Rust Forge （コントリビュータ向けドキュメント）
 footer-policies = 規約とポリシー
 footer-coc = 行動規範

--- a/locales/ko/common.ftl
+++ b/locales/ko/common.ftl
@@ -35,7 +35,6 @@ nav-logo-alt = Rust 로고
 
 footer-doc = 문서
 footer-ask = 사용자 포럼에 질문하기 (영어)
-footer-status = 웹사이트 상태 확인
 footer-policies = 약관 및 정책
 footer-coc = 행동강령
 footer-licenses = 라이선스

--- a/locales/pl/common.ftl
+++ b/locales/pl/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Logo Rusta
 
 footer-doc = Dokumentacja
 footer-ask = Zadaj Pytanie na Forum Użytkowników
-footer-status = Sprawdź Status Witryny
 footer-sup-doc = Rust Forge (Dokumentacja dla Kontrybutorów)
 footer-policies = Warunki i zasady
 footer-coc = Kodeks Postępowania

--- a/locales/pt-BR/common.ftl
+++ b/locales/pt-BR/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Logo Rust
 
 footer-doc = Documentação
 footer-ask = Faça uma Pergunta no Fórum de Usuários
-footer-status = Confira o status do website
 footer-sup-doc = Rust Forge (Documentação para contribuidores)
 footer-policies = Termos e políticas
 footer-coc = Código de Conduta

--- a/locales/ru/common.ftl
+++ b/locales/ru/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Логотип Rust
 
 footer-doc = Документация
 footer-ask = Задать вопрос на пользовательском форуме
-footer-status = Проверить статус сайта
 footer-sup-doc = Rust Forge (Документация для контрибьюторов)
 footer-policies = Условия и политики
 footer-coc = Правила поведения

--- a/locales/tr/common.ftl
+++ b/locales/tr/common.ftl
@@ -37,7 +37,6 @@ nav-logo-alt = Rust Logosu
 
 footer-doc = Belgelendirme
 footer-ask = Kullanıcılar Forumunda Bir Soru Sorun
-footer-status = İnternet Sitesinin Durumunu Kontrol Et
 footer-policies = Şartlar ve politikalar
 footer-coc = Davranış Kuralları
 footer-licenses = Lisanslar

--- a/locales/xx-AU/common.ftl
+++ b/locales/xx-AU/common.ftl
@@ -17,7 +17,6 @@ nav-logo-alt = oƃo˥ ʇsnɹ
 # components/footer.hbs
 footer-doc = uoᴉʇɐʇuǝɯnɔop
 footer-ask = ɯnɹoℲ sɹǝs∩ ǝɥʇ uo uoᴉʇsǝnQ ɐ ʞs∀
-footer-status = snʇɐʇS ǝʇᴉsqǝM ʞɔǝɥƆ
 footer-policies = sǝᴉɔᴉlod puɐ sɯɹǝ┴
 footer-coc = ʇɔnpuoƆ ɟo ǝpoƆ
 footer-licenses = sǝsuǝɔᴉ˥

--- a/locales/zh-CN/common.ftl
+++ b/locales/zh-CN/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Rust 标志
 
 footer-doc = 文档
 footer-ask = 在用户论坛提问
-footer-status = 检查网站状态
 footer-sup-doc = Rust Forge（贡献者文档）
 footer-policies = 条款与政策
 footer-coc = 行为准则

--- a/locales/zh-TW/common.ftl
+++ b/locales/zh-TW/common.ftl
@@ -38,7 +38,6 @@ nav-logo-alt = Rust 標誌
 
 footer-doc = 技術文件
 footer-ask = 在使用者論壇提問
-footer-status = 檢查網站狀態
 footer-sup-doc = Rust Forge（貢獻者文件）
 footer-policies = 條款和政策
 footer-coc = 行為準則

--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -7,7 +7,6 @@
           <li><a href="{{baseurl}}/learn">{{fluent "footer-doc"}}</a></li>
           <li><a href="http://forge.rust-lang.org">{{fluent "footer-sup-doc"}}</a></li>
           <li><a href="https://users.rust-lang.org">{{fluent "footer-ask"}}</a></li>
-          <li><a href="http://ping.rust-lang.org">{{fluent "footer-status"}}</a></li>
         </ul>
         <div class="languages">
             <label for="language-footer" class="hidden">{{fluent "choose-language"}}</label>


### PR DESCRIPTION
The site has not been up for over a month, and through chatting with
some folks from the infra team on [Zulip], it seems they would prefer to
remove the link rather than trying to restore the site.

I agree that a separate site for status is not awfully useful, as
www.rust-lang.org is mostly if not entirely static content. Simply
visiting the site checks whether it is available.

cc @Mark-Simulacrum @pietroalbini

[Zulip]: https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/rust-lang.2Eorg.20.20issues/near/268123956

Closes GH-1619