### PR TITLE
Fix redirects

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -301,6 +301,12 @@ fn not_found(req: &Request) -> Result<Template, Redirect> {
     Ok(not_found_locale(lang))
 }
 
+#[catch(422)]
+#[allow(clippy::result_large_err)]
+fn unprocessable_content(req: &Request) -> Result<Template, Redirect> {
+    not_found(req)
+}
+
 fn not_found_locale(lang: String) -> Template {
     let page = "404";
     let context = Context::new(page, "error404-page-title", false, (), lang);
@@ -526,5 +532,8 @@ async fn rocket() -> _ {
                 redirect_bare_en_us,
             ],
         )
-        .register("/", catchers![not_found, catch_error])
+        .register(
+            "/",
+            catchers![not_found, unprocessable_content, catch_error],
+        )
 }


### PR DESCRIPTION
fix #1921

This regression was introduced in ca2a1621ece46315bdce0c1f76ed055f3d18a20a.

In the update from Rocket v0.5.0-rc.3 to v0.5.0, there was a breaking change missed in the [changelog](https://github.com/rwf2/Rocket/blob/v0.5.0-rc.4/CHANGELOG.md
) of v0.5.0-rc.4 that affected us. 
The relevant section in the changelog starts with the line: "The status codes used when built-in guards forward were changed."

We used the status code 404 to invoke our custom `not_found` catcher. This custom catcher is responsible for the redirects. When the status code changed to 422, this catcher was not invoked and the redirects were not triggered.

This fix simply invokes the catcher for both status codes 404 and 422.