### PR TITLE
Update rustup documentation links

### DIFF
--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -74,7 +74,7 @@ install-notes-rustup-heading = Toolchain management with <code>rustup</code>
 install-notes-rustup-description = 
         <p>
           Rust is installed and managed by the
-          <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>
+          <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>
           tool. Rust has a 6-week
           <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
             rapid release process
@@ -92,7 +92,7 @@ install-notes-rustup-description =
         </p>
         <p>
           For more information see the
-          <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+          <a href="https://rust-lang.github.io/rustup/">
           <code>rustup</code> documentation</a>.
         </p>
 
@@ -143,7 +143,7 @@ install-notes-windows-description =
         </p>
         <p>
           For further information about configuring Rust on Windows see the
-          <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+          <a href="https://rust-lang.github.io/rustup/installation/windows.html">
           Windows-specific <code>rustup</code> documentation</a>.
         </p>
 

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -35,7 +35,7 @@ install-notes-rustup-heading = Gestión del conjunto de herramientas con <code>r
 install-notes-rustup-description =
     <p>
     Rust es instalado y gestionado por la herramienta 
-    <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>. 
+    <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>.
     Rust tiene un
     <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
     proceso rápido de lanzamiento
@@ -51,7 +51,7 @@ install-notes-rustup-description =
     </p>
     <p>
     Para más información visita la documentación de
-    <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+    <a href="https://rust-lang.github.io/rustup/">
           <code>rustup</code></a>.
     </p>
 install-notes-uninstall-heading = Desinstalar Rust
@@ -96,7 +96,7 @@ install-notes-windows-description =
     </p>
     <p>
       Para más información sobre la configuración de Rust en Windows, consulta la
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       documentación específica de Windows para <code>rustup</code></a>.
     </p>
 install-other-methods-heading = Otros métodos de instalación

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -34,7 +34,7 @@ install-notes-getting-started-description = Si vous commencez avec Rust et que v
 install-notes-rustup-heading = Gestion des chaînes d'outils avec <code>rustup</code>
 install-notes-rustup-description =
     <p>
-      Rust est installé et géré par l'outil <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>. Rust suit un 
+      Rust est installé et géré par l'outil <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>. Rust suit un
       <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
         processus de publication rapide
       </a> avec une nouvelle version toutes les six semaines et il supporte un <a href="https://forge.rust-lang.org/release/platform-support.html">grand nombre de plateformes</a>, donc il y a de nombreuses versions de Rust disponibles en même temps. <code>rustup</code> gère ces différentes versions de manière consistante sur toutes les plateformes supportées par Rust, permettant l'installation de Rust depuis les canaux beta et nightly ainsi que le support de cibles de cross-compilation supplémentaires.
@@ -44,7 +44,7 @@ install-notes-rustup-description =
     </p>
     <p>
       Pour plus d'information, visitez la
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+      <a href="https://rust-lang.github.io/rustup/">
       documentation de <code>rustup</code></a>.
     </p>
 install-notes-uninstall-heading = Désinstaller Rust
@@ -82,7 +82,7 @@ install-notes-windows-description =
     </p>
     <p>
       Pour plus d'informations sur la configuration de Rust sur Windows, visitez la
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       documentation de <code>rustup</code> spécifique à Windows</a>.
     </p>
 install-other-methods-heading = Autres méthodes d'installation

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -34,7 +34,7 @@ install-rustup64-button = Scarica <span class="nowrap">rustup-init.exe</span> <s
 install-notes-heading = Note sull'installazione di Rust
 install-notes-getting-started-description = Se stai iniziando con Rust e vorresti una guida passo passo più dettagliata, guarda la nostra pagina <a href="{ $getting-started-href }">getting started</a> .
 install-notes-rustup-heading = Gestione della toolchain con <code>rustup</code>
-install-notes-rustup-description = Rust è installato e gestito da <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>. Rust ha un rapido <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">ciclo di rilasci</a> di 6 settimane e supporta una <a href="https://forge.rust-lang.org/release/platform-support.html">grande quantità di piattaforme</a>, quindi ci sono sempre molteplici build di Rust disponibili. <code>rustup</code> gestisce queste build in maniera coerente su qualsiasi piattaforma supportata dalle release beta e nightly così come il supporto alla cross-compilation per differenti target.
+install-notes-rustup-description = Rust è installato e gestito da <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>. Rust ha un rapido <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">ciclo di rilasci</a> di 6 settimane e supporta una <a href="https://forge.rust-lang.org/release/platform-support.html">grande quantità di piattaforme</a>, quindi ci sono sempre molteplici build di Rust disponibili. <code>rustup</code> gestisce queste build in maniera coerente su qualsiasi piattaforma supportata dalle release beta e nightly così come il supporto alla cross-compilation per differenti target.
 install-notes-uninstall-heading = Disinstalla Rust
 install-notes-uninstall-description =
     <p>
