### PR TITLE
Update Eclipse editor landing page

### DIFF
--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -16,7 +16,7 @@
        class="button button-secondary">{{fluent "tools-editor-idea"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://www.eclipse.org/downloads/packages/release/2019-09/r/eclipse-ide-rust-developers-includes-incubating-components"
+    <a href="https://projects.eclipse.org/projects/tools.corrosion"
        class="button button-secondary">{{fluent "tools-editor-eclipse"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">


### PR DESCRIPTION
The original link is 8 versions and 4 years outdated.