### PR TITLE
Add Zed to tools

### DIFF
--- a/locales/de/tools.ftl
+++ b/locales/de/tools.ftl
@@ -34,3 +34,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -71,7 +71,7 @@ install-notes-getting-started-description = If you're just getting started with
         <a href="{ $getting-started-href }">getting started</a> page.
 
 install-notes-rustup-heading = Toolchain management with <code>rustup</code>
-install-notes-rustup-description = 
+install-notes-rustup-description =
         <p>
           Rust is installed and managed by the
           <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>
@@ -106,7 +106,7 @@ install-notes-uninstall-description =
 
 install-notes-path-heading = Configuring the <code>PATH</code> environment
         variable
-install-notes-path-description = 
+install-notes-path-description =
         <p>
           In the Rust development environment, all tools are installed to the
           <span class="platform-specific not-win di">
@@ -176,3 +176,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -34,7 +34,7 @@ install-notes-getting-started-description = Si estás empezando con Rust y te gu
 install-notes-rustup-heading = Gestión del conjunto de herramientas con <code>rustup</code>
 install-notes-rustup-description =
     <p>
-    Rust es instalado y gestionado por la herramienta 
+    Rust es instalado y gestionado por la herramienta
     <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>.
     Rust tiene un
     <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
@@ -86,7 +86,7 @@ install-notes-path-description =
 install-notes-windows-heading = Consideraciones para Windows
 install-notes-windows-description =
     <p>
-      En Windows, Rust adicionalmente requiere las herramientas de compilación de C++ para Visual Studio 2013 o posterior. La forma más sencilla de adquirir estas herramientas es instalando 
+      En Windows, Rust adicionalmente requiere las herramientas de compilación de C++ para Visual Studio 2013 o posterior. La forma más sencilla de adquirir estas herramientas es instalando
       <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019">
         Microsoft Visual C++ Build Tools 2019
       </a>
@@ -126,3 +126,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/fa/tools.ftl
+++ b/locales/fa/tools.ftl
@@ -26,3 +26,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -57,7 +57,7 @@ install-notes-uninstall-description =
 install-notes-path-heading = Configuration de la variable d’environnement <code>PATH</code>
 install-notes-path-description =
     <p>
-      Dans l’environnement de développement de Rust, tous les outils sont installés dans le répertoire 
+      Dans l’environnement de développement de Rust, tous les outils sont installés dans le répertoire
       <span class="platform-specific not-win di">
         <code>~/.cargo/bin</code>
       </span>
@@ -75,7 +75,7 @@ install-notes-path-description =
 install-notes-windows-heading = Problématiques Windows
 install-notes-windows-description =
     <p>
-      Sous Windows, Rust requiert l'installation additionnelle des C++ build tools de Visual Studio 2013 ou supérieur. La façon la plus facile d'obtenir les build tools est d'installer <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019">Microsoft Visual C++ Build Tools 2019</a> qui fournit uniquement les build tools de Visual C++. 
+      Sous Windows, Rust requiert l'installation additionnelle des C++ build tools de Visual Studio 2013 ou supérieur. La façon la plus facile d'obtenir les build tools est d'installer <a href="https://www.visualstudio.com/downloads/#build-tools-for-visual-studio-2019">Microsoft Visual C++ Build Tools 2019</a> qui fournit uniquement les build tools de Visual C++.
     Comme alternative, vous pouvez <a href="https://www.visualstudio.com/downloads/"> installer </a>
       Visual Studio 2019, Visual Studio 2017, Visual Studio 2015, ou Visual
       Studio 2013 en sélectionnant les "C++ tools" durant l’installation
@@ -111,3 +111,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -7,7 +7,7 @@ tools-build-heading = Porta serenità nelle tue build
 tools-build-description = Cargo è lo strumento per compilare in Rust, racchiude tutte le azioni più comuni in un singolo comando. Nessun boilerplate.
 tools-build-install-heading = Installa
 tools-build-install-description =
-    Con decine di migliaia di librerie, c'è una buona probabilità che <a href="https://crates.io">crates.io</a> abbia la soluzione che stai cercando. 
+    Con decine di migliaia di librerie, c'è una buona probabilità che <a href="https://crates.io">crates.io</a> abbia la soluzione che stai cercando.
     Stai sulle spalle dei giganti e porta il tuo team dalla ripetizione portandolo verso l'innovazione.
 tools-build-test-heading = Test
 tools-build-test-description = Fidati del tuo codice grazie agli eccellenti strumenti per testare in Rust. <code class="nowrap">cargo test</code> è la soluzione unificata di Rust per il testing. Puoi scrivere i test accanto al tuo codice o organizzarli in file separati: la soluzione per tutte le esigenze.
@@ -101,3 +101,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -102,3 +102,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/ko/tools.ftl
+++ b/locales/ko/tools.ftl
@@ -31,7 +31,7 @@ install-notes-path-description =
       </span>
       <span class="platform-specific win dn">
         <code>%USERPROFILE%\.cargo\bin</code>
