### PR TITLE
Move release-profile bind address to Rocket.toml

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: ROCKET_PORT=$PORT RUST_BACKTRACE=1 ROCKET_ADDRESS=0.0.0.0 ROCKET_PROFILE=release ./target/release/www-rust-lang-org
+web: ROCKET_PORT=$PORT RUST_BACKTRACE=1 ROCKET_PROFILE=release ./target/release/www-rust-lang-org

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,3 +1,7 @@
 [debug]
 address = "127.0.0.1"
 port = 7878
+
+[release]
+# MUST be 0.0.0.0 for Heroku to work
+address = "0.0.0.0"


### PR DESCRIPTION
More resilient for the heroku build since it doesn't rely on Procfile configs