### PR TITLE
fix: use a string instead of bytes array

### DIFF
--- a/templates/learn/get-started.hbs
+++ b/templates/learn/get-started.hbs
@@ -95,7 +95,7 @@ fn main() {
     let width = message.chars().count();
 
     let mut writer = BufWriter::new(stdout.lock());
-    say(message.as_bytes(), width, &mut writer).unwrap();
+    say(message.as_str(), width, &mut writer).unwrap();
 }
     </code></pre>
     {{/fluentparam}}


### PR DESCRIPTION
This issue fixes the code example on the getting started page.

It resolves #1790