### PR TITLE
Align text on learn page

### DIFF
--- a/templates/learn/index.html.hbs
+++ b/templates/learn/index.html.hbs
@@ -14,7 +14,7 @@
     </header>
     <section class="flex flex-column flex-row-l pv0-l">
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
-        <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
+        <div class="v-top pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-book"}}</p>
           <div class="buttons">
             <a class="button button-secondary" href="https://doc.rust-lang.org/book/">{{fluent "learn-book-button"}}</a>
@@ -23,7 +23,7 @@
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
-        <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
+        <div class="v-top pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-rustlings"}}</p>
           <div class="buttons">
             <a class="button button-secondary" href="https://github.com/rust-lang/rustlings/">{{fluent "learn-rustlings-button"}}</a>
@@ -31,7 +31,7 @@
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
-        <div class="v-top pl4 pl0-l pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
+        <div class="v-top pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
           <p class="flex-grow-1">{{fluent "learn-rbe"}}</p>
           <div class="buttons">
             <a class="button button-secondary" href="https://doc.rust-lang.org/rust-by-example/">{{fluent "learn-rbe-button"}}</a>


### PR DESCRIPTION
closes #1833 

I'm not sure why this padding-left was added in the first place. It only appears when the page is less than `l` wide and the three sections are in a column instead of a row.

The commit that introduced this padding-left is 89dd4fea18312952f49d34fa7de35eda18509279, there's no mention of the padding in the commit message.