### PR TITLE
Render custom roles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -708,7 +708,6 @@ checksum = "10a35a97730320ffe8e2d410b5d3b69279b98d2c14bdb8b70ea89ecf7888d41e"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -1496,9 +1495,9 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#811f92f4395068e1b826b208fd7f2ba677abd452"
+source = "git+https://github.com/rust-lang/team#3e3704e7655c881533306ef09f077786e47eeda4"
 dependencies = [
- "indexmap 1.9.1",
+ "indexmap 2.1.0",
  "serde",
 ]
 

--- a/locales/en-US/teams.ftl
+++ b/locales/en-US/teams.ftl
@@ -289,3 +289,5 @@ governance-team-wg-triage-description = Triaging repositories under the rust-lan
 
 governance-team-wg-wasm-name = WebAssembly (WASM) working group
 governance-team-wg-wasm-description = Improving on the end-to-end experience of embedding Rust code in JS libraries and apps via WebAssembly
+
+governance-role-spec-editor = Editor

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ use sass_rs::{compile_file, Options};
 use category::Category;
 
 use caching::CachedNamedFile;
+use handlebars::handlebars_helper;
 use handlebars_fluent::{loader::Loader, FluentHelper};
 use i18n::{create_loader, LocaleInfo, SupportedLocale, TeamHelper, EXPLICIT_LOCALE_INFO};
 
@@ -491,6 +492,11 @@ async fn rocket() -> _ {
         engine
             .handlebars
             .register_helper("encode-zulip-stream", Box::new(encode_zulip_stream));
+
+        handlebars_helper!(concat: |x: String, y: String| x + &y);
+        engine
+            .handlebars
+            .register_helper("concat", Box::new(concat));
     });
 
     let rust_version = RustVersion::fetch().await.unwrap_or_default();

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -299,16 +299,25 @@ mod tests {
             subteam_of: None,
             members: vec![
                 TeamMember {
+                    name: "Jupiter Doe".into(),
+                    github: "jupiterd".into(),
+                    github_id: 123,
+                    is_lead: false,
+                    roles: vec!["convener".to_owned()],
+                },
+                TeamMember {
                     name: "John Doe".into(),
                     github: "johnd".into(),
+                    github_id: 456,
                     is_lead: false,
-                    github_id: 1234,
+                    roles: Vec::new(),
                 },
                 TeamMember {
                     name: "Jane Doe".into(),
                     github: "janed".into(),
+                    github_id: 789,
                     is_lead: true,
-                    github_id: 1234,
+                    roles: Vec::new(),
                 },
             ],
             alumni: Vec::new(),

--- a/templates/governance/group-team.html.hbs
+++ b/templates/governance/group-team.html.hbs
@@ -60,6 +60,10 @@
                         </div>
                         {{#if member.is_lead}}
                             <div>{{fluent "governance-user-team-leader"}}</div>
+                        {{else}}
+                            {{#if member.roles}}
+                                <div>{{fluent (concat "governance-role-" (lookup member.roles 0))}}</div>
+                            {{/if}}
                         {{/if}}
                     </div>
                 </div>


### PR DESCRIPTION
https://github.com/rust-lang/team/pull/1154 added support for roles other than "Team leader".

![Screenshot from 2024-01-08 12-25-08](https://github.com/rust-lang/www.rust-lang.org/assets/1940490/0dc752d8-2353-444d-b101-5f720a64b74a)

For now I've rendered only at most 1 role per member, as that's all we currently use. If members begin holding multiple roles then we'll need to render them using some internationalized notion of "comma-separated" (?) or see how sensible it would be to stack them vertically on different lines.