### PR TITLE
Add redirect for wg-async adoption by lang

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -38,6 +38,10 @@ static PAGE_REDIRECTS: &[(&str, &str)] = &[
     ),
     ("governance/teams/language-and-compiler", "governance#teams"),
     ("governance/teams/operations", "governance#teams"),
+    (
+        "governance/wgs/wg-async",
+        "governance/teams/lang#team-wg-async",
+    ),
     // miscellaneous
     ("governance/teams", "governance#teams"),
     ("governance/wgs", "governance#working-groups"),


### PR DESCRIPTION
If WG-async is to be adopted by lang, let's add a redirect from where its page previously appeared on our website to where it will now.

See:

- https://github.com/rust-lang/team/pull/1639
