### PR TITLE
Delete Geany from editors list, add Visual Studio

### DIFF
--- a/locales/de/tools.ftl
+++ b/locales/de/tools.ftl
@@ -32,4 +32,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/de/tools.ftl
+++ b/locales/de/tools.ftl
@@ -32,3 +32,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -174,4 +174,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -174,3 +174,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -124,4 +124,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -124,3 +124,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/fa/tools.ftl
+++ b/locales/fa/tools.ftl
@@ -24,3 +24,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/fa/tools.ftl
+++ b/locales/fa/tools.ftl
@@ -24,4 +24,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -109,3 +109,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -109,4 +109,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -99,4 +99,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -99,3 +99,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -100,3 +100,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -100,4 +100,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/ko/tools.ftl
+++ b/locales/ko/tools.ftl
@@ -59,3 +59,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/ko/tools.ftl
+++ b/locales/ko/tools.ftl
@@ -59,4 +59,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/pl/tools.ftl
+++ b/locales/pl/tools.ftl
@@ -44,3 +44,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/pl/tools.ftl
+++ b/locales/pl/tools.ftl
@@ -44,4 +44,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -149,4 +149,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -149,3 +149,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -122,4 +122,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -122,3 +122,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -133,3 +133,4 @@ tools-editor-idea = { ENGLISH("RustRover") }
 tools-editor-eclipse = { ENGLISH("Eclipse") }
 tools-editor-vim = { ENGLISH("Vim") }
 tools-editor-emacs = { ENGLISH("Emacs") }
+tools-editor-visual-studio = { ENGLISH("Visual Studio") }

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -133,4 +133,3 @@ tools-editor-idea = { ENGLISH("RustRover") }
 tools-editor-eclipse = { ENGLISH("Eclipse") }
 tools-editor-vim = { ENGLISH("Vim") }
 tools-editor-emacs = { ENGLISH("Emacs") }
-tools-editor-geany = { ENGLISH("Geany") }

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -136,3 +136,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -136,4 +136,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -110,3 +110,4 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
+tools-editor-visual-studio = Visual Studio

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -110,4 +110,3 @@ tools-editor-idea = RustRover
 tools-editor-eclipse = Eclipse
 tools-editor-vim = Vim
 tools-editor-emacs = Emacs
-tools-editor-geany = Geany

--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -23,8 +23,4 @@
     <a href="https://github.com/rust-lang/rust-mode"
        class="button button-secondary">{{fluent "tools-editor-emacs"}}</a>
   </div>
-  <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://geany.org/about/filetypes/"
-       class="button button-secondary">{{fluent "tools-editor-geany"}}</a>
-  </div>
 </div>

--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -23,4 +23,8 @@
     <a href="https://github.com/rust-lang/rust-mode"
        class="button button-secondary">{{fluent "tools-editor-emacs"}}</a>
   </div>
+  <div class="w-25-l w-50-m w-100 pa3">
+    <a href="https://rust-analyzer.github.io/manual.html#visual-studio-2022"
+       class="button button-secondary">{{fluent "tools-editor-visual-studio"}}</a>
+  </div>
 </div>


### PR DESCRIPTION
Pointed out in https://github.com/rust-lang/www.rust-lang.org/pull/1782#issuecomment-1476912746: Geany isn't nearly as popular as it was in the past.

Closes  #1781. Closes  #1782.