### PR TITLE
Delete Atom editor

### DIFF
--- a/locales/de/tools.ftl
+++ b/locales/de/tools.ftl
@@ -28,7 +28,6 @@ tools-automation-cargo-doc-link = Zur Webseite
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -170,7 +170,6 @@ tools-rustup-manual-default-windows = If you are running Windows,<br>download an
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -120,7 +120,6 @@ tools-rustup-manual-default-windows = Si usas Windows, <br>descarga y ejecuta <a
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/fa/tools.ftl
+++ b/locales/fa/tools.ftl
@@ -20,7 +20,6 @@ install-other-methods-link = آموزش بیشتر
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -105,7 +105,6 @@ tools-rustup-manual-default-windows = Si vous utilisez Windows,<br> télécharge
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -95,7 +95,6 @@ tools-rustup-manual-default-windows = Se stai usando Windows,<br>scarica ed eseg
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -96,7 +96,6 @@ tools-rustup-manual-default-windows = Windows上であれば、<br><a href="http
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/ko/tools.ftl
+++ b/locales/ko/tools.ftl
@@ -55,7 +55,6 @@ tools-rustup-wsl-heading = Linux용 Windows 하위 시스템 (WSL)
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/pl/tools.ftl
+++ b/locales/pl/tools.ftl
@@ -40,7 +40,6 @@ tools-rustup-report = Zgłoś problem
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -145,7 +145,6 @@ tools-rustup-manual-default-windows = Se vocÃª estiver rodando Windows, <br> faÃ
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -118,7 +118,6 @@ tools-rustup-manual-default-windows = Если у вас запущен Windows,
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -129,7 +129,6 @@ tools-rustup-manual-default-windows = Eğer Windows kullanıyorsanız <br><a hre
 
 tools-editor-vscode = { ENGLISH("VS Code") }
 tools-editor-sublime = { ENGLISH("Sublime Text") }
-tools-editor-atom = { ENGLISH("Atom") }
 tools-editor-idea = { ENGLISH("RustRover") }
 tools-editor-eclipse = { ENGLISH("Eclipse") }
 tools-editor-vim = { ENGLISH("Vim") }

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -132,7 +132,6 @@ tools-rustup-manual-default-windows = 如果您正在运行 Windows，<br>请下
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -106,7 +106,6 @@ tools-rustup-manual-default-windows = 如果您的電腦是 Windows 作業系統
 
 tools-editor-vscode = VS Code
 tools-editor-sublime = Sublime Text
-tools-editor-atom = Atom
 tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim

--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -8,10 +8,6 @@
        class="button button-secondary">{{fluent "tools-editor-sublime"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://github.com/rust-lang/atom-ide-rust"
-       class="button button-secondary">{{fluent "tools-editor-atom"}}</a>
-  </div>
-  <div class="w-25-l w-50-m w-100 pa3">
     <a href="https://jetbrains.com/rust"
        class="button button-secondary">{{fluent "tools-editor-idea"}}</a>
   </div>


### PR DESCRIPTION
Atom is defunct. See https://github.blog/2022-06-08-sunsetting-atom, https://atom-editor.cc, and https://github.com/atom/atom.

A fork exists at https://github.com/pulsar-edit/pulsar but does not meet the bar to appear on https://www.rust-lang.org/learn/get-started, particularly compared to other modern options like Helix which has 10&times; as many GitHub stars.