### PR TITLE
doc(zh-CN): Fix reference to rust-analyzer in tools.ftl

### DIFF
--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -4,7 +4,7 @@ tools-page-title = 工具
 tools-editor-support-heading = 主流编辑器支持
 tools-editor-support-description =
     无论您喜欢用命令行还是可视化编辑器，都有适合的 Rust 集成供您选择。
-    您也可以使用 <a href="https://github.com/rust-analyzer/rust-analyzer">Rust DO_NOT_SUBMIT</a>来为自己的编辑器添加 Rust 支持。
+    您也可以使用 <a href="https://github.com/rust-analyzer/rust-analyzer">rust-analyzer</a> 来为自己的编辑器添加 Rust 支持。
 tools-build-heading = 流畅的构建体验
 tools-build-description = Cargo 是 Rust 的构建工具，它将常用命令集于一身，无需引入其它命令。
 tools-build-install-heading = 安装


### PR DESCRIPTION
Fix `DO_NOT_SUBMIT` introduced by #1620, referencing as rust-analyzer to be in line with original text and other languages.

At: https://www.rust-lang.org/zh-CN/tools


Extra suggestion:
后半句表述为“打造自己的工具”是否更好