### PR TITLE
ES: Revamp `homepage.ftl`

### DIFF
--- a/locales/es/homepage.ftl
+++ b/locales/es/homepage.ftl
@@ -1,7 +1,7 @@
 ## index.hbs
 
-tagline = Un lenguaje que empodera a todos { $linebreak } para construir software fiable y eficiente.
-get-started = Comenzar
+tagline = El lenguaje que empodera a todos { $linebreak } para construir software fiable y eficiente.
+get-started = Comienza
 homepage-version = Versión { $number }
 
 ## components/panels/production.hbs
@@ -9,78 +9,78 @@ homepage-version = Versión { $number }
 production-title = Rust en producción
 production-blurb =
     Cientos de compañías de todo el mundo están actualmente usando Rust en producción en
-    soluciones multiplataforma rápidas con bajo consumo de recursos. Software conocido y admirado como
+    soluciones multiplataforma rápidas con bajo consumo de recursos. Software conocido y amado como
     <a href="https://hacks.mozilla.org/2017/08/inside-a-super-fast-css-engine-quantum-css-aka-stylo/">Firefox</a>,
     <a href="https://blogs.dropbox.com/tech/2016/06/lossless-compression-with-brotli/">Dropbox</a>
     o <a href="https://blog.cloudflare.com/cloudflare-workers-as-a-serverless-rust-platform/">Cloudflare</a>
     usa Rust. <strong>Ya sea en startups o grandes corporaciones,
-    en dispositivos embebidos o servidores web escalables, Rust encaja idóneamente.</strong>
-production-testimonial-npm = Mi mayor cumplido para Rust es que es aburrido, y este es un cumplido sobresaliente.
+    en dispositivos integrados o servidores web escalables, Rust encaja perfectamente.</strong>
+production-testimonial-npm = Mi mayor elogio para Rust es que es aburrido, y este es un excelente cumplido.
 production-testimonial-npm-attribution = Chris Dickinson, ingeniero en npm, Inc
 production-testimonial-npm-alt = Logo de npm
-production-testimonial-yelp = La documentación, las herramientas, la comunidad, son todas geniales. Tienes todo lo necesario para escribir código Rust con éxito.
-production-testimonial-yelp-attribution = Antonio Verardi, ingeniero de infraestructura
+production-testimonial-yelp = La documentación, las herramientas, la comunidad, todas son geniales. Tienes todo lo necesario para escribir código con éxito.
+production-testimonial-yelp-attribution = Antonio Verardi, ingeniero de infraestructura en Yelp
 production-testimonial-yelp-alt = Logo de Yelp
 
 ## components/panels/language-values.hbs
 
 language-values-performance = Rendimiento
 language-values-performance-blurb =
-    Rust es rápido como el rayo y eficiente con la memoria: sin runtime ni
-    colector de basura, puede sustentar servicios de rendimiento crítico, ejecutarse en
-    dispositivos embebidos, e integrarse con otros lenguajes fácilmente.
+    Rust es increíblemente rápido y eficiente con la memoria: sin runtime ni
+    recolector de basura, puede sustentar servicios de rendimiento crítico, ejecutarse en
+    dispositivos integrados, y colaborar con otros lenguajes fácilmente.
 language-values-reliability = Fiabilidad
 language-values-reliability-blurb =
     El rico sistema de tipos de Rust y su modelo de propiedad (ownership) garantizan seguridad de memoria
-    y seguridad de hilos, y te permiten eliminar muchas clases de
-    bugs en tiempo de compilación.
+    y seguridad en hilos, y te permiten eliminar muchas clases de
+    bugs, reportándose a la hora de compilar.
 language-values-productivity = Productividad
 language-values-productivity-blurb =
-    Rust tiene una documentación genial, un compilador accesible con mensajes de
+    Rust tiene una documentación <strong>muy</strong> completa, un compilador accesible con mensajes de
     error útiles, y herramientas de primera: gestor de paquetes y de proyecto
-    integrado, soporte avanzado multi-editor con autocompletado e
+    integrados, soporte avanzado multi-editor con autocompletado e
     inspecciones de tipos, auto-formateador, etc.
 
 ## components/panels/domains.hbs
 
 domains-title = Constrúyelo con Rust
-domains-blurb = En 2018, la comunidad de Rust decidió mejorar la experiencia de programación en unos pocos dominios concretos (ver <a href="https://blog.rust-lang.org/2018/03/12/roadmap.html">el plan para 2018</a>). Para estos, puedes encontrar múltiples bibliotecas (crates) de gran calidad y varias guías estupendas sobre cómo iniciarse.
+domains-blurb = En 2018, la comunidad de Rust decidió mejorar la experiencia de programación en unos pocos dominios concretos (ver <a href="https://blog.rust-lang.org/2018/03/12/roadmap.html">el plan para 2018</a>). Gracias a esto, puedes encontrar muchas librerias (crates) de gran calidad y varias guías estupendas sobre cómo iniciarse.
 domains-cli = Línea de comandos
 domains-cli-blurb =
