### PR TITLE
Install current stable Rust in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,6 +8,8 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - uses: dtolnay/rust-toolchain@stable
+
       - name: Formatting
         run: |
           # Install extra rustup components

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,12 +9,11 @@ jobs:
       - uses: actions/checkout@v2
 
       - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
 
       - name: Formatting
-        run: |
-          # Install extra rustup components
-          rustup component add rustfmt
-          cargo fmt --all -- --check
+        run: cargo fmt --all -- --check
 
       - name: Test
         run: |


### PR DESCRIPTION
Apparently the Rust version pre-installed on these runners fluctuates non-monotonically as a new image is rolled out.

#1905 originally got built by Rust 1.75. That's why it failed CI and necessitated #1906.

Then #1909, which requires Rust 1.75, obviously got built by 1.75.

Then the second build of #1905 got built by 1.74 (as a merge commit which includes #1909), which failed CI.

```console
error[E0562]: `impl Trait` only allowed in function and inherent method return types, not in trait method return types
  --> src/cache.rs:16:19
   |
16 |     fn fetch() -> impl Future<Output = Result<Self, Box<dyn Error + Send + Sync>>> + Send;
   |                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information

error[E0706]: functions in traits cannot be declared `async`
  --> src/cache.rs:17:5
   |
17 |     async fn get(cache: &Cache<Self>) -> Self {
   |     -----^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |     |
   |     `async` because of this
   |
   = note: `async` trait functions are not currently supported
   = note: consider using the `async-trait` crate: https://crates.io/crates/async-trait
   = note: see issue #91611 <https://github.com/rust-lang/rust/issues/91611> for more information
```