-      </span> 디렉토리에 설치되므로, 이곳이 
+      </span> 디렉토리에 설치되므로, 이곳이
       <code>rustc</code>, <code>cargo</code>, <code>rustup</code> 등을 포함한 Rust 툴체인을 찾을 수 있는 곳입니다.
     </p>
     <p>
@@ -61,3 +61,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/pl/tools.ftl
+++ b/locales/pl/tools.ftl
@@ -46,3 +46,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -5,7 +5,7 @@ tools-editor-support-heading = Suporte de primeira classe em editores
 tools-editor-support-description =
     Independente se você prefere trabalhar com código a partir
     da linha de comando, ou usando um editor gráfico, existe uma
-    extensão Rust disponível para o editor da sua escolha. Ou você pode criar 
+    extensão Rust disponível para o editor da sua escolha. Ou você pode criar
     a sua própria usando <a href="https://github.com/rust-analyzer/rust-analyzer">rust-analyzer</a>.
 tools-build-heading = Traga tranquilidade para a compilação
 tools-build-description =
@@ -29,7 +29,7 @@ tools-automation-cargo-doc-heading = Cargo Doc
 tools-automation-cargo-doc-description =
     A ferramenta de documentação do Cargo garante
     que nenhuma API fique sem documentação. Ela está
-    disponível localmente através do comando 
+    disponível localmente através do comando
     <code class="nowrap">cargo doc</code>, e online para <i>crates</i>
     públicas através de <a href="https://docs.rs">docs.rs</a>.
 tools-automation-cargo-doc-link = Vá para o website
@@ -54,15 +54,15 @@ install-notes-rustup-description =
     <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
     de lançamentos a cada 6 semanas
      </a> e suporta
-      <a href="https://forge.rust-lang.org/release/platform-support.html">um grande número de plataformas</a>, 
-    o que faz com que sempre existam uma grande quantidade de 
+      <a href="https://forge.rust-lang.org/release/platform-support.html">um grande número de plataformas</a>,
+    o que faz com que sempre existam uma grande quantidade de
     binários.
     <code>rustup</code> gerencia esses binários consistentemente
     em todas as plataformas suportadas por Rust, permitindo a instalação
     do Rust desde a versão beta ou nightly até mesmo suporte adiciona de componentes para cross-compilação.
     </p>
     <p>
-     Se você já instalou <code>rustup</code> no passado, você pode atualizar a instalação 
+     Se você já instalou <code>rustup</code> no passado, você pode atualizar a instalação
     executando <code>rustup update</code>.
     </p>
     <p>
@@ -86,16 +86,16 @@ install-notes-path-description =
       </span>
       <span class="platform-specific win dn">
         <code>%USERPROFILE%\.cargo\bin</code>
-      </span>, onde você encontra todo o conjunto de ferramentas 
+      </span>, onde você encontra todo o conjunto de ferramentas
     de Rust, incluindo <code>rustc</code>, <code>cargo</code>,e <code>rustup</code>.
     </p>
     <p>
     Normalmente é comum para quem desenvolve Rust incluir esse diretório
     na <a href="https://en.wikipedia.org/wiki/PATH_(variable)">
-      variável de ambiente <code>PATH</code></a>. 
+      variável de ambiente <code>PATH</code></a>.
     Durante a instalação do <code>rustup</code>, será feito uma tentativa de configurar a variável <code>PATH</code>.
     Por causa da diferença entre plataformas, terminais, e problemas no
-      <code>rustup</code>, as mudanças feitas na variável <code>PATH</code> 
+      <code>rustup</code>, as mudanças feitas na variável <code>PATH</code>
     podem não ser aplicadas até que o console seja reiniciado, o usuário do sistema entre novamente,
     ou até mesmo nunca.
     </p>
@@ -151,3 +151,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -60,7 +60,7 @@ install-notes-uninstall-description =
 install-notes-path-heading = Настройка переменной окружения <code>PATH</code>
 install-notes-path-description =
     <p>
-      В среде разработки Rust, все инструменты устанавливаются в директорию 
+      В среде разработки Rust, все инструменты устанавливаются в директорию
       <span class="platform-specific not-win di">
         <code>~/.cargo/bin</code>
       </span>
@@ -124,3 +124,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -13,7 +13,7 @@ tools-build-description =
     bir tek komuta paketler. Şablon gerektirmez.
 tools-build-install-heading = Yükle
 tools-build-install-description =
-    <a href="https://crates.io">Crates.io</a> içindeki binlerce paket ile birlikte çok büyük 
+    <a href="https://crates.io">Crates.io</a> içindeki binlerce paket ile birlikte çok büyük
     ihtimalle aradığınız çözüme sahip. Devlerin omuzlarında durun ve ekibinizi tekerrürden
     yeniliğe taşıyın.
 tools-build-test-heading = Test et
