### PR TITLE
Handle launching-pad subteams.

### DIFF
--- a/src/teams.rs
+++ b/src/teams.rs
@@ -59,7 +59,7 @@ impl Data {
         self.teams
             .into_iter()
             .filter(|team| team.website_data.is_some())
-            .filter(|team| team.subteam_of.is_none())
+            .filter(|team| matches!(team.subteam_of.as_deref(), None | Some("launching-pad")))
             .map(|team| IndexTeam {
                 url: format!(
                     "{}/{}",
@@ -98,8 +98,12 @@ impl Data {
             .ok_or(TeamNotFound)?;
 
         // Don't show pages for subteams
-        if main_team.subteam_of.is_some() {
-            return Err(TeamNotFound.into());
+        if let Some(subteam) = &main_team.subteam_of {
+            // Launching-pad does not have a page of its own, but we do want
+            // to show the working groups that are inside it.
+            if subteam != "launching-pad" {
+                return Err(TeamNotFound.into());
+            }
         }
 
         // Then find all the subteams, working groups and project groups.


### PR DESCRIPTION
In https://github.com/rust-lang/team/pull/1206 I am planning to add the launching-pad team, and connecting its subteams underneath it so that we can track it more effectively. Unfortunately this will break the working-group listing at https://www.rust-lang.org/governance because the current code is looking for working groups with no parent team. This changes it so that if a team/working-group is part of the launching-pad, it will continue to be displayed.

I don't know if long-term it would make sense to give the launching-pad its own sub-page. In practice, it is a transparent "umbrella" team, and I'm not sure if it makes sense to separate it out as an actual entity.
