### PR TITLE
Use TLSv1.3 with curl if specified at all

### DIFF
--- a/templates/components/tools/rustup.hbs
+++ b/templates/components/tools/rustup.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div id="platform-instructions-unix" class="instructions db">
     <p>{{fluent "tools-rustup-unixy"}}</p>
-    <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+    <pre><code class="db w-100">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</code></pre>
   </div>
   <div id="platform-instructions-win" class="instructions dn">
     <p>{{fluent "tools-rustup-windows-2"}}</p>
@@ -17,7 +17,7 @@
   </div>
   <h3 class="mt4">{{fluent "tools-rustup-wsl-heading"}}</h3>
   <p>{{fluent "tools-rustup-wsl"}}</p>
-  <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+  <pre><code class="db w-100">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</code></pre>
   </div>
   <div id="platform-instructions-unknown" class="instructions dn">
     <!-- unrecognized platform: ask for help -->
@@ -39,7 +39,7 @@
       <p>
         {{fluent "tools-rustup-manual-unixy"}}
       </p>
-      <code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code>
+      <code class="db w-100">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</code>
     </div>
     <hr>
     <div>
@@ -53,7 +53,7 @@
       <p>
         {{tools-rustup-manual-default}}
       </p>
-      <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+      <pre><code class="db w-100">curl --proto '=https' --tlsv1.3 -sSf https://sh.rustup.rs | sh</code></pre>
     </div>
     <hr>
     <div>


### PR DESCRIPTION
The curl option specified to use TLSv1.2 explicity while nowadays 1.3
is availalble and recommended.
Switch to specifying 1.3 instead of 1.2 for the command that downloads
the install script.

See https://github.com/rust-lang/book/pull/3130 and https://github.com/rust-lang/rustup/pull/2996