### PR TITLE
Fix broken links on tools page

### DIFF
--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -12,7 +12,7 @@
        class="button button-secondary">{{fluent "tools-editor-rover"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://rust-analyzer.github.io/manual.html#helix"
+    <a href="https://rust-analyzer.github.io/book/other_editors.html#helix"
        class="button button-secondary">{{fluent "tools-editor-helix"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
@@ -24,7 +24,7 @@
        class="button button-secondary">{{fluent "tools-editor-sublime"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">
-    <a href="https://rust-analyzer.github.io/manual.html#visual-studio-2022"
+    <a href="https://rust-analyzer.github.io/book/other_editors.html#visual-studio-2022"
        class="button button-secondary">{{fluent "tools-editor-visual-studio"}}</a>
   </div>
   <div class="w-25-l w-50-m w-100 pa3">


### PR DESCRIPTION
rust-analyzer seems to have moved its documentation to mdbook and broke some links in the process.

shouldn't conflict with #2154