### PR TITLE
Remove excess padding-bottom on learn page

### DIFF
--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -13,7 +13,7 @@
       <div class="highlight"></div>
     </header>
     <section class="flex flex-column flex-row-l pv0-l">
-      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb6-ns ph4-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
         <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-book"}}</p>
           <div class="buttons">
@@ -22,7 +22,7 @@
           </div>
         </div>
       </div>
-      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb6-ns ph4-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
         <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-rustlings"}}</p>
           <div class="buttons">
@@ -30,7 +30,7 @@
           </div>
         </div>
       </div>
-      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb6-ns ph4-l">
+      <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
         <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-rbe"}}</p>
           <div class="buttons">


### PR DESCRIPTION
Each of the action items in the first section of the learn page has its own padding-bottom, which is added to the padding-bottom of the section it's contained in. I believe this was a mistake, since all other pages appear to use the section's padding-bottom.

Fixes #1727 

After:

<img src="https://user-images.githubusercontent.com/220205/197377788-519fa981-4c5a-48b1-96a5-ae6a5c40d487.png" width=200>

Before:

<img src="https://user-images.githubusercontent.com/220205/197377070-5b631874-8846-4b72-adc8-fc650edd7555.png" width=200>