### PR TITLE
Sort editors according to popularity

### DIFF
--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -4,31 +4,31 @@
        class="button button-secondary">{{fluent "tools-editor-vscode"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://github.com/rust-lang/rust-enhanced"
-       class="button button-secondary">{{fluent "tools-editor-sublime"}}</a>
+    <a href="https://github.com/rust-lang/rust.vim"
+       class="button button-secondary">{{fluent "tools-editor-vim"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
     <a href="https://jetbrains.com/rust"
        class="button button-secondary">{{fluent "tools-editor-rover"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://projects.eclipse.org/projects/tools.corrosion"
-       class="button button-secondary">{{fluent "tools-editor-eclipse"}}</a>
-  </div>
-  <div class="w-25-l w-50-m w-100 pa3">
     <a href="https://rust-analyzer.github.io/manual.html#helix"
        class="button button-secondary">{{fluent "tools-editor-helix"}}</a>
-  </div>
-  <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://github.com/rust-lang/rust.vim"
-       class="button button-secondary">{{fluent "tools-editor-vim"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
     <a href="https://github.com/rust-lang/rust-mode"
        class="button button-secondary">{{fluent "tools-editor-emacs"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
+    <a href="https://github.com/rust-lang/rust-enhanced"
+       class="button button-secondary">{{fluent "tools-editor-sublime"}}</a>
+  </div>
+  <div class="w-25-l w-50-m w-100 pa3">
     <a href="https://rust-analyzer.github.io/manual.html#visual-studio-2022"
        class="button button-secondary">{{fluent "tools-editor-visual-studio"}}</a>
+  </div>
+  <div class="w-25-l w-50-m w-100 pa3">
+    <a href="https://projects.eclipse.org/projects/tools.corrosion"
+       class="button button-secondary">{{fluent "tools-editor-eclipse"}}</a>
   </div>
 </div>


### PR DESCRIPTION
The order seemed a little random, the new one is according to the [Annual Rust Survey result](https://blog.rust-lang.org/2024/02/19/2023-Rust-Annual-Survey-2023-results.html#rust-usage).

The whole section may be do for an overhaul at some point, since there's really no need anymore these days to tell people which editors have Rust support. All of the ones to be taken seriously do. But that's for another day.

before:
![Screenshot from 2024-05-23 03-50-48](https://github.com/rust-lang/www.rust-lang.org/assets/54984957/f1778291-5358-4f61-b856-8ab5bf0ca9d8)

after:
![Screenshot from 2024-05-23 03-50-53](https://github.com/rust-lang/www.rust-lang.org/assets/54984957/6b6e47bf-cffb-422f-8111-099d782ac565)
