### PR TITLE
Remove /stable/ in a couple of links

### DIFF
--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -138,7 +138,7 @@ install-notes-windows-description =
         <p>
           On Windows, Rust additionally requires the MSVC build tools
           for Visual Studio 2013 or later. See
-          <a href="https://doc.rust-lang.org/stable/book/ch01-01-installation.html#installing-rustup-on-windows">
+          <a href="https://doc.rust-lang.org/book/ch01-01-installation.html#installing-rustup-on-windows">
           Installing <code>rustup</code> on Windows</a>
         </p>
         <p>

--- a/templates/learn/index.hbs
+++ b/templates/learn/index.hbs
@@ -34,7 +34,7 @@
         <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-rbe"}}</p>
           <div class="buttons">
-            <a class="button button-secondary" href="https://doc.rust-lang.org/stable/rust-by-example/">{{fluent "learn-rbe-button"}}</a>
+            <a class="button button-secondary" href="https://doc.rust-lang.org/rust-by-example/">{{fluent "learn-rbe-button"}}</a>
             {{#if (fluent "translated-rbe")}}<a class="button-additional" href={{fluent "translated-rbe"}}>{{fluent "translated-rbe-button"}}</a>{{/if}}
           </div>
         </div>


### PR DESCRIPTION
The default channel for docs on doc.rust-lang.org is stable, so adding an explicit /stable/ in the URL is redundant (and splits pagerank).