### PR TITLE
Move launching pad to its own page

### DIFF
--- a/locales/en-US/teams.ftl
+++ b/locales/en-US/teams.ftl
@@ -56,6 +56,9 @@ governance-team-lang-docs-description = Developing and writing the docs related 
 governance-team-lang-ops-name = lang-ops team
 governance-team-lang-ops-description = Operations for the lang team: preparing agenda, issue triage, scheduling and documenting meetings
 
+governance-team-launching-pad-name = Launching pad
+governance-team-launching-pad-description = An interim home for teams
+
 governance-team-leadership-council-name = Leadership council
 governance-team-leadership-council-description = Charged with the success of the Rust Project as whole, consisting of representatives from top-level teams
 

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -15,7 +15,6 @@ use crate::cache::{Cache, Cached};
 #[derive(Default, Serialize)]
 pub struct IndexData {
     teams: Vec<IndexTeam>,
-    wgs: Vec<IndexTeam>,
 }
 
 #[derive(Serialize)]
@@ -63,13 +62,11 @@ impl Data {
             .into_iter()
             .filter(|team| team.website_data.is_some())
             // On the main page, show the leadership-council, all top-level
-            // teams, and everything in the launching pad. We may want to
-            // consider putting launching pad teams in a separate page in the
-            // future?
+            // teams.
             .filter(|team| {
                 matches!(
                     team.subteam_of.as_deref(),
-                    None | Some("launching-pad") | Some("leadership-council")
+                    None | Some("leadership-council")
                 )
             })
             .map(|team| IndexTeam {
@@ -80,16 +77,13 @@ impl Data {
                 ),
                 team,
             })
-            .for_each(|team| match team.team.kind {
-                TeamKind::Team => data.teams.push(team),
-                TeamKind::WorkingGroup => data.wgs.push(team),
-                _ => {}
+            .for_each(|team| {
+                if team.team.kind == TeamKind::Team {
+                    data.teams.push(team)
+                }
             });
 
         data.teams.sort_by_key(|index_team| {
-            Reverse(index_team.team.website_data.as_ref().unwrap().weight)
-        });
-        data.wgs.sort_by_key(|index_team| {
             Reverse(index_team.team.website_data.as_ref().unwrap().weight)
         });
         Ok(data)
@@ -374,9 +368,6 @@ mod tests {
         assert_eq!(res.teams.len(), 1);
         assert_eq!(res.teams[0].url, "teams/bar");
         assert_eq!(res.teams[0].team.name, "bar");
-        assert_eq!(res.wgs.len(), 1);
-        assert_eq!(res.wgs[0].url, "wgs/foo");
-        assert_eq!(res.wgs[0].team.name, "foo");
     }
 
     #[test]

--- a/templates/governance/index.html.hbs
+++ b/templates/governance/index.html.hbs
@@ -37,20 +37,5 @@
     </div>
 </section>
 
-<section id="working-groups" class="green">
-    <div class="w-100 mw-none ph3 mw-8-m mw9-l center f3">
-        <header>
-            <h2>{{fluent "governance-wgs-header"}}</h2>
-            <div class="highlight"></div>
-        </header>
-        <div class="flex flex-column flex-row-l flex-wrap-l justify-start tc">
-
-            {{#each data.wgs as |team| ~}}
-                {{> governance/index-team}}
-            {{/each~}}
-        </div>
-    </div>
-</section>
-
 {{/inline}}
 {{~> (lookup this "parent")~}}


### PR DESCRIPTION
This changes the governance page so that the launching pad has its own page. All the working groups are moved from the top-level page to show up under the launching-pad page instead.

One of the intentions here is to support showing team members for non-working-groups in the launching pad. Currently there is no way to view them.

I suspect that we will keep the launching pad for a long time, as it will take a while to reorganize everything. It's also unclear if we should keep the launching-pad indefinitely, or if there will be some point where we will remove it. I think once we reach that point, then we'll just remove the launching-pad page.

The old links for things like https://www.rust-lang.org/governance/wgs/wg-security-response continue to work, but there are no direct links to them anymore.
