### PR TITLE
Remove broken redirect to Chucklefish whitepaper

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -44,10 +44,6 @@ static STATIC_FILES_REDIRECTS: &[(&str, &str)] = &[
         "/static/pdfs/Rust-npm-Whitepaper.pdf",
     ),
     (
-        "pdfs/Rust-Chucklefish-Whitepaper.pdf",
-        "/static/pdfs/Rust-Chucklefish-Whitepaper.pdf",
-    ),
-    (
         "pdfs/Rust-Tilde-Whitepaper.pdf",
         "/static/pdfs/Rust-Tilde-Whitepaper.pdf",
     ),


### PR DESCRIPTION
The PDF was removed in the following PR:
https://github.com/rust-lang/www.rust-lang.org/pull/771