@@ -26,7 +26,7 @@ tools-build-deploy-heading = Yayınla
 tools-build-deploy-description =
     <code class="nowrap">cargo build</code> kodu her platform için
     ekstra bilgi taşımayan ikili kod oluşturur. Kodunuz tek bir komutla Windows'u,
-    Linux'u, macOS'i ve webi hedef alabilir. Hepsi sipariş usulü yapı dosyalarına gerek 
+    Linux'u, macOS'i ve webi hedef alabilir. Hepsi sipariş usulü yapı dosyalarına gerek
     olmadan modern bir arayüzün parçası.
 tools-automation-heading = Otomasyonla gelen hız
 tools-automation-description =
@@ -41,12 +41,12 @@ tools-automation-rustfmt-link = Depoya git
 tools-automation-clippy-heading = Clippy
 tools-automation-clippy-description =
     <i>“Görünüşe bakılırsa bir yineleyici
-    yazıyorsunuz.”</i> <br> Clippy her seviyedeki geliştiriciye deyimsel kod 
+    yazıyorsunuz.”</i> <br> Clippy her seviyedeki geliştiriciye deyimsel kod
     yazmakta ve standartları uygulamakta yardımcı olur.
 tools-automation-clippy-link = Depoya git
 tools-automation-cargo-doc-heading = Cargo Belgeleri
 tools-automation-cargo-doc-description =
-    Cargo'nun belgelendirmecisi işinizi halleder. Bu da 
+    Cargo'nun belgelendirmecisi işinizi halleder. Bu da
     hiçbir UPA'nın belgelendirmesiz ortaya çıkmamasını sağlar.
     <code class="nowrap">cargo doc</code> ile yerel olarak erişebilirsiniz ve
     <a href="https://docs.rs">docs.rs</a> ile herkese açık cratelere çevrimiçi ulaşabilirsiniz.
@@ -60,8 +60,8 @@ install-rustup32-button = <span class="nowrap">rustup-init.exe</span> indir <spa
 install-rustup64-button = <span class="nowrap">rustup-init.exe</span> indir <span class="nowrap">(64-bit)</span>
 install-notes-heading = Rust kurulumu hakkında notlar
 install-notes-getting-started-description =
-    Eğer Rust'a yeni başlıyorsanız ve daha 
-    detaylı bir gidiş yolu arıyorsanız 
+    Eğer Rust'a yeni başlıyorsanız ve daha
+    detaylı bir gidiş yolu arıyorsanız
     <a href="{ $getting-started-href }">başlarken</a> sayfamıza göz atın.
 install-notes-rustup-heading = <code>Rustup</code> ile araç zincirinin yönetimi
 install-notes-rustup-description =
@@ -69,10 +69,10 @@ install-notes-rustup-description =
       Rust, <a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a> aracı ile yüklenir ve
       yönetilir. Rust'ın 6 haftalık <a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">
         hızlı yayımlama süreci
-      </a> vardır ve 
+      </a> vardır ve
       <a href="https://forge.rust-lang.org/release/platform-support.html">çok sayıda platformu</a> destekler. Bu yüzden her zaman Rust'ın birçok
       yapısı vardır. <code>rustup</code> Rust'ın desteklediği her platformda bu yapıları tutarlı bir şekilde
-      yönetir. Bu durum, Rust'ın beta ve nightly yayın kanallarından yüklenmesine ve farklı hedeflere 
+      yönetir. Bu durum, Rust'ın beta ve nightly yayın kanallarından yüklenmesine ve farklı hedeflere
       derlenmesine katkıda bulunur.
     </p>
     <p>
@@ -135,3 +135,4 @@ tools-editor-eclipse = { ENGLISH("Eclipse") }
 tools-editor-vim = { ENGLISH("Vim") }
 tools-editor-emacs = { ENGLISH("Emacs") }
 tools-editor-geany = { ENGLISH("Geany") }
+tools-editor-zed = { ENGLISH("Zed") }

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -138,3 +138,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -112,3 +112,4 @@ tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
 tools-editor-geany = Geany
+tools-editor-zed = Zed

--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -12,6 +12,10 @@
        class="button button-secondary">{{fluent "tools-editor-atom"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
+    <a href="https://zed.dev"
+       class="button button-secondary">{{fluent "tools-editor-zed"}}</a>
+  </div>
+  <div class="w-25-l w-50-m w-100 pa3">
     <a href="https://jetbrains.com/rust"
        class="button button-secondary">{{fluent "tools-editor-idea"}}</a>
   </div>


### PR DESCRIPTION
[Zed](https://zed.dev) is a text editor written in Rust that provides first-class support for Rust. No plugin installations are necessary to get up and running; RA is automatically downloaded when working in a rust project.

I placed the button next to the button for Atom, since the same team who is building Zed initially built Atom, but I can move it if others disagree. Looks like a few trailing whitespaces were stripped as well in this PR. If that's a problem, I can remove those changes.

<img width="1354" alt="SCR-20231011-ombh" src="https://github.com/rust-lang/www.rust-lang.org/assets/19867440/aba77b6b-ffc8-487d-b6fa-32139676bb97">