### PR TITLE
fix: center production user names (fixes #1688)

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -475,6 +475,11 @@ blockquote::before {
   min-height: 100px;
 }
 
+.user-name {
+  display: flex;
+  justify-content: center;
+}
+
 .user-container {
   min-height: 300px;
 }

--- a/templates/production/users.hbs
+++ b/templates/production/users.hbs
@@ -17,7 +17,7 @@
                 <img src="/static/images/user-logos/{{ u.logo }}" alt="{{ u.logo }}" />
               </a>
             </div>
-            <h4 class="f2 fw6">{{ u.name }}</h4>
+            <h4 class="user-name f2 fw6">{{ u.name }}</h4>
             <p>{{{ u.how }}}</p>
           </div>
         {{/each~}}


### PR DESCRIPTION
Addresses issue #1688
Production user names can be incorrectly centered if they contain long words. This PR addresses this by adding a class for user names with simple styling to ensure centered content even with overflow, while not affecting appearance of shorter user names.
Before: 
![image](https://user-images.githubusercontent.com/59463268/174467324-25065b08-22c8-40aa-b250-f2a1221824b4.png)
After:
![image](https://user-images.githubusercontent.com/59463268/174467329-8d9b8c3a-fe8c-4186-9340-599767ab3bd8.png)

