### PR TITLE
Update locales/zh-CN/learn.ftl

### DIFF
--- a/locales/zh-CN/learn.ftl
+++ b/locales/zh-CN/learn.ftl
@@ -121,7 +121,7 @@ learn-ferris-who = 这只螃蟹是谁？ Ferris ？
 learn-ferris =
     <p>Ferris 是 Rust 社区的非官方吉祥物。很多 Rust 程序员自称“Rustaceans”，
     它与“<a href="https://en.wikipedia.org/wiki/Crustacean">crustacean</a>”相似。
-    我们用“they”、“them”等代词，而不用带性别的代词来指代 Ferris。</p>
+    我们可以用“她”、“他”、“它”等任何代词来指代 Ferris。</p>
     <p>Ferris 与形容词“ferrous”相似，它的含义与铁有关。由于 Rust（锈）通常由铁形成，
     因此它算得上是个吉祥物名字的有趣来源。</p>
     <p>您可以在 <a href="http://rustacean.net/">http://rustacean.net/</a> 上找到更多


### PR DESCRIPTION
The original text is: 
[We refer to Ferris with any pronouns “she,” “he,” “they,” “it,” etc.](https://github.com/rust-lang/www.rust-lang.org/blob/5d64fda39b9fc96073ff28eeeb9db2e70de0b053/locales/en-US/learn.ftl#L144)