### PR TITLE
Use Rust 1.75's async fn in trait instead of #[async_trait]

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -1,4 +1,5 @@
 use std::error::Error;
+use std::future::Future;
 use std::sync::Arc;
 use std::time::Instant;
 
@@ -10,10 +11,9 @@ const CACHE_TTL_SECS: u64 = 120;
 
 pub type Cache<T> = State<Arc<RwLock<T>>>;
 
-#[async_trait]
 pub trait Cached: Send + Sync + Clone + 'static {
     fn get_timestamp(&self) -> Instant;
-    async fn fetch() -> Result<Self, Box<dyn Error + Send + Sync>>;
+    fn fetch() -> impl Future<Output = Result<Self, Box<dyn Error + Send + Sync>>> + Send;
     async fn get(cache: &Cache<Self>) -> Self {
         let cached = cache.read().await.clone();
         let timestamp = cached.get_timestamp();

--- a/src/rust_version.rs
+++ b/src/rust_version.rs
@@ -42,7 +42,6 @@ impl Default for RustVersion {
     }
 }
 
-#[async_trait]
 impl Cached for RustVersion {
     fn get_timestamp(&self) -> Instant {
         self.1
@@ -68,7 +67,6 @@ impl Default for RustReleasePost {
     }
 }
 
-#[async_trait]
 impl Cached for RustReleasePost {
     fn get_timestamp(&self) -> Instant {
         self.1

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -238,7 +238,6 @@ impl Default for RustTeams {
     }
 }
 
-#[async_trait]
 impl Cached for RustTeams {
     fn get_timestamp(&self) -> Instant {
         self.1


### PR DESCRIPTION
Announcement: https://blog.rust-lang.org/2023/12/21/async-fn-rpit-in-traits.html