### PR TITLE
Improve unknown platform issue template

### DIFF
--- a/static/scripts/tools-install.js
+++ b/static/scripts/tools-install.js
@@ -157,8 +157,23 @@ function set_up_cycle_button() {
 function fill_in_bug_report_values() {
     var nav_plat = document.getElementById("nav-plat");
     var nav_app = document.getElementById("nav-app");
+    var report_link = document.getElementById("report-unknown-platform-link");
     nav_plat.textContent = navigator.platform;
     nav_app.textContent = navigator.appVersion;
+    var issue_template = `\
+<!--
+    PLEASE do not open an issue if you are using Android!
+
+    The Rust toolchain does not run and can't be installed on Android.
+
+    If you are on desktop, go ahead and open this issue.
+-->
+
+navigator.platform: \`${navigator.platform}\`
+navigator.appVersion: \`${navigator.appVersion}\`
+
+The website did not recognize the platform I'm on, so I am unable to install rustup.`;
+    report_link.href = "https://github.com/rust-lang/www.rust-lang.org/issues/new?title=Unrecognized%20platform&body=" + encodeURIComponent(issue_template);
 }
 
 var override_map = new Map ([

--- a/templates/components/tools/rustup.html.hbs
+++ b/templates/components/tools/rustup.html.hbs
@@ -33,7 +33,14 @@
       </div>
     </div>
     <br/>
-    <a href="https://github.com/rust-lang/www.rust-lang.org/issues/new?title=Unrecognized%20platform&body=navigator.platform%3A%20_please%20fill%20out_%0Anavigator.appVersion%3A%20_please%20fill%20out_%0A%0AThe%20website%20did%20not%20recognize%20the%20platform%20I%27m%20on%2C%20so%20I%20am%20unable%20to%20install%20rustup." class="button button-secondary">{{fluent "tools-rustup-report"}}</a>
+    <!-- This href is overwritten with a better template in static/scripts/tools-install.js -->
+    <a
+      href="https://github.com/rust-lang/www.rust-lang.org/issues/new"
+      id="report-unknown-platform-link"
+      class="button button-secondary"
+    >
+      {{fluent "tools-rustup-report"}}
+    </a>
     <hr/>
     <div>
       <p>


### PR DESCRIPTION
Apparently, the previous instructions to include the values for `navigator.platform` and `navigator.appVersion` were not clear enough. This automates the process completely, hopefully preventing useless issues like these:

- https://github.com/rust-lang/www.rust-lang.org/issues/2034
- https://github.com/rust-lang/www.rust-lang.org/issues/2037
- https://github.com/rust-lang/www.rust-lang.org/issues/2038

Security wise, I think `encodeURIComponent` should prevent any risk of code injection via `navigator.platform` (I don't know if that's even possible in the first place).