### PR TITLE
Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+
+updates:
+  - package-ecosystem: cargo
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      all:
+        patterns:
+          - "*"


### PR DESCRIPTION
Weekly PRs with all updates grouped into one PR to keep the noise down.
Exclude JavaScript, because those are just currently unused dev tools.
We should still be notified about actual security vulnerabilities in the JS dependencies.