### PR TITLE
Use translated text for policy footer

### DIFF
--- a/templates/components/footer.hbs
+++ b/templates/components/footer.hbs
@@ -22,7 +22,7 @@
           <li><a href="{{baseurl}}/policies/licenses">{{fluent "footer-licenses"}}</a></li>
           <li><a href="{{baseurl}}/policies/media-guide">{{fluent "footer-media"}}</a></li>
           <li><a href="{{baseurl}}/policies/security">{{fluent "footer-security"}}</a></li>
-          <li><a href="https://foundation.rust-lang.org/policies/privacy-policy/">Privacy Policy</a></li>
+          <li><a href="https://foundation.rust-lang.org/policies/privacy-policy/">{{fluent "policies-privacy-link"}}</a></li>
           <li><a href="{{baseurl}}/policies">{{fluent "footer-policies-all"}}</a></li>
         </ul>
       </div>


### PR DESCRIPTION
Removing this was a mistake