### PR TITLE
Remove unrecognized platform report button

### DIFF
--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -159,10 +159,6 @@ tools-rustup-unixy = It looks like you’re running macOS, Linux, or another Uni
 tools-rustup-windows-2 = It looks like you’re running Windows. To start using Rust, download the installer, then run the program and follow the onscreen instructions. You may need to install the <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">Visual Studio C++ Build tools</a> when prompted to do so. If you are not on Windows see <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Other Installation Methods"</a>.
 tools-rustup-wsl-heading = Windows Subsystem for Linux
 tools-rustup-wsl = If you’re a Windows Subsystem for Linux user run the following in your terminal, then follow the on-screen instructions to install Rust.
-tools-rustup-unknown = Rust runs on Windows, Linux, macOS, FreeBSD and NetBSD. If you are on one of these platforms and are seeing this then please report an issue with the following values:
-tools-rustup-report = Report an Issue
-tools-rustup-manual-unixy = To install Rust, if you are running Unix, <br>run the following in your terminal, then follow the on-screen instructions.
-tools-rustup-manual-windows = If you are running Windows,<br>download and run <a href="https://win.rustup.rs">rustup‑init.exe</a> then follow the on-screen instructions.
 tools-rustup-manual-default = To install Rust, if you are running a Unix such as WSL, Linux or macOS,<br> run the following in your terminal, then follow the on-screen instructions.
 tools-rustup-manual-default-windows = If you are running Windows,<br>download and run <a href="https://win.rustup.rs">rustup‑init.exe</a> then follow the on-screen instructions.
 

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -109,10 +109,6 @@ tools-rustup-unixy = Parece que estás usando macOS, GNU/Linux u otra variante d
 tools-rustup-windows-2 = Parece que estás usando Windows. Para empezar a usar Rust, descarga el instalador, ejecútalo y sigue las instrucciones que aparecen en pantalla. Es posible que tengas que instalar las <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">Visual Studio C++ Build tools</a> cuando se te pida. Si no estás usando Windows, ve a <a href="https://forge.rust-lang.org/infra/other-installation-methods.html"><em>"Other Installation Methods"</em></a>
 tools-rustup-wsl-heading = Subsistema de Windows para Linux
 tools-rustup-wsl = Si utilizas el Subsistema de Windows para Linux (WSL), ejecuta el siguiente comando en tu terminal y sigue las instrucciones que aparecen en pantalla para instalar Rust.
-tools-rustup-unknown = Rust funciona en Windows, Linux, macOS, FreeBSD and NetBSD. Si estás en una de estas plataformas y ves esto, por favor, informa de un problema con los siguientes valores:
-tools-rustup-report = Informar de un problema
-tools-rustup-manual-unixy = Para instalar Rust, si usas Unix, <br>ejecuta el siguiente comando en tu terminal y sigue las instrucciones que aparecen en pantalla.
-tools-rustup-manual-windows = Si usas Windows, <br>descarga y ejecuta <a href="https://win.rustup.rs">rustup‑init.exe</a> y sigue las instrucciones que aparecen en pantalla.
 tools-rustup-manual-default = Para instalar Rust, si usas una variante de Unix como WSL, GNU/Linux o macOS, <br> ejecuta el siguiente comando en tu terminal y sigue las instrucciones que aparecen en pantalla.
 tools-rustup-manual-default-windows = Si usas Windows, <br>descarga y ejecuta <a href="https://win.rustup.rs">rustup‑init.exe</a> y sigue las instrucciones que aparecen en pantalla.
 

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -95,10 +95,6 @@ tools-rustup-unixy = Il semblerait que vous utilisez macOS, Linux ou un autre OS
 tools-rustup-windows-2 = Il semblerait que vous utilisez Windows. Pour commencer à utiliser Rust, téléchargez l'installeur, puis exécutez-le et suivez les instructions à l'écran. Vous pourriez avoir besoin d'installer les <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">outils Visual Studio C++ Build</a> lorsque cela vous sera demandé. Si vous n'utilisez pas Windows, consultez les <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"autres méthodes d'installation"</a>.
 tools-rustup-wsl-heading = Sous-système Windows pour Linux
 tools-rustup-wsl = Si vous êtes un utilisateur du sous-système Windows pour Linux, exécutez la commande suivante dans votre terminal, puis suivez les instructions à l'écran.
