### PR TITLE
Update structopt example to use clap

### DIFF
--- a/templates/components/what/cli/code-inputs.html.hbs
+++ b/templates/components/what/cli/code-inputs.html.hbs
@@ -1,9 +1,11 @@
+use clap::Parser;
+
 /// Read some lines of a file
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 struct Cli {
     /// Input file to read
     file: String,
     /// Number of lines to read
-    #[structopt(short = "n")]
+    #[structopt(short = 'n')]
     num: usize,
 }

--- a/templates/components/what/cli/code-main.html.hbs
+++ b/templates/components/what/cli/code-main.html.hbs
@@ -1,9 +1,8 @@
-use quicli::prelude::*;
-use structopt::StructOpt;
+use std::{error::Error, fs::read_to_string};
 
-fn main() -> CliResult {
-    let args = Cli::from_args();
-    read_file(&args.file)?
+fn main() -> Result<(), Box<dyn Error>> {
+    let args = Cli::parse();
+    read_to_string(&args.file)?
         .lines()
         .take(args.num)
         .for_each(|line| println!("{}", line));


### PR DESCRIPTION
inspired by #1848 

`structopt` was merged into `clap`, and `quicli` doesn't seem necessary anymore for this example since `read_to_string` was stabilized.

Maybe the `Result<(), Box<dyn Error>>` in this version is less nice? But I'd say it's pretty common for quick-and-dirty error handling.