### PR TITLE
learn: change "grow with Rust" to "documentation"

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -14,7 +14,7 @@ learn-rbe-button = Check out Rust by Example!
 translated-rbe = {""}
 translated-rbe-button = {""}
 
-learn-use = Grow with Rust
+learn-use = Documentation
 
 learn-doc-heading = Read the core documentation
 learn-doc = All of this documentation is also available locally using the <code>rustup doc</code> command, which will open up these resources for you in your browser without requiring a network connection!


### PR DESCRIPTION
Rationale:

 - "grow with Rust" requires some idiomatic, non-literal interpretation, while "documentation" is plainer English.
 - When people are looking for documentation, they are usually skimming the site for the literal word "documentation".
 - Anecdotally, whenever I type "doc.rust-lang.org" in my URL bar and got redirected to https://www.rust-lang.org/learn, I thought I had made a horrible mistake, because the page I wound up on seemed to have nothing to do with the documentation I was expecting from doc.rust-lang.org. (see also https://github.com/rust-lang/rust/issues/77537).