### PR TITLE
build: Verify checksum of `rustup-init`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,11 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y \
 
 # Install the currently pinned toolchain with rustup
 COPY rust-toolchain /tmp/
-RUN curl https://static.rust-lang.org/rustup/dist/x86_64-unknown-linux-gnu/rustup-init >/tmp/rustup-init && \
+ENV RUSTUP_VERSION="1.24.3"
+ENV RUSTUP_TRIPLE="x86_64-unknown-linux-gnu"
+ENV RUSTUP_SHA="3dc5ef50861ee18657f9db2eeb7392f9c2a6c95c90ab41e45ab4ca71476b4338"
+RUN curl "https://static.rust-lang.org/rustup/archive/${RUSTUP_VERSION}/${RUSTUP_TRIPLE}/rustup-init" >/tmp/rustup-init && \
+    echo "${RUSTUP_SHA}  /tmp/rustup-init" | sha256sum --check && \
     chmod +x /tmp/rustup-init && \
     /tmp/rustup-init -y --no-modify-path --default-toolchain $(cat /tmp/rust-toolchain)
 ENV PATH=/root/.cargo/bin:$PATH


### PR DESCRIPTION
Adds a checksum verification of `rustup-init` before running it.