### PR TITLE
Add /governance/teams/crates-io redirect

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -29,6 +29,10 @@ static PAGE_REDIRECTS: &[(&str, &str)] = &[
         "governance/teams/release",
         "governance/teams/infra#team-release",
     ),
+    (
+        "governance/teams/crates-io",
+        "governance/teams/dev-tools#team-crates-io",
+    ),
 ];
 
 static STATIC_FILES_REDIRECTS: &[(&str, &str)] = &[


### PR DESCRIPTION
The `crates-io` team was moved to a `dev-tools` subteam. This caused existing blogpost links to fail since the server is not aware of this change. This commit fixes the issue by adding an explicit redirect.

Big thanks to @Turbo87 for showing the proper way to process this change in #1929 !

r? @rust-lang/website