-    Esboza una herramienta de CLI rápidamente con el robusto ecosistema de Rust.
-    Rust te ayuda a mantener tu aplicación con confianza y a distribuirla fácilmente.
+    Crea una herramienta de CLI rápidamente con el robusto ecosistema de Rust.
+    Rust te ayuda a mantener y desarrollar tu aplicación con confianza y a distribuirla fácilmente.
 domains-cli-alt = terminal
 domains-wasm = WebAssembly
 domains-wasm-blurb =
     Usa Rust para potenciar tu JavaScript, módulo a módulo.
-    Publica en npm, empaqueta con webpack y listo.
-domains-wasm-alt = engranaje con piezas de puzle
+    Publica en npm, compacta con webpack y listo.
+domains-wasm-alt = engranaje con piezas de puzzle
 domains-net = Redes
 domains-net-blurb =
-    Rendimiento predecible. Bajo consumo de recursos. Fiabilidad sólida.
-    Rust es genial para servicios de red.
-domains-net-alt = una nube con nodos
-domains-embedded = Embebido
+    Rendimiento predecible, bajo consumo de recursos y fiabilidad sólida.
+    Rust es perfecto para servicios de red.
+domains-net-alt = nube con nodos
+domains-embedded = Dispositivos integrados
 domains-embedded-blurb =
     ¿Trabajas con dispositivos de bajos recursos?
     ¿Necesitas control de bajo nivel sin renunciar a las comodidades de alto nivel?
     Rust te guarda las espaldas.
-domains-embedded-alt = un chip de un dispositivo embebido
+domains-embedded-alt = un chip de un dispositivo integrado
 
 ## components/panels/get-involved.hbs
 
 get-involved = Involúcrate
-get-involved-read-rust = Leer sobre Rust
+get-involved-read-rust = Lee sobre Rust
 get-involved-read-rust-blurb =
     ¡Nos encanta la documentación! Echa un vistazo a los libros disponibles online,
-    así como a entradas en blogs claves y guías de usuario.
+    así como a entradas en blogs y guías de usuario útiles.
 get-involved-read-rust-link = Leer el libro
-get-involved-watch-rust = Ver vídeos sobre Rust
+get-involved-watch-rust = Ve vídeos sobre Rust
 get-involved-watch-rust-blurb = La comunidad de Rust tiene un canal de Youtube con un gran número de charlas y tutoriales.
 get-involved-watch-rust-link = Ver los vídeos
-get-involved-contribute = Contribuir al código
-get-involved-contribute-blurb = Rust es innegablemente un esfuerzo colectivo, y las contribuciones son bien recibidas, ya sean de aficionados o usuarios de producción, novatos o profesionales con experiencia. ¡Ayúdanos a mejorar la experiencia con Rust aún más!
-get-involved-contribute-link = Leer la Guía de contribución
+get-involved-contribute = Contribuye al código
+get-involved-contribute-blurb = Rust es innegablemente un esfuerzo colectivo, y las contribuciones son muy bien recibidas, ya sean de aficionados o usuarios que lo usan en producción, novatos o profesionales con experiencia. ¡Ayúdanos a mejorar la experiencia con Rust aún más!
+get-involved-contribute-link = Leer la guía de contribución
 
 ## components/panels/thanks.hbs
 
@@ -90,5 +90,5 @@ thanks-individuals-header = Individuos
 thanks-individuals-blurb = Rust es un proyecto comunitario y está muy agradecido por las numerosas contribuciones que recibe.
 thanks-individuals-link = Ver contribuidores individuales
 thanks-companies-header = Patrocinadores corporativos
-thanks-companies-blurb = El proyecto Rust recibe apoyo de empresas mediante donaciones de infraestructura.
-thanks-companies-link = Ver patrocinadores
+thanks-companies-blurb = El proyecto Rust recibe apoyo de empresas mediante la Rust Foundation
+thanks-companies-link = Ver miembros de la fundación


### PR DESCRIPTION
The old homepage feels too stiff, it feels like it was translated almost word by word, using complex words just because of their similarities with the english ones (e.g. "embebido", it was the first time I've heard it in my whole career). So this PR aims to make the homepage less stiff and bring some common expressions used in the Spanish language instead of being a complex, boring 1:1 translation (which is hard to read, being honest).