@@ -71,7 +71,7 @@ install-notes-windows-description =
     </p>
     <p>
     Puoi trovare ulteriori informazioni su come configurare Rust in Windows a questo link di
-    <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+    <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       documentazione specifica per <code>rustup</code> su Windows</a>.
     </p>
 install-other-methods-heading = Altri metodi di installazione

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -36,7 +36,7 @@ install-notes-getting-started-description = Rustをこれから始めようと�
 install-notes-rustup-heading = <code>rustup</code>を使ったツールチェーンの管理
 install-notes-rustup-description =
     <p>
-    Rustは<a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>というツールによってインストール・管理されます。
+    Rustは<a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>というツールによってインストール・管理されます。
     Rustには６週間ごとの<a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">ラピッドリリースプロセス</a>があり、<a href="https://forge.rust-lang.org/release/platform-support.html">多数のプラットフォーム</a>をサポートしているので、 数多くのビルドがいつても利用できます。
     <code>rustup</code>はこれらのビルドを、Rustがサポートしているすべてのプラットフォームで一貫した方法で管理し、betaやnightly版のリリースチャンネルや、追加のクロスコンパイルターゲットもサポートしています。
     </p>
@@ -44,7 +44,7 @@ install-notes-rustup-description =
     もし<code>rustup</code>で過去にRustをインストールしたならば、いつでも<code>rustup update</code>を実行することでインストールしたものをアップデートできます。
     </p>
     <p>
-    より詳しい情報は<a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md"><code>rustup</code>のドキュメント</a>を参照してください。
+    より詳しい情報は<a href="https://rust-lang.github.io/rustup/"><code>rustup</code>のドキュメント</a>を参照してください。
     </p>
 install-notes-uninstall-heading = Rustをアンインストールする
 install-notes-uninstall-description =
@@ -73,7 +73,7 @@ install-notes-windows-description =
     他には、Visual Studio 2019、Visual Studio 2017、Visual Studio 2015、Visual Studio 2013のいずれかを<a href="https://www.visualstudio.com/downloads/">インストール</a>し、インストール時に「C++ tools」を選択することでもできます。
     </p>
     <p>
-    WindowsでのRustの設定についての詳しい情報は、<a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">Windows用の<code>rustup</code>ドキュメント</a>を参照してください。
+    WindowsでのRustの設定についての詳しい情報は、<a href="https://rust-lang.github.io/rustup/installation/windows.html">Windows用の<code>rustup</code>ドキュメント</a>を参照してください。
     </p>
 install-other-methods-heading = その他のインストール方法
 install-other-methods-description = 上記の<code>rustup</code>によるインストールが、ほとんどの開発者にとってRustをインストールをする好ましい方法です。しかし、Rustは他の方法でもインストールすることができます。

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -49,7 +49,7 @@ install-notes-rustup-heading = Gerenciamento de ferramentas com <code>rustup</co
 install-notes-rustup-description =
     <p>
       Rust é instalado e gerenciado pela ferramenta
-      <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>.
+      <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>.
       Rust possui um rápido processo
     <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
     de lançamentos a cada 6 semanas
@@ -67,7 +67,7 @@ install-notes-rustup-description =
     </p>
     <p>
       Para mais informações confira a documentação do
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+      <a href="https://rust-lang.github.io/rustup/">
       <code>rustup</code></a>.
     </p>
 install-notes-uninstall-heading = Desinstalar Rust
@@ -117,7 +117,7 @@ install-notes-windows-description =
     </p>
     <p>
     Para mais informações sobre como configurar Rust no Windows consulte a
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
     documentação específica sobre Windows do <code>rustup</code></a>.
     </p>
 install-other-methods-heading = Outros métodos de instalação

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -35,7 +35,7 @@ install-notes-rustup-heading = Управление инструментами �
 install-notes-rustup-description =
     <p>
       Rust устанавливается и управляется при помощи
-      <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>. Rust имеет 6-недельный
+      <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>. Rust имеет 6-недельный
       <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
         процесс выпуска
       </a> и поддерживает
@@ -47,7 +47,7 @@ install-notes-rustup-description =
     </p>
     <p>
     Для дополнительной информации смотрите
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+      <a href="https://rust-lang.github.io/rustup/">
       документацию по <code>rustup</code></a>.
     </p>
 install-notes-uninstall-heading = Удалить Rust
