### PR TITLE
fix favicon tags

### DIFF
--- a/templates/components/layout.html.hbs
+++ b/templates/components/layout.html.hbs
@@ -35,8 +35,8 @@
 
     <!-- favicon -->
     <link rel="apple-touch-icon" sizes="180x180" href="/static/images/apple-touch-icon.png?v=ngJW8jGAmR">
-    <link rel="alternate icon" type="image/png" href="/static/images/favicon-16x16.png">
-    <link rel="alternate icon" type="image/png" href="/static/images/favicon-32x32.png">
+    <link rel="icon" sizes="16x16" type="image/png" href="/static/images/favicon-16x16.png">
+    <link rel="icon" sizes="32x32" type="image/png" href="/static/images/favicon-32x32.png">
     <link rel="icon" type="image/svg+xml" href="/static/images/favicon.svg">
     <link rel="manifest" href="/static/images/site.webmanifest?v=ngJW8jGAmR">
     <link rel="mask-icon" href="/static/images/safari-pinned-tab.svg?v=ngJW8jGAmR" color="#000000">


### PR DESCRIPTION
`rel="alternate"` indicates an alternate representation of the *current* document (i.e. the docs page), not the *linked* document. Also, add `sizes` attribute since currently there’s no way to programmatically know the difference between these two links.