### PR TITLE
Updated the ferris-says example

### DIFF
--- a/locales/en-US/learn.ftl
+++ b/locales/en-US/learn.ftl
@@ -119,7 +119,7 @@ learn-dependencies-steps = <p>Let’s add a dependency to our application. You c
       <p>In this project, we’ll use a crate called <a href="https://crates.io/crates/ferris-says"><code>ferris-says</code></a>.
       <p>In our <code>Cargo.toml</code> file we’ll add this information (that we got from the crate page):</p>
       { $cargotoml }
-      <p>We can also do this by running <code>cargo add ferris-says@0.2</code>.</p>
+      <p>We can also do this by running <code>cargo add ferris-says@0.3.1</code>.</p>
       <p>Now we can run:</p>
       <p><code>cargo build</code></p>
       <p>...and Cargo will install our dependency for us.</p>

--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -71,7 +71,7 @@ Hello, world!</code></pre>
     {{#fluent "learn-dependencies-steps"}}
     {{#fluentparam "cargotoml"}}
       <pre><code>[dependencies]
-ferris-says = "0.2"</code></pre>
+ferris-says = "0.3.1"</code></pre>
     {{/fluentparam}}
     {{/fluent}}
 
@@ -87,15 +87,14 @@ ferris-says = "0.2"</code></pre>
     {{#fluent "learn-app-steps"}}
     {{#fluentparam "code"}}
 <pre><code>use ferris_says::say; // from the previous step
-use std::io::{stdout, BufWriter};
+use std::io::{ stdout, BufWriter };
 
 fn main() {
-    let stdout = stdout();
-    let message = String::from("Hello fellow Rustaceans!");
+    let message = "Hello fellow Rustaceans!";
     let width = message.chars().count();
 
-    let mut writer = BufWriter::new(stdout.lock());
-    say(message.as_bytes(), width, &mut writer).unwrap();
+    let mut writer = BufWriter::new(stdout().lock());
+    say(message, width, &mut writer).unwrap();
 }
     </code></pre>
     {{/fluentparam}}


### PR DESCRIPTION
Updated the ferris-says example, fixing the issue https://github.com/rust-lang/www.rust-lang.org/issues/1736

For some reason, github shows that I changed a massive amount of code, which is incorrect. The only things that I changed are:
- In file locales/en-US/learn.ftl, at line 122 I changed the 'ferris-says@0.2' to 'ferris-says@0.3.1'
- In file templates/learn/get-started.hbs:
    * at line 74 I changed 'ferris-says = "0.2"' to 'ferris-says = "0.3.1"'
    * at lines 89 - 99 I changed the code so it matches the new way the 'say' function works and made the code more beginner friendly

I also checked if this change affects other languages; it does not, so it's ready to be merged.