### PR TITLE
fix(links): add target="_blank" to social media links

### DIFF
--- a/templates/components/footer.html.hbs
+++ b/templates/components/footer.html.hbs
@@ -31,10 +31,10 @@
       <div class="flex flex-column mw8 w-100 measure-wide-l pv2 pv5-m pv2-ns ph4-m ph4-l">
         <h4>{{fluent "footer-social"}}</h4>
         <div class="flex flex-row flex-wrap items-center">
-          <a href="https://twitter.com/rustlang"><img src="/static/images/twitter.svg" alt="twitter logo" title="{{fluent "footer-youtube-alt"}}"/></a>
-          <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA"><img class="pv2" src="/static/images/youtube.svg" alt="{{fluent "footer-alt-youtube"}}" title="YouTube"/></a>
-          <a href="https://discord.gg/rust-lang"><img src="/static/images/discord.svg" alt="discord logo" title="{{fluent "footer-discord-alt"}}"/></a>
-          <a href="https://github.com/rust-lang"><img src="/static/images/github.svg" alt="github logo" title="{{fluent "footer-github-alt"}}"/></a>
+          <a href="https://twitter.com/rustlang" target="_blank"><img src="/static/images/twitter.svg" alt="twitter logo" title="{{fluent "footer-youtube-alt"}}"/></a>
+          <a href="https://www.youtube.com/channel/UCaYhcUwRBNscFNUKTjgPFiA" target="_blank"><img class="pv2" src="/static/images/youtube.svg" alt="{{fluent "footer-alt-youtube"}}" title="YouTube"/></a>
+          <a href="https://discord.gg/rust-lang" target="_blank"><img src="/static/images/discord.svg" alt="discord logo" title="{{fluent "footer-discord-alt"}}"/></a>
+          <a href="https://github.com/rust-lang" target="_blank"><img src="/static/images/github.svg" alt="github logo" title="{{fluent "footer-github-alt"}}"/></a>
         </div>
       </div>
 


### PR DESCRIPTION
This pull request addresses an issue with the social media links in the footer of our website. Currently, when users click on these links, they navigate away from our site, which can be an inconvenience. To improve the user experience, this PR adds the target="_blank" attribute to the anchor elements of the social media links. This change ensures that when users click on these links, they will open in new tabs, allowing them to easily return to our website after visiting the social media profiles.

Changes Made:
- Modified the HTML code in the footer to include the target="_blank" attribute for each social media link.

Motivation:
- Improve user experience: By opening the social media links in new tabs, we prevent users from accidentally leaving our website and enable them to seamlessly return to our content.
- Best practice: Using target="_blank" for external links is considered a best practice in web development, as it provides a more predictable and consistent user experience.

Testing:
- Tested the changes locally to verify that the social media links open in new tabs.
- Ensured the overall functionality and appearance of the website were not affected by this change.

Please review and merge this PR to enhance our website's usability and adhere to web development best practices. Thank you!