### PR TITLE
Add a french translation for tools-rustup-windows-2

### DIFF
--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -92,6 +92,7 @@ install-other-methods-link = En apprendre plus
 ## components/tools/rustup.hbs
 
 tools-rustup-unixy = Il semblerait que vous utilisez macOS, Linux ou un autre OS de type UNIX. Pour télécharger Rustup et installer Rust, exécutez la commande suivante dans votre terminal, puis suivez les instructions à l'écran.
+tools-rustup-windows-2 = Il semblerait que vous utilisez Windows. Pour commencer à utiliser Rust, téléchargez l'installeur, puis exécutez-le et suivez les instructions à l'écran. Vous pourriez avoir besoin d'installer les <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">outils Visual Studio C++ Build</a> lorsque cela vous sera demandé. Si vous n'utilisez pas Windows, consultez les <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"autres méthodes d'installation"</a>.
 tools-rustup-wsl-heading = Sous-système Windows pour Linux
 tools-rustup-wsl = Si vous êtes un utilisateur du sous-système Windows pour Linux, exécutez la commande suivante dans votre terminal, puis suivez les instructions à l'écran.
 tools-rustup-unknown = Rust fonctionne sur Windows, Linux, macOS, FreeBSD et NetBSD. Si vous êtes sur une de ces plateformes et voyez ceci, veuillez rapporter une erreur avec les valeur suivantes :
@@ -100,6 +101,7 @@ tools-rustup-manual-unixy = Pour installer Rust, si vous utilisez Unix, <br> ex�
 tools-rustup-manual-windows = Si vous êtes sous Windows,<br> téléchargez et exécutez <a href="https://win.rustup.rs">rustup‑init.exe</a>, puis suivez les instructions à l'écran.
 tools-rustup-manual-default = Pour installer Rust, si vous utilisez un Unix comme le WSL, Linux ou macOS,<br> exécutez la commande suivante dans votre terminal, puis suivez les instructions à l'écran.
 tools-rustup-manual-default-windows = Si vous utilisez Windows,<br> téléchargez et exécutez <a href="https://win.rustup.rs">rustup‑init.exe</a>, puis suivez les instructions à l'écran.
+
 
 ## components/tools/editors.hbs
 


### PR DESCRIPTION
I was checking the french "tools/install" page from a Windows computer when I noticed that the first paragraph is in English.
It seems to be because there was no value for "tools-rustup-windows-2".
I came to this conclusion based on the Italian version of the webpage, and the content of this variable in the Italian translation files.

So here is a french translation for this variable.
I hope this helps.