### PR TITLE
Use installation instruction with rustup as recommended in forge and rustup

### DIFF
--- a/templates/components/tools/rustup.html.hbs
+++ b/templates/components/tools/rustup.html.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div id="platform-instructions-unix" class="instructions db">
     <p>{{fluent "tools-rustup-unixy"}}</p>
-    <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+    <pre><code class="db w-100">curl https://sh.rustup.rs -sSf | sh</code></pre>
   </div>
   <div id="platform-instructions-win" class="instructions dn">
     <p>{{fluent "tools-rustup-windows-2"}}</p>
@@ -17,7 +17,7 @@
   </div>
   <h3 class="mt4">{{fluent "tools-rustup-wsl-heading"}}</h3>
   <p>{{fluent "tools-rustup-wsl"}}</p>
-  <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+  <pre><code class="db w-100">curl https://sh.rustup.rs -sSf | sh</code></pre>
   </div>
   <div id="platform-instructions-unknown" class="instructions dn">
     <!-- unrecognized platform: ask for help -->
@@ -39,7 +39,7 @@
       <p>
         {{fluent "tools-rustup-manual-unixy"}}
       </p>
-      <code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code>
+      <code class="db w-100">curl https://sh.rustup.rs -sSf | sh</code>
     </div>
     <hr>
     <div>
@@ -53,7 +53,7 @@
       <p>
         {{tools-rustup-manual-default}}
       </p>
-      <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+      <pre><code class="db w-100">curl https://sh.rustup.rs -sSf | sh</code></pre>
     </div>
     <hr>
     <div>


### PR DESCRIPTION
This PR updates installation instruction with rustup to the one recommended in forge and rustup.

[`rustup-init.sh`](https://github.com/rust-lang/rustup/blob/843459f893091f89b2dd5c7a977da1b3eb28df1b/rustup-init.sh) will try to enforce TLS 1.2 or higher if it is supported by curl. If it is not supported, it will print out the following warnings:
```
Warning: Not enforcing strong cipher suites for TLS, this is potentially less secure
Warning: Not enforcing TLS v1.2, this is potentially less secure
```

Adding `--proto '=https' --tlsv1.2` arguments as we have right now does not do anything at all.

Both [forge](https://github.com/rust-lang/rust-forge/blob/32328a5142a1044363d74c354eccc25b9c4cf34e/src/infra/other-installation-methods.md) and [rustup](https://github.com/rust-lang/rustup/blob/843459f893091f89b2dd5c7a977da1b3eb28df1b/doc/src/installation/other.md) recommend using rustup with `curl https://sh.rustup.rs -sSf | sh`.

Fixes https://github.com/rust-lang/rust-forge/issues/684