-tools-rustup-unknown = Rust fonctionne sur Windows, Linux, macOS, FreeBSD et NetBSD. Si vous êtes sur une de ces plateformes et voyez ceci, veuillez rapporter une erreur avec les valeur suivantes :
-tools-rustup-report = Rapporter une erreur
-tools-rustup-manual-unixy = Pour installer Rust, si vous utilisez Unix, <br> exécutez la commande suivante dans votre terminal, puis suivez les instructions à l'écran.
-tools-rustup-manual-windows = Si vous êtes sous Windows,<br> téléchargez et exécutez <a href="https://win.rustup.rs">rustup‑init.exe</a>, puis suivez les instructions à l'écran.
 tools-rustup-manual-default = Pour installer Rust, si vous utilisez un Unix comme le WSL, Linux ou macOS,<br> exécutez la commande suivante dans votre terminal, puis suivez les instructions à l'écran.
 tools-rustup-manual-default-windows = Si vous utilisez Windows,<br> téléchargez et exécutez <a href="https://win.rustup.rs">rustup‑init.exe</a>, puis suivez les instructions à l'écran.
 

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -84,10 +84,6 @@ tools-rustup-unixy = Sembra che tu stia usando macOS, Linux o un altro sistema d
 tools-rustup-windows-2 = Sembra che il tuo sistema opertivo sia Windows. Per iniziare ad usare Rust, scarica l'installer, eseguilo ed infine segui i passaggi che ti vengono mostrati. Per completare l'installazione occorre installare <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">Visual Studio C++ Build tools</a>, ti verrà richiesto in caso risulti mancante. Se invece non sei su Windows, vai alla pagina <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Other Rust Installation Methods"</a>.
 tools-rustup-wsl-heading = Windows Subsystem per Linux
 tools-rustup-wsl = Se stai usando Windows Subsystem for Linux esegui i seguenti comandi nel tuo terminale e segui le istruzioni a schermo per installare Rust.
-tools-rustup-unknown = Rust gira su Windows, Linux, macOS, FreeBSD and NetBSD. Se stai usando una di queste piattaforme e stai vedendo questo messaggio segnala l'errore inserendo i seguenti valori:
-tools-rustup-report = Segnala un problema
-tools-rustup-manual-unixy = Se stai usando un sistema Unix, per installare Rust <br>esegui i seguenti comandi nel tuo terminale e segui le istruzioni a schermo.
-tools-rustup-manual-windows = Se stai usando Windows,<br>scarica ed esegui <a href="https://win.rustup.rs">rustup‑init.exe</a> e segui le istruzioni a schermo.
 tools-rustup-manual-default = Se stai usando un sistema Unix come WSL, Linux o macOS<br>esegui i seguenti comandi nel tuo terminale e segui le istruzioni a schermo.
 tools-rustup-manual-default-windows = Se stai usando Windows,<br>scarica ed esegui <a href="https://win.rustup.rs">rustup‑init.exe</a> e segui le istruzioni a schermo.
 

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -85,10 +85,6 @@ tools-rustup-unixy = あなたはmacOSかLinuxまたはその他のUnix系OSを�
 tools-rustup-windows-2 = あなたはWindowsを使用しているようです。Rustを使い始めるには、インストーラをダウンロードして実行し、画面に表示される指示に従ってください。場合によっては、<a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">Visual Studio C++ Build tools</a>をインストールする必要があります。もしWindowsユーザでない場合には、<a href="https://forge.rust-lang.org/infra/other-installation-methods.html">「その他のインストール方法」</a>を参照してください。
 tools-rustup-wsl-heading = Windows Subsystem for Linux
 tools-rustup-wsl = あなたがWindows Subsystem for Linuxのユーザーであるなら、下記をターミナル上で実行し、スクリーン上の説明に従ってRustをインストールしてください。
-tools-rustup-unknown = RustはWindows、Linux、macOS、FreeBSD、そしてNetBSD上で動作します。これらのプラットフォームのいずれかでこれが表示されている場合は、以下の値と一緒に問題を報告してください。
-tools-rustup-report = 問題を報告する
-tools-rustup-manual-unixy = Unix上でRustをインストールするときは、<br>以下をターミナルで実行し、画面の指示に従ってください。
-tools-rustup-manual-windows = Windows上では、<br><a href="https://win.rustup.rs">rustup-init.exe</a>をダウンロード・実行し、画面の指示に従ってください。
 tools-rustup-manual-default = WSL、Linux、あるいはmacOSのようなUnix系統のOS上でRustをインストールするときは、<br>以下をターミナルで実行し、画面の指示に従ってください。
 tools-rustup-manual-default-windows = Windows上であれば、<br><a href="https://win.rustup.rs">rustup-init.exe</a>をダウンロード・実行し、画面の指示に従ってください。
 