@@ -94,7 +94,7 @@ install-notes-windows-description =
     </p>
     <p>
       Для получения дополнительной информации о настройке Rust в Windows, смотрите
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       Windows-специфичную документацию <code>rustup</code></a>.
     </p>
 install-other-methods-heading = Другие методы установки

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -66,7 +66,7 @@ install-notes-getting-started-description =
 install-notes-rustup-heading = <code>Rustup</code> ile araç zincirinin yönetimi
 install-notes-rustup-description =
     <p>
-      Rust, <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a> aracı ile yüklenir ve
+      Rust, <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a> aracı ile yüklenir ve
       yönetilir. Rust'ın 6 haftalık <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
         hızlı yayımlama süreci
       </a> vardır ve 
@@ -81,7 +81,7 @@ install-notes-rustup-description =
     </p>
     <p>
       Daha fazla bilgi için
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+      <a href="https://rust-lang.github.io/rustup/">
       <code>rustup</code> belgelendirmesine</a> bakabilirsiniz.
     </p>
 install-notes-path-heading = <code>PATH</code> ortam değişkenini yapılandırma
@@ -102,7 +102,7 @@ install-notes-windows-description =
     </p>
     <p>
       Rust'ı Windows'ta yapılandırmak hakkında daha fazla bilgiye
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       Windows'a özgü <code>rustup</code> belgelendirmesi</a>nden ulaşabilirsiniz.
     </p>
 install-other-methods-heading = Diğer kurulum yöntemleri

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -49,7 +49,7 @@ install-notes-rustup-heading = 用 <code>rustup</code> 管理工具链
 install-notes-rustup-description =
     <p>
        Rust 由工具
-       <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a>
+       <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>
        安装和管理。Rust 有着以 6 星期为周期的
        <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
          快速版本迭代机制</a>，支持
@@ -64,7 +64,7 @@ install-notes-rustup-description =
      </p>
      <p>
        更多信息请查阅
-       <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+       <a href="https://rust-lang.github.io/rustup/">
        <code>rustup</code> 文档</a>。
      </p>
 install-notes-uninstall-heading = 卸载 Rust
@@ -108,7 +108,7 @@ install-notes-windows-description =
     </p>
     <p>
       有关在 Windows 上配置 Rust 的更多信息见
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       Windows 专用的 <code>rustup</code> 文档</a>。
     </p>
 install-other-methods-heading = 其它安装方式

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -34,13 +34,13 @@ install-notes-getting-started-description = 如果您正要開始使用 Rust，�
 install-notes-rustup-heading = 用 <code>rustup</code> 管理工具鏈
 install-notes-rustup-description =
     <p>
-      <a href="https://github.com/rust-lang/rustup.rs"><code>rustup</code></a> 是負責安裝及管理 Rust 的工具。Rust 以六星期為週期進行<a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">快速的版本發行</a>，而且支援<a href="https://forge.rust-lang.org/release/platform-support.html">大量不同的平台</a>，因此不論何時 Rust 都有許多不同的建構版本。<code>rustup</code> 在所有平台上用統一的方式管理這些不同版本，讓您可以同時安裝 beta 或 nightly 通道的 Rust 工具，或是進行跨平台編譯。
+      <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a> 是負責安裝及管理 Rust 的工具。Rust 以六星期為週期進行<a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">快速的版本發行</a>，而且支援<a href="https://forge.rust-lang.org/release/platform-support.html">大量不同的平台</a>，因此不論何時 Rust 都有許多不同的建構版本。<code>rustup</code> 在所有平台上用統一的方式管理這些不同版本，讓您可以同時安裝 beta 或 nightly 通道的 Rust 工具，或是進行跨平台編譯。
     </p>
     <p>
       如果您之前已經安裝過 <code>rustup</code>，您可以用 <code>rustup update</code> 指令來更新它。
     </p>
     <p>
-      請參考 <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md">
+      請參考 <a href="https://rust-lang.github.io/rustup/">
       <code>rustup</code> 文件</a> 以取得更多資訊。
     </p>
 install-notes-uninstall-heading = 解除安裝 Rust
@@ -82,7 +82,7 @@ install-notes-windows-description =
     </p>
     <p>
       有關更多關於在 Windows 系統上安裝 Rust 的資訊詳見
-      <a href="https://github.com/rust-lang/rustup.rs/blob/master/README.md#working-with-rust-on-windows">
+      <a href="https://rust-lang.github.io/rustup/installation/windows.html">
       Windows 專屬 <code>rustup</code> 文件</a>。
     </p>
 install-other-methods-heading = 其它安裝方式


### PR DESCRIPTION
Rustup's documentation moved out of the README page a long while ago to https://rust-lang.github.io/rustup/. This updates the links to the new home.
