### PR TITLE
Fix button style for long text

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -78,6 +78,7 @@ pre > code {
   border: 1px solid;
   cursor: pointer;
   box-sizing: border-box;
+  white-space: nowrap;
 
   &:hover,
   &:focus {


### PR DESCRIPTION
Fixes #1780

Without white-space: nowrap;, the text inside the button can wrap in unexpected ways due to its placement for long text.