--- a/locales/pl/tools.ftl
+++ b/locales/pl/tools.ftl
@@ -34,7 +34,6 @@ install-other-methods-link = Dowiedz się więcej
 ## components/tools/rustup.hbs
 
 tools-rustup-wsl-heading = Windows Subsystem for Linux
-tools-rustup-report = Zgłoś problem
 
 ## components/tools/editors.hbs
 

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -134,10 +134,6 @@ tools-rustup-unixy = Aparentemente você está rodando macOS, Linux, ou outro si
 tools-rustup-windows-2 = Parece que você está rodando Windows. Para começar a usar Rust, baixe o instalador, em seguida rode o programa e siga as instruções na tela. Você pode precisar instalar o <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/"><i>Visual Studio C++ Build tools</i></a> se solicitado durante o processo de instalação. Se você não está no Windows, veja <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Outros Métodos de Instalação"</a>.
 tools-rustup-wsl-heading = Windows Subsystem for Linux
 tools-rustup-wsl = Se você for um usuário do Windows Subsystem for Linux (WSL) execute o seguinte comando no terminal, e siga as instruções na tela para a instalação de Rust.
-tools-rustup-unknown = Rust funciona em Windows, Linux, macOS, FreeBSD e NetBSD. Se você estiver em alguma dessas plataformas e estiver vendo essa mensagem, então reporte um problema com as seguintes informações:
-tools-rustup-report = Reporte um problema
-tools-rustup-manual-unixy = Para instalar Rust, se você estiver rodando Unix, <br> execute o seguinte no seu terminal, e siga as instruções que surgirem na tela.
-tools-rustup-manual-windows = Se você estiver rodando Windows, <br>baixe e execute <a href="https://win.rustup.rs">rustup‑init.exe</a>, e então siga as instruções que surgirem na tela.
 tools-rustup-manual-default = Para instalar Rust, se você estiver rodando algum Unix como o WSL, Linux ou macOS, <br> execute o seguinte comando no seu terminal, e siga as instruções que surgirem na tela.
 tools-rustup-manual-default-windows = Se você estiver rodando Windows, <br> faça o download e execute <a href="https://win.rustup.rs">rustup‑init.exe</a>, e então siga as instruções que aparecem na tela.
 

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -107,10 +107,6 @@ tools-rustup-unixy = Кажется у вас запущена macOS, Linux ил
 tools-rustup-windows-2 = Похоже, вы работаете под управлением Windows. Чтобы начать использовать Rust, загрузите установщик, затем запустите программу и следуйте инструкциям на экране. Возможно, Вам потребуется установить<a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/">Visual Studio C++ Build tools</a> при появлении соответствующего запроса. Если вы не работаете в Windows, смотрите <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"другие методы установки"</a>.
 tools-rustup-wsl-heading = Windows Subsystem for Linux
 tools-rustup-wsl = Если вы используете Windows Subsystem for Linux, для установки Rust запустите следующее в вашем терминале и затем следуйте инструкциям на экране.
-tools-rustup-unknown = Rust запускается на Windows, Linux, macOS, FreeBSD и NetBSD. Если вы используете одну из этих платформ и видите это, то пожалуйста, сообщите о проблеме и следующих значениях:
-tools-rustup-report = Сообщить о проблеме
-tools-rustup-manual-unixy = Если вы используете Unix, то для установки Rust<br>запустите в терминале следующую команду и следуйте инструкциям на экране.
-tools-rustup-manual-windows = Если у вас запущен Windows,<br>скачайте и запустите <a href="https://win.rustup.rs">rustup‑init.exe</a> и затем следуйте инструкциям на экране.
 tools-rustup-manual-default = Если вы используете Unix, такой как WSL, Linux или macOS, то для установки Rust<br>запустите следующую команду в вашем терминале и следуйте инструкциям на экране.
 tools-rustup-manual-default-windows = Если у вас запущен Windows,<br>скачайте и запустите <a href="https://win.rustup.rs">rustup‑init.exe</a>, а затем следуйте инструкциям на экране.
 

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -118,10 +118,6 @@ tools-rustup-unixy = Görünüşe bakılırsa macOS, Linux veya Unix tabanlı bi
 tools-rustup-windows = Görünüşe bakılırsa Windows kullanıyorsunuz. Rust'ı yüklemek için şunu indirin ve çalıştırın. Ardından ekrandaki talimatları izleyin.
 tools-rustup-wsl-heading = Windows için Linux Altsistemi
 tools-rustup-wsl = Eğer Windows için Linux Altsistemi kullanıcısıysanız Rust'ı yüklemek için uçbiriminizde şunları çalıştırın ve ardından ekrandaki talimatları izleyin.
