### PR TITLE
Fix whitespace around fluent parameter

### DIFF
--- a/templates/policies/code-of-conduct.html.hbs
+++ b/templates/policies/code-of-conduct.html.hbs
@@ -41,9 +41,7 @@
       <div class="highlight"></div>
     </header>
     {{#fluent "coc-moderation-description"}}
-      {{#fluentparam "coc-rust-moderation-team-anchor"}}
-        <a href="{{baseurl}}/governance/teams/moderation">{{fluent "coc-moderation-description-team-anchor-text"}}</a>
-      {{/fluentparam}}
+      {{#fluentparam "coc-rust-moderation-team-anchor"}}<a href="{{baseurl}}/governance/teams/moderation">{{fluent "coc-moderation-description-team-anchor-text"}}</a>{{/fluentparam}}
     {{/fluent}}
   </div>
 </section>


### PR DESCRIPTION
closes #1793

I checked all other occurrences of `#fluentparam`, it seems to be the only place where this is a problem.