### PR TITLE
Resolve Rust 1.75's new get_first clippy lint

### DIFF
--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -17,7 +17,7 @@ simple_loader!(create_loader, "./locales/", "en-US", core: "./locales/core.ftl",
 fn add_bundle_functions(bundle: &mut FluentBundle<&'static FluentResource>) {
     bundle
         .add_function("EMAIL", |values, _named| {
-            let email = match values.get(0) {
+            let email = match values.first() {
                 Some(FluentValue::String(ref s)) => s,
                 _ => return FluentValue::None,
             };
@@ -27,7 +27,7 @@ fn add_bundle_functions(bundle: &mut FluentBundle<&'static FluentResource>) {
 
     bundle
         .add_function("ENGLISH", |values, _named| {
-            let text = match values.get(0) {
+            let text = match values.first() {
                 Some(FluentValue::String(ref s)) => s,
                 _ => return FluentValue::None,
             };


### PR DESCRIPTION
CI in #1905 is failing because the default `rustc` available in GitHub's runner got bumped from 1.74 to 1.75 recently.

```console
error: accessing first element with `values.get(0)`
  --> src/i18n.rs:20:31
   |
20 |             let email = match values.get(0) {
   |                               ^^^^^^^^^^^^^ help: try: `values.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
   = note: `-D clippy::get-first` implied by `-D warnings`
   = help: to override `-D warnings` add `#[allow(clippy::get_first)]`

error: accessing first element with `values.get(0)`
  --> src/i18n.rs:30:30
   |
30 |             let text = match values.get(0) {
   |                              ^^^^^^^^^^^^^ help: try: `values.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
```