-tools-rustup-unknown = Rust, Windows'ta, Linux'ta, macOS'ta, FreeBSD'de ve NetBSD'de çalışır. Eğer bu platformlardan birisini kullanıyorsanız ve bunu görüyorsanız lütfen aşağıdaki değerlerle birlikte sorunu bildirin.
-tools-rustup-report = Bir sorun bildirin
-tools-rustup-manual-unixy = Eğer Unix kullanıyorsanız Rust'ı yüklemek için <br>uçbiriminizde şunları çalıştırın. Ardından ekrandaki talimatları izleyin.
-tools-rustup-manual-windows = Eğer Windows kullanıyorsanız <br><a href="https://win.rustup.rs">{ ENGLISH("rustup-init.exe") }</a>'yi indirin ve çalıştırın. Ardından ekrandaki talimatları izleyin.
 tools-rustup-manual-default = Eğer WSL, Linux veya macOS gibi bir Unix işletim sistemi kullanıyorsanız Rust'ı yüklemek için <br> uçbiriminizde şunları çalıştırın. Ardından ekrandaki talimatları izleyin.
 tools-rustup-manual-default-windows = Eğer Windows kullanıyorsanız <br><a href="https://win.rustup.rs">{ ENGLISH("rustup-init.exe") }</a>'yi indirin ve çalıştırın. Ardından ekrandaki talimatları izleyin.
 

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -121,10 +121,6 @@ tools-rustup-unixy = 您似乎正在运行 macOS、Linux 或其它类 Unix 系�
 tools-rustup-windows-2 = 您似乎正在运行 Windows。要使用 Rust，请下载安装器，然后运行该程序并遵循屏幕上的指示。当看到相应提示时，您可能需要安装 <a href="https://visualstudio.microsoft.com/zh-hans/visual-cpp-build-tools/">Microsoft C++ 生成工具</a>。如果您不在 Windows 上，参看 <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">“其他安装方式”</a>。
 tools-rustup-wsl-heading = Windows 的 Linux 子系统（WSL）
 tools-rustup-wsl = 如果您是 Windows 的 Linux 子系统（WSL）用户，要安装 Rust，请在终端中运行以下命令，然后遵循屏幕上的指示。
-tools-rustup-unknown = Rust 可在 Windows、Linux、macOS、FreeBSD 和 NetBSD 上运行。如果您在这些平台上看到了本条信息，请报告一个问题并附上以下内容：
-tools-rustup-report = 报告问题
-tools-rustup-manual-unixy = 如果您正在运行 Unix，要安装 Rust，<br>请在终端中运行以下命令，然后遵循屏幕上的指示。
-tools-rustup-manual-windows = 如果您正在运行 Windows，<br>请下载并运行 <a href="https://win.rustup.rs">rustup‑init.exe</a>，然后遵循屏幕上的指示。
 tools-rustup-manual-default = 如果您正在运行 WSL、Linux 或 macOS 等类-Unix 系统，要安装 Rust，<br>请在终端中运行以下命令，然后遵循屏幕上的指示。
 tools-rustup-manual-default-windows = 如果您正在运行 Windows，<br>请下载并运行 <a href="https://win.rustup.rs">rustup‑init.exe</a>，然后遵循屏幕上的指示。
 

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -95,10 +95,6 @@ tools-rustup-unixy = 您的作業系統似乎是 macOS、Linux 或其他類 Unix
 tools-rustup-windows-2 = 您似乎正在運行 Windows。欲使用 Rust，請下載安裝工具後，執行該程式並遵照螢幕上的指示。當看見相關提示時，您可能需要下載 <a href="https://visualstudio.microsoft.com/visual-cpp-build-tools/"> Visual Studio C++ Build tools</a>。若您並非使用 Windows，請參考<a href="https://forge.rust-lang.org/infra/other-installation-methods.html">「其他安裝方式」</a>。
 tools-rustup-wsl-heading = Windows 的 Linux 子系統（WSL）
 tools-rustup-wsl = 如果您是 Windows 的 Liunx 子系統（WSL）使用者，要安裝 Rust，請在終端機執行以下指令，並遵循螢幕上的指示。
-tools-rustup-unknown = Rust 可以在 Windows、Linux、maxOS、FreeBSD 和 NetBSD 上運作。如果您在這些平台上，看到此訊息，請回報問題，並附上以下內容：
-tools-rustup-report = 回報問題
-tools-rustup-manual-unixy = 如果您的作業系統是 Unix，要安裝 Rust，<br> 請在終端機執行以下指令，並遵循螢幕上的指示。
-tools-rustup-manual-windows = 如果您的電腦是 Windows 作業系統，<br>請下載並執行 <a href="https://win.rustup.rs">rustup‑init.exe</a> ，然後遵循螢幕上的指示。
 tools-rustup-manual-default = 如果您的作業系統是 Linux 或 macOS、WSL 等類 Unix 系統，要安裝 Rust，<br> 請在終端機執行以下指令，並遵循螢幕上的指示。
 tools-rustup-manual-default-windows = 如果您的電腦是 Windows 作業系統，<br>請下載並執行 <a href="https://win.rustup.rs">rustup‑init.exe</a> ，然後遵循螢幕上的指示。
 

