### PR TITLE
Fix clippy config

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,6 +20,7 @@ jobs:
           IFS=$'\n\t'
           # Check if the code is good
           cargo build --all --locked
+          cargo clippy -- --deny warnings
           cargo test --all --locked
 
       - name: Build the Docker image

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,3 @@
-#![cfg_attr(test, deny(warnings))]
-
 #[macro_use]
 extern crate lazy_static;
 extern crate rand;
@@ -284,6 +282,7 @@ fn redirect_bare_en_us() -> Redirect {
 }
 
 #[catch(404)]
+#[allow(clippy::result_large_err)]
 fn not_found(req: &Request) -> Result<Template, Redirect> {
     if let Some(redirect) = crate::redirect::maybe_redirect(req.uri().path()) {
         return Err(redirect);

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -155,7 +155,7 @@ impl Data {
         let mut subteams = Vec::with_capacity(raw_subteams.len());
         lay_out_subteams_hierarchically(&mut subteams, None, &main_team.name, &raw_subteams);
 
-        fn lay_out_subteams_hierarchically<'a>(
+        fn lay_out_subteams_hierarchically(
             result: &mut Vec<Team>,
             team: Option<&Team>,
             main_team: &str,


### PR DESCRIPTION
Denying all warnings for test builds results in a poor development experience, as everying always appears as an error in the editor. The program might still compile and run fine though.

At the same time, CI only denies rustc's warnings, not those of clippy. So code that gets marked as an error in an editor can still pass CI.

Both of these issues are fixed by running clippy in CI explicitly.