### PR TITLE
fix(i18n): home page footer layout overflow error

### DIFF
--- a/templates/components/footer.html.hbs
+++ b/templates/components/footer.html.hbs
@@ -1,6 +1,6 @@
 <footer>
   <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <div class="flex flex-column flex-row-ns pv0-l">
+    <div class="flex flex-column flex-row-l pv0-l">
       <div class="flex flex-column mw8 w-100 measure-wide-l pv2 pv5-m pv2-ns ph4-m ph4-l" id="get-help">
         <h4>{{fluent "footer-get-help"}}</h4>
         <ul>


### PR DESCRIPTION
# error page

```
url:https://www.rust-lang.org/ru/
windows width size: 500

Mozilla/5.0 (Linux; Android 6.0; Nexus 5 Build/MRA58N) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/136.0.0.0 Mobile Safari/537.36

Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:136.0) Gecko/20100101 Firefox/136.0
```

<img width="500" alt="image" src="https://github.com/user-attachments/assets/dd174162-4934-4e07-a3a3-54039254dee0" />

---

# This pr page
<img width="500" alt="image" src="https://github.com/user-attachments/assets/716b32db-86ad-4548-b996-b33e7f18c427" />
