### PR TITLE
Make install command easier to select

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -109,6 +109,10 @@ code.code-header {
   margin: 0 0 3px 0;
 }
 
+code.copyable {
+  user-select: all;
+}
+
 header h1,
 section h2 {
   z-index: 999999;

--- a/templates/components/tools/rustup.html.hbs
+++ b/templates/components/tools/rustup.html.hbs
@@ -1,7 +1,7 @@
 <div class="row">
   <div id="platform-instructions-unix" class="instructions db">
     <p>{{fluent "tools-rustup-unixy"}}</p>
-    <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+    <pre><code class="db w-100 copyable">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
   </div>
   <div id="platform-instructions-win" class="instructions dn">
     <p>{{fluent "tools-rustup-windows-2"}}</p>
@@ -17,14 +17,14 @@
   </div>
   <h3 class="mt4">{{fluent "tools-rustup-wsl-heading"}}</h3>
   <p>{{fluent "tools-rustup-wsl"}}</p>
-  <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+  <pre><code class="db w-100 copyable">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
   </div>
   <div id="platform-instructions-default" class="instructions dn">
     <div>
       <p>
         {{fluent "tools-rustup-manual-default"}}
       </p>
-      <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+      <pre><code class="db w-100 copyable">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
     </div>
     <hr class="white-hr" />
     <div>


### PR DESCRIPTION
This is a simpler version of #1695. The entire text is selected with a single click, instead of a triple click or dragging the mouse. The user still has to hit Ctrl+C themselves.

closes #1659