### PR TITLE
Add `/governance/teams/release` redirect

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -24,6 +24,11 @@ static PAGE_REDIRECTS: &[(&str, &str)] = &[
     ("security.html", "policies/security"),
     ("team.html", "governance"),
     ("user-groups.html", "community"),
+    // Team changes
+    (
+        "governance/teams/release",
+        "governance/teams/infra#team-release",
+    ),
 ];
 
 static STATIC_FILES_REDIRECTS: &[(&str, &str)] = &[

--- a/templates/governance/group-team.html.hbs
+++ b/templates/governance/group-team.html.hbs
@@ -1,7 +1,7 @@
-<a id="{{team-text team name}}" name="{{team.name}}"></a>
+<a id="team-{{team.name}}"></a>
 <div class="w-100 mw-none mw-8-m mw9-l ph3 center f3">
     <header class="pb0 pt5">
-        <a class="linkable-subheading" href="#{{team-text team name}}"><h2>{{team-text team name}}</h2></a>
+        <a class="linkable-subheading" href="#team-{{team.name}}"><h2>{{team-text team name}}</h2></a>
         <div class="highlight"></div>
     </header>
     <div>


### PR DESCRIPTION
The `release` team was moved to an `infra` subteam. This caused existing blogpost links to fail since the server is not aware of this change. This commit fixes the issue by adding an explicit redirect.

Resolves https://github.com/rust-lang/blog.rust-lang.org/issues/1246

r? @rust-lang/website 