### PR TITLE
Add fallback for role descriptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1495,7 +1495,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#3e3704e7655c881533306ef09f077786e47eeda4"
+source = "git+https://github.com/rust-lang/team#ae0fe5cb83bbb24c9533c6829f2ca11667e8ab2d"
 dependencies = [
  "indexmap 2.1.0",
  "serde",

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,6 @@ use sass_rs::{compile_file, Options};
 use category::Category;
 
 use caching::CachedNamedFile;
-use handlebars::handlebars_helper;
 use handlebars_fluent::{loader::Loader, FluentHelper};
 use i18n::{create_loader, LocaleInfo, SupportedLocale, TeamHelper, EXPLICIT_LOCALE_INFO};
 
@@ -492,11 +491,6 @@ async fn rocket() -> _ {
         engine
             .handlebars
             .register_helper("encode-zulip-stream", Box::new(encode_zulip_stream));
-
-        handlebars_helper!(concat: |x: String, y: String| x + &y);
-        engine
-            .handlebars
-            .register_helper("concat", Box::new(concat));
     });
 
     let rust_version = RustVersion::fetch().await.unwrap_or_default();

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -334,6 +334,7 @@ mod tests {
                 zulip_stream: None,
                 weight: 0,
             }),
+            roles: Vec::new(),
             github: None,
             discord: vec![],
         }

--- a/templates/governance/group-team.html.hbs
+++ b/templates/governance/group-team.html.hbs
@@ -62,7 +62,7 @@
                             <div>{{fluent "governance-user-team-leader"}}</div>
                         {{else}}
                             {{#if member.roles}}
-                                <div>{{fluent (concat "governance-role-" (lookup member.roles 0))}}</div>
+                                <div>{{team-text team role (lookup member.roles 0)}}</div>
                             {{/if}}
                         {{/if}}
                     </div>


### PR DESCRIPTION
Followup to #1904. Just as already done for team names and team descriptions, if a new role is added in the rust-lang/team repo, www will render it using the en-US text supplied in teams.json until translations appear in this repo.

**Before:**

<p align="center"><img src="https://github.com/rust-lang/www.rust-lang.org/assets/1940490/e6504a72-bc85-4f7a-a3b9-985c758267d4" width="500"></p>

**After:**

<p align="center"><img src="https://github.com/rust-lang/www.rust-lang.org/assets/1940490/9b1c6d60-980b-4305-ba13-e72c521ede5b" width="500"></p>