--- a/static/scripts/tools-install.js
+++ b/static/scripts/tools-install.js
@@ -64,20 +64,16 @@ function adjust_for_platform() {
 
     var unix_div = document.getElementById("platform-instructions-unix");
     var win_div = document.getElementById("platform-instructions-win");
-    var unknown_div = document.getElementById("platform-instructions-unknown");
     var default_div = document.getElementById("platform-instructions-default");
 
     vis(unix_div, "dn");
     vis(win_div, "dn");
-    vis(unknown_div, "dn");
     vis(default_div, "dn");
 
     if (platform == "unix") {
         vis(unix_div, "db");
     } else if (platform == "win") {
         vis(win_div, "db");
-    } else if (platform == "unknown") {
-        vis(unknown_div, "db");
     } else {
         vis(default_div, "db");
     }
@@ -154,28 +150,6 @@ function set_up_cycle_button() {
     };
 }
 
-function fill_in_bug_report_values() {
-    var nav_plat = document.getElementById("nav-plat");
-    var nav_app = document.getElementById("nav-app");
-    var report_link = document.getElementById("report-unknown-platform-link");
-    nav_plat.textContent = navigator.platform;
-    nav_app.textContent = navigator.appVersion;
-    var issue_template = `\
-<!--
-    PLEASE do not open an issue if you are using Android!
-
-    The Rust toolchain does not run and can't be installed on Android.
-
-    If you are on desktop, go ahead and open this issue.
--->
-
-navigator.platform: \`${navigator.platform}\`
-navigator.appVersion: \`${navigator.appVersion}\`
-
-The website did not recognize the platform I'm on, so I am unable to install rustup.`;
-    report_link.href = "https://github.com/rust-lang/www.rust-lang.org/issues/new?title=Unrecognized%20platform&body=" + encodeURIComponent(issue_template);
-}
-
 var override_map = new Map ([
     ["unix", "unix"],
     ["win", "win"],
@@ -207,5 +181,4 @@ function check_initial_override() {
     check_initial_override();
     adjust_for_platform();
     set_up_cycle_button();
-    fill_in_bug_report_values();
 }());

--- a/templates/components/tools/rustup.html.hbs
+++ b/templates/components/tools/rustup.html.hbs
@@ -19,46 +19,10 @@
   <p>{{fluent "tools-rustup-wsl"}}</p>
   <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
   </div>
-  <div id="platform-instructions-unknown" class="instructions dn">
-    <!-- unrecognized platform: ask for help -->
-    <p>
-      {{fluent "tools-rustup-unknown"}}
-    </p>
-    <div class="install-details code">
-      <div>navigator.platform:
-        <span id="nav-plat">MacIntel</span>
-      </div>
-      <div>navigator.appVersion:
-        <span id="nav-app">5.0 (Macintosh)</span>
-      </div>
-    </div>
-    <br/>
-    <!-- This href is overwritten with a better template in static/scripts/tools-install.js -->
-    <a
-      href="https://github.com/rust-lang/www.rust-lang.org/issues/new"
-      id="report-unknown-platform-link"
-      class="button button-secondary"
-    >
-      {{fluent "tools-rustup-report"}}
-    </a>
-    <hr class="white-hr" />
-    <div>
-      <p>
-        {{fluent "tools-rustup-manual-unixy"}}
-      </p>
-      <code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code>
-    </div>
-    <hr class="white-hr" />
-    <div>
-      <p>
-        {{fluent "tools-rustup-manual-windows"}}
-      </p>
-    </div>
-  </div>
   <div id="platform-instructions-default" class="instructions dn">
     <div>
       <p>
-        {{tools-rustup-manual-default}}
+        {{fluent "tools-rustup-manual-default"}}
       </p>
       <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
     </div>


### PR DESCRIPTION
There was a steady stream of issues generated by this report button.

None of the people who opened issues would be responsive and eloborate on the kind of platform they're using. Most of them had "Android" in their user agent, even though the issue template specifically said not to open an issue if one is using Android.

At this point, it seems safe to assume the platform detection code works pretty well and getting rid of the report button is not a big loss.