### PR TITLE
governance/teams: show teams' matrix rooms

### DIFF
--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -19,6 +19,7 @@ governance-team-email = Email the { $teamname }
 governance-team-repository = { $teamname } repository
 governance-team-discord = { $channel } on Discord
 governance-team-zulip = { $stream } on Zulip
+governance-team-matrix-room = { $room } on Matrix
 governance-user-github = GitHub: { $link }
 governance-user-team-leader = Team leader
 governance-members-header = Members

--- a/templates/governance/group-team.html.hbs
+++ b/templates/governance/group-team.html.hbs
@@ -36,6 +36,13 @@
                         </a>
                     </div>
                 {{/if}}
+                {{#if team.website_data.matrix_room}}
+                    <div class="pt4 pt3-l flex flex-column flex-row-l items-center-l">
+                        <a class="button button-secondary" href="https://matrix.to/#/{{team.website_data.matrix_room}}">
+                        {{#fluent "governance-team-matrix-room"}}{{#fluentparam "room"}}{{team.website_data.matrix_room}}{{/fluentparam}}{{/fluent}}
+                        </a>
+                    </div>
+                {{/if}}
             </div>
         </div>
     </div>


### PR DESCRIPTION
Requires rust-lang/team#1080.