### PR TITLE
Hide big logos on small screens

### DIFF
--- a/templates/components/what/wasm/production.html.hbs
+++ b/templates/components/what/wasm/production.html.hbs
@@ -6,7 +6,7 @@
         </header>
         <div class="testimonials">
             <div class="testimonial flex flex-row">
-                <div class="w-30-l tc pa5">
+                <div class="w-30-l tc pa5 dn db-l">
                   <img src="/static/images/user-logos/cloudflare.svg" alt="{{fluent "wasm-production-cloudflare-alt"}}" />
                 </div>
                 <div class="w-70-l">
@@ -27,14 +27,14 @@
                         &ndash; {{fluent "wasm-production-mozilla-attribution" href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/"}}
                     </p>
                 </div>
-                <div class="w-30-l tc pa3">
+                <div class="w-20-l tc pa3 dn db-l">
                     <a href="https://hacks.mozilla.org/2018/01/oxidizing-source-maps-with-rust-and-webassembly/" class="db">
                         <img src="/static/images/firefox.png" alt="{{fluent "wasm-production-mozilla-alt"}}" />
                     </a>
                 </div>
             </div>
             <div class="testimonial flex flex-row">
-                <div class="w-30-l tc pa5">
+                <div class="w-30-l tc pa5 dn db-l">
                   <img src="/static/images/dropbox.svg" alt="{{fluent "wasm-production-dropbox-alt"}}" />
                 </div>
                 <div class="w-70-l">


### PR DESCRIPTION
Also decrease size of Firefox logo a little bit, making it visually more similar in size to the other logos.

closes #2029 