### PR TITLE
Remove doubled horizontal padding from "get started" button

### DIFF
--- a/templates/index.html.hbs
+++ b/templates/index.html.hbs
@@ -7,7 +7,7 @@
         {{fluent "tagline" linebreak="<br class='dn db-ns'>"}}
       </h2>
     </div>
-    <div class="w-30-l flex-column pl0-l pr0-l pl3 pr3">
+    <div class="w-30-l flex-column pl0-l pr0-l">
       <a class="button button-download ph4 mt0 w-100" href="{{baseurl}}/learn/get-started">
         {{fluent "get-started"}}
       </a>


### PR DESCRIPTION
This removes the double horizontal padding from the "get started" button on the home page to align it with all other content and buttons on the page

fixes: #2146