### PR TITLE
Remove redundant 404 handlers

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -151,16 +151,6 @@ fn baseurl(lang: &str) -> String {
     }
 }
 
-#[get("/components/<_file..>", rank = 1)]
-fn components(_file: PathBuf) -> Template {
-    not_found_locale(ENGLISH.into())
-}
-
-#[get("/<locale>/components/<_file..>", rank = 11)]
-fn components_locale(locale: SupportedLocale, _file: PathBuf) -> Template {
-    not_found_locale(locale.0)
-}
-
 #[get("/logos/<file..>", rank = 1)]
 async fn logos(file: PathBuf) -> Option<CachedNamedFile> {
     NamedFile::open(Path::new("static/logos").join(file))
@@ -521,14 +511,12 @@ async fn rocket() -> _ {
                 files,
                 robots_txt,
                 logos,
-                components,
                 index_locale,
                 category_locale,
                 governance_locale,
                 team_locale,
                 production_locale,
                 subject_locale,
-                components_locale,
                 redirect_bare_en_us,
             ],
         )


### PR DESCRIPTION
I'm not sure why these existed in the first place. If they are removed, any requests to paths starting with "components/" correctly return (localized) 404 pages.

Maybe this was intended to prevent accidentally matching a template in the components directory as a standalone page? Even if such directory-based templating was a problem at some point, it doesn't seem to be anymore.