### PR TITLE
Updates to the security policy

### DIFF
--- a/locales/core.ftl
+++ b/locales/core.ftl
@@ -20,6 +20,8 @@
         https://groups.google.com/forum/#!forum/rustlang-security-announcements
 -rust-security-announcements-mailing-list-href =
         https://groups.google.com/group/rustlang-security-announcements/subscribe
+-rust-security-supported-channels-href =
+        https://doc.rust-lang.org/book/appendix-07-nightly-rust.html
 -rustlang-security-announcements-subscribe-anchor =
         <a href="mailto:rustlang-security-announcements+subscribe@googlegroups.com">rustlang-security-announcements+subscribe@googlegroups.com</a>
 -distros-openwall-email-anchor =

--- a/locales/core.ftl
+++ b/locales/core.ftl
@@ -1,8 +1,6 @@
 -security-at-rust-lang-org-anchor = { EMAIL("security@rust-lang.org") }
 -rust-security-team-key-href =
         /static/keys/rust-security-team-key.gpg.ascii
--rust-pgp-key-mit-keyserver-href =
-        https://pgp.mit.edu/pks/lookup?op=vindex&amp;search=0xEFB9860AE7520DAC"
 -wikipedia-rfpolicy-href =
         https://en.wikipedia.org/wiki/RFPolicy
 

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -78,6 +78,6 @@ security-receiving-heading = Receiving security updates
 security-receiving-description--2025-07 =
         <p>The best way to receive all the security announcements is to subscribe to the <a href="{ -rust-security-announcements-mailing-list-href }">Rust security announcements mailing list</a> (alternatively by sending an email to { -rustlang-security-announcements-subscribe-anchor }). The mailing list is very low traffic, and it receives the public notifications the moment the embargo is lifted.</p>
         <p>The Rust project only provides support and security updates for the most recent stable release and the latest releases in our <a href="{ -rust-security-supported-channels-href }">beta and nightly channels</a>. As Rust releases must be built in the public, we will begin the release process as soon as the embargo lifts, and a release blog post will be published once updated binaries are available for download.</p>
-        <p>We will announce vulnerabilities 72 hours before the embargo is lifted to { -distros-openwall-email-anchor }, so that Linux distributions can update their packages.</p>
+        <p>When a vulnerability affects software distributions, we will announce vulnerabilities 72 hours before the embargo is lifted to { -distros-openwall-email-anchor }, so that distributions can update their packages when the embargo lifts.</p>
 
 security-pgp-key-heading = Plaintext PGP key

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -69,8 +69,8 @@ security-disclosure-description--2025-07 =
           <li>The security report is received and is assigned a primary handler. This person will coordinate the fix and release process.</li>
           <li>The problem is confirmed, the affected versions are identified, and relevant domain experts from relevant Rust teams are involved.</li>
           <li>Code is audited to find any potential similar problems.</li>
-          <li>Fixes are prepared for all supported release branches. These fixes are not committed to the public repository but rather held in private repositories pending the announcement. These fixes are reviewed privately using the same review process of public changes.</li>
-          <li>On the embargo date, a copy of the announcement is sent to the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> and posted on the Rust blog. The changes are pushed to the public repository and the release process is started.</li>
+          <li>Fixes are prepared for all supported release branches, and a CVE number is reserved. These fixes are not committed to the public repository but rather held in private repositories pending the announcement. These fixes are reviewed privately using the same review process of public changes.</li>
+          <li>On the embargo date, a copy of the announcement is sent to the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> and posted on the Rust blog. The changes are pushed to the public repository and the release process is started. Within an hour, full details are published in the CVE database</li>
         </ol>
         <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
 

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -67,9 +67,9 @@ security-disclosure-description--2025-07 =
         <p>The Rust project has a 5 step disclosure process.</p>
         <ol>
           <li>The security report is received and is assigned a primary handler. This person will coordinate the fix and release process.</li>
-          <li>The problem is confirmed and a list of all affected versions is determined.</li>
+          <li>The problem is confirmed, the affected versions are identified, and relevant domain experts from relevant Rust teams are involved.</li>
           <li>Code is audited to find any potential similar problems.</li>
-          <li>Fixes are prepared for all supported release branches. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
+          <li>Fixes are prepared for all supported release branches. These fixes are not committed to the public repository but rather held in private repositories pending the announcement. These fixes are reviewed privately using the same review process of public changes.</li>
           <li>On the embargo date, the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and the release process is started. Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
         </ol>
         <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -5,9 +5,9 @@ policies-security-page-title = Security policy
 
 security-reporting-heading = Reporting
 security-reporting-link = email { ENGLISH("security@rust-lang.org") }
-security-reporting-description--2022-01 =
+security-reporting-description--2025-07 =
         <p>Safety is one of the core principles of Rust, and to that end, we would like to ensure that Rust has a secure implementation. Thank you for taking the time to responsibly disclose any issues you find.</p>
-        <p>All security bugs in the Rust distribution should be reported by email to { -security-at-rust-lang-org-anchor }. This list is delivered to a small security team. Your email will be acknowledged within 24 hours, and you’ll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report. If you would like, you can encrypt your report using <a href="{ -rust-security-team-key-href }">our public key</a>. This key is also <a href="{ -rust-pgp-key-mit-keyserver-href }">On MIT’s keyserver</a> and <a href="#security-pgp-key">reproduced below</a>.</p>
+        <p>All security bugs in the Rust distribution should be reported by email to { -security-at-rust-lang-org-anchor }. This list is delivered to a small security team. Your email will be acknowledged within 24 hours, and you’ll receive a more detailed response to your email within 48 hours indicating the next steps in handling your report.</p>
         <p>This email address receives a large amount of spam, so be sure to use a descriptive subject line to avoid having your report be missed. After the initial reply to your report, the security team will endeavor to keep you informed of the progress being made towards a fix and full announcement. As recommended by <a href="{ -wikipedia-rfpolicy-href }">RFPolicy</a>, these updates will be sent at least every five days. In reality, this is more likely to be every 24-48 hours.</p>
         <p>If you have not received a reply to your email within 48 hours, or have not heard from the security team for the past five days, there are a few steps you can take (in order):</p>
         <ul>
@@ -76,8 +76,6 @@ security-disclosure-description--2025-07 =
 
 security-receiving-heading = Receiving security updates
 security-receiving-description--2025-07 =
-        <p>The best way to receive all the security announcements is to subscribe to the <a href="{ -rust-security-announcements-mailing-list-href }">Rust security announcements mailing list</a> (alternatively by sending an email to { -rustlang-security-announcements-subscribe-anchor }). The mailing list is very low traffic, and it receives the public notifications the moment the embargo is lifted.</p>
+        <p>The best way to receive all the security announcements is to subscribe to the <a href="{ -rust-security-announcements-mailing-list-href }">Rust security announcements mailing list</a> (alternatively by sending an email to { -rustlang-security-announcements-subscribe-anchor }). The mailing list is very low traffic, and it receives the public notifications the moment the embargo is lifted. Announcements on the mailing list are signed with the <a href="{{ -rust-security-team-key-href }}">Rust's security key</a>.</p>
         <p>The Rust project only provides support and security updates for the most recent stable release and the latest releases in our <a href="{ -rust-security-supported-channels-href }">beta and nightly channels</a>. As Rust releases must be built in the public, we will begin the release process as soon as the embargo lifts, and a release blog post will be published once updated binaries are available for download.</p>
         <p>When a vulnerability affects software distributions, we will announce vulnerabilities 72 hours before the embargo is lifted to { -distros-openwall-email-anchor }, so that distributions can update their packages when the embargo lifts.</p>
-
-security-pgp-key-heading = Plaintext PGP key

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -63,20 +63,21 @@ security-scope--2025-04 =
         <p>If you have doubts on whether something falls within our scope, <a href="mailto:security@rust-lang.org">please reach out</a> and we will provide guidance.</p>
 
 security-disclosure-heading = Disclosure policy
-security-disclosure-description =
+security-disclosure-description--2025-07 =
         <p>The Rust project has a 5 step disclosure process.</p>
         <ol>
           <li>The security report is received and is assigned a primary handler. This person will coordinate the fix and release process.</li>
           <li>The problem is confirmed and a list of all affected versions is determined.</li>
           <li>Code is audited to find any potential similar problems.</li>
-          <li>Fixes are prepared for all releases which are still under maintenance. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
-          <li>On the embargo date, the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and new builds are deployed to rust-lang.org.  Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
+          <li>Fixes are prepared for all supported release branches. These fixes are not committed to the public repository but rather held locally pending the announcement.</li>
+          <li>On the embargo date, the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and the release process is started. Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
         </ol>
         <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
 
 security-receiving-heading = Receiving security updates
-security-receiving-description =
+security-receiving-description--2025-07 =
         <p>The best way to receive all the security announcements is to subscribe to the <a href="{ -rust-security-announcements-mailing-list-href }">Rust security announcements mailing list</a> (alternatively by sending an email to { -rustlang-security-announcements-subscribe-anchor }). The mailing list is very low traffic, and it receives the public notifications the moment the embargo is lifted.</p>
+        <p>The Rust project only provides support and security updates for the most recent stable release and the latest releases in our <a href="{ -rust-security-supported-channels-href }">beta and nightly channels</a>. As Rust releases must be built in the public, we will begin the release process as soon as the embargo lifts, and a release blog post will be published once updated binaries are available for download.</p>
         <p>We will announce vulnerabilities 72 hours before the embargo is lifted to { -distros-openwall-email-anchor }, so that Linux distributions can update their packages.</p>
 
 security-pgp-key-heading = Plaintext PGP key

--- a/locales/en-US/security.ftl
+++ b/locales/en-US/security.ftl
@@ -70,7 +70,7 @@ security-disclosure-description--2025-07 =
           <li>The problem is confirmed, the affected versions are identified, and relevant domain experts from relevant Rust teams are involved.</li>
           <li>Code is audited to find any potential similar problems.</li>
           <li>Fixes are prepared for all supported release branches. These fixes are not committed to the public repository but rather held in private repositories pending the announcement. These fixes are reviewed privately using the same review process of public changes.</li>
-          <li>On the embargo date, the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> is sent a copy of the announcement. The changes are pushed to the public repository and the release process is started. Within 6 hours of the mailing list being notified, a copy of the advisory will be published on the Rust blog.</li>
+          <li>On the embargo date, a copy of the announcement is sent to the <a href="{ -rustlang-security-announcements-google-groups-forum-href }"> Rust security mailing list</a> and posted on the Rust blog. The changes are pushed to the public repository and the release process is started.</li>
         </ol>
         <p>This process can take some time, especially when coordination is required with maintainers of other projects. Every effort will be made to handle the bug in as timely a manner as possible, however it’s important that we follow the release process above to ensure that the disclosure is handled in a consistent manner.</p>
 

--- a/templates/policies/security.html.hbs
+++ b/templates/policies/security.html.hbs
@@ -25,7 +25,7 @@
       <div class="highlight"></div>
     </header>
     <p><a class="button button-secondary" href="mailto:security@rust-lang.org">{{fluent "security-reporting-link"}}</a></p>
-    {{fluent "security-reporting-description--2022-01"}}
+    {{fluent "security-reporting-description--2025-07"}}
     <p><a class="button button-secondary" href="mailto:security@rust-lang.org">{{fluent "security-reporting-link"}}</a></p>
   </div>
 </section>
@@ -57,91 +57,6 @@
       <div class="highlight"></div>
     </header>
     {{fluent "security-receiving-description--2025-07"}}
-  </div>
-</section>
-
-<section id="security-pgp-key" class="red">
-  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <header>
-      <h2>{{fluent "security-pgp-key-heading"}}</h2>
-      <div class="highlight"></div>
-    </header>
-    <pre><code>-----BEGIN PGP PUBLIC KEY BLOCK-----
-Version: GnuPG v1
-
-mQINBFVT5MsBEADKZtOjBhitDx1aYt2ljz1+MUhnmsnJy8duMe6T/b30rEuXTLH8
-6INTYoU08qw7m+7YmxAlpdNHZW3VL0csYiaOOKsHJ4KuUB0Phjnm1ePjE/Q3g7el
-H6TNXQWsjy3V9E0cI3r5En0SDnBmwZoYuE0/mf9Gc313DvSjipFpyXS0R+D3RiPz
-t4LcDWDS7XPRgp9LJ4mWDeYI4GitKfKxvSYrQpLjdNUSmehJ62rZY+i/Mox+zHEQ
-QCrjfKttkoVs6fvLSKJTUGsy4eSViSLLYR8ty2SC/o9u/EG17dfX/EeEbo9yu2iK
-lLo+W58RvmdAtK6Y9MSX2rzlB2akbbEp6LYDaBKDlWBOAT/qQdMmHmUOWjV/8PSi
-Y03Cmx0v/6N3bv617iRe5MXIih7KZH4uYzf7eoCDA7LoopkI84xQIkciKblIGzpe
-0hCOdUYnf+uC3EWmP/e4TA9M7OjiSezOjsedI41ryRKMgpmdx1kHBqsZZVKIGHaf
-mdL/MxlvZrzfgbV8/6e5VhumPBWqih1HwvEzmNSdvFZV8/BgXqhlDidzGNa3eKIT
-1iTYX/YVikBLP0HsvSNwrtOZIjmeiMMivf4daH9bcySthp6PyAcjFa7pcS+GmPrz
-RJh3wAX1fpiaP/HQaIQJzvYHwpCwjFVt5/WpPLBB1b6miUebFpz5oZfApwARAQAB
-tDZSdXN0IExhbmd1YWdlIChTZWN1cml0eSBUZWFtKSA8c2VjdXJpdHlAcnVzdC1s
-YW5nLm9yZz6JAjgEEwECACIFAlVT5MsCGwMGCwkIBwMCBhUIAgkKCwQWAgMBAh4B
-AheAAAoJEO+5hgrnUg2sEsIQAMff5YzBLQb+6Z2euj/+7tcKdAflvTGToHiRZ4xK
-7mhZs5ytQ0/qBKLJ51lM3qo33MUXk8Yx6uQxJjLV/3Fjr/In7jrGXLLtEsXF1+RZ
-8+o5XQahhSjJ5W5E9O7E9tbHZe9VB0Tfv30S6CRZD9F/tUQhknwmgc+0twc3zKq0
-8X8jtNCAgSt0JZ+jOPlXUwMkoK9bsRVTVqj227cHxG6l1ZZmxm29JVOWPtqN3vXZ
-hAwwaHpn09fvcavnBWm9fX4jfdodnOmtnS0a5YQXrjF8TP+MV9fgdpg+lVjJB7NE
-azR3Tj0XYLze+KpL3aSNkpMz0RuXd4OqR3Z3pOOMiov2cEQooH0NGpYSTWzXzZCI
-C5CcgFqxYjv/KjN3FwxCFfdkn22V14jw+IkmOV8n7i2HVpw/D+/0+X4tnp9zaVW2
-+1S4xeX13UMEgr29kYoKngzKmolruOftiBdLpM9HWNu/14hggOmSZ2+qNANw27JJ
-lXve/dpZdMpLPMgk+bwa2aXAvygUSlELFVcZf9fFLFoN3bInixzy28zeywwkv4Tn
-Ar5BLLbeS5rfzrAGR8hj55uVdiLTEL+ayG/mXOfSkqigvSzTKxgixPAxhHtOJtmF
-vDVL/UXhprRp6olDRLXA8a+mkIMWt4bpwflxQUNrxIee9T8tZCIShU5ubhvXXKtf
-bjT7iQIcBBABAgAGBQJVU+27AAoJEBZFemNoz/JvQ4cP/0X9xnapa8+Bx0BqSdVH
-CLqJinywVcTsjsY+TTeT+T+rFoERBI/ljFd7OhZg8bPOMln/KXLlh+7nLFoKyxUm
-XqAyY0tXMDGaEWT+KcnVLs/5hMv/KidswFAWq9TiJJFu9DJUt+OwyVT+/troC3VL
-28tAtMEmMIH+7EjH9qRlTf0ZtrNEmgIL8Fa2QEeaIZI8u3jDnrZGsBSxPB+fOW17
-745d7APWCmsv6ZYEv+h0JqVAb4QGIQVo2lQvqpEh0jLg8yqiyp89bdPfmo3ZOm8x
-Ns8JDWQrtbtoEAlVrrKu9oL9T+zbyrRLniYmCgtRxFAcYx5idxYjuWWTP/kwDwq2
-y0F6frZjGMwOsTCHqeZIVuCWHWkLzEduAxOdh7H8hJSpl2E2JnvBhEtAmlyEhrJc
-7Kyf8ZQ4VJe3Q8mcoAbSZS0Q36UnQAH9ww0rYXqCZA+uaPFdjOwW1Puzq6wM7AfT
-Z5EHToho9LPvmyoRvY26sTqxsS6E/HG4DTkD6JqScHCSwPk0GkPCVjOnnnjBVMFS
-n7/s7x6Vhmv/lIkMQ0qW12hfJFuxSWcqBo0Vro6R1IqeoWUewnvY0OEmxiPC+j1X
-2aIHXqTV1jZDVWQ9sBx+v/L/giPbiBFdTofOFXLkaT4A+ZwIexyKuaMVSOhrq1x+
-3Uf5sZAW5Yn6zI0wgIcsw2OPiQIcBBABAgAGBQJVU+5mAAoJEIWrlub6G+X++kQQ
-AMHAP5N88Po0tebcfZTpDCm2/fjFFh29h9mdltbZ0yjOQHNnhfkLDzyQnoQMge5g
-W4Cf3+U6yPx97wUXUVh0lxFlXVZpLExOEYOjPHah6DvvzWjvn2CimzQ5wurI6Bhw
-PPEO6ucDhjeEdr784/4yR2DEjKW+NTCZWaJT67JvKhQFs3N74AeeuWj6caFgxKLk
-qK8LRt7rjlXem+vQgGSHEZQGG4+Srd2Kr1EyhP5SHG3RDaLb3vcUBRhTBaoTT3xj
-aIdz/vt6Ve1W5Mcc2UPY0PO/pRnVQUGNt7MSbt50XJXbDt+zFJ2xKaHnJihDg81z
-/GxKrjHS5t0RAdW5SRfB9izboWIPJo4I/vmuxXINeK+KjmPEazxdkULXzfVOOAxg
-NJjxz46sZw7lZkHcz94g8TthndQHTo6v8AS9JtkIfe54cfg9PFUmlURTatabw67x
-Wqs6+PLmjInvGmAByFw2IgV0Y760xJ+JuPY1W7II/PIa6uSb8VIrkB8tNPFqASAT
-k3xIUEvRqMT62gnRB+iIb7aZUEKPmYZ9Q7OuB1yEHd+juxy5xoZ9jKx3ru6ia+jh
-bneg+Obpl6d9t0mpCblWXuCcnb2hwAr45xWNz8/rexDZQeNFfeNB3sq0u4jdwzjU
-CKFivH2P07FEJajgbIy6t4T0+AzwpEVMU5BN6bhNI3M6uQINBFVT5MsBEAC5xvIx
-8Oa3US6RGaM/SZ9nF3xCdVQhQWK3VL+MsClDInULgNpdzZspwc9JtClUo/fCNgM9
-zXIzFOwlyTPAhwDbQYLSdfkwhT6vsvfPx+T0uC96OrVhNsJsUmLuYNLOlQa3ybpi
-XTmNcnLaEvMEwHPVNYAw88HjHp23jdTOLOHZFg0p+q2dByfbpgGNy8xHDG28AZ+i
-BToLQCT2IZTZlOpnLr3gLI5C54ZNX7dbVu7xnC0mibOCqUi7nRH/a2oJRV/6DvtY
-uqHdDJumXW6/h0JvfNVydsy2N+WK9pirmsgIUq52sAey7MSbzKqbdw+zyZSA/Iyv
-XzMXoTPYxTCCE5MSwHwW5Mar9KelvTRjpBj5DqkBxVVPyehH3FXOGfvomgbB+F2I
-ZK1h9wCZDWnk0i8i/7pdQXPw22i/k7BOrBjQ5je60ezZUKvDAq4z5/xjXaD/ZtxO
-HRTTgPboEluuUl0KEtEVm/8zDXas89GlmTYaXv3baXFCGsV+TIkYRtsyWr6Mtirq
-/ZkU0RE+newBCBSF7tDrXoVrcflRIo8XG5y2UqKkiLqssBVx9J9s8LBwA/6+xkgA
-yxS7+KfkOVITW3QuiDCH/ydxnpU/9kzxv9Y68jgOnX3a8wmBTqU3PRwbz9WCQ8qi
-qNCKPBDwf42SVbdSBCljGTiVI9mcaMYtRHDQAQARAQABiQIfBBgBAgAJBQJVU+TL
-AhsMAAoJEO+5hgrnUg2sstoP+wbfIr5vR8CiIqoU8qxU/Co5m2jyyUMiU9iYSaSO
-9Itu9cCpP6dFbx1p7u41zutDaeO/wil3fpH2I7T3qAilvqey9UqhVTkSlotFh07T
-yXw/929Pd3tTekIbeJON+4XdHeF6gfsT/SL9hCDwsMk9Jzyx01n1Oq2fq2fGxqHg
-G6er9HssF7VBs7N0jOgMG2ou8DVEIjbhKJqyvLUsKk6Zolfy+HGn6OWSdgjenaFT
-KcDCOMhQs8ZH95I50stp26njFfcoh82qJNYZbTPWe05ZsGNFdBM+pANxHsiS1Mbd
-Fo21HM8tp8Vs2toimaa1dIyFl5+2vvCcGECcCQ3eT1mb8Ac5rR0TsDMiVGPmhabg
-9mKehJIR4OsqruyCF5yk/zwa7gFb7t83xTDxarlXyN1ltroF/sGod0IDk0UlQPsp
-d0BSiGNx9eNOi2iavxg94cqEK+dF1dUZsuSzTW1UDA4hA5aiX56YOiiSoC9mBqgN
-ZjaHjR6KwulHdIDUg8icmmJdtYDtFDz0DKUBuZshadb9gv3TUe3FbO3W1YhlDA+i
-t1yhhXbJR4oYYwpMuxtpeE+lGkFiJbBeIKG2WocWUn385KPUo2r2trvZUnvaxWy1
-/WMRGsGeczGIkGawwYuSXtkzmYpqs7VdQaPq4JZmAPcU9ogwMSlNYVsuV3FUtVsv
-u05l
-=SPB7
------END PGP PUBLIC KEY BLOCK-----
-</code></pre>
   </div>
 </section>
 

--- a/templates/policies/security.html.hbs
+++ b/templates/policies/security.html.hbs
@@ -46,7 +46,7 @@
       <h2>{{fluent "security-disclosure-heading"}}</h2>
       <div class="highlight"></div>
     </header>
-    {{fluent "security-disclosure-description"}}
+    {{fluent "security-disclosure-description--2025-07"}}
   </div>
 </section>
 
@@ -56,7 +56,7 @@
       <h2>{{fluent "security-receiving-heading"}}</h2>
       <div class="highlight"></div>
     </header>
-    {{fluent "security-receiving-description"}}
+    {{fluent "security-receiving-description--2025-07"}}
   </div>
 </section>
 


### PR DESCRIPTION
The PR makes multiple changes to our security policy:

* Clarifies which branches we support (latest stable, beta, nightly).
* Clarifies we only email distros@openwall when the vulnerability is relevant to them (this is our standard practice anyway).
* Mentions that we loop relevant members of the Rust team in vulnerabilities, who review the fixes.
* Removes the 6 hours delay notice for the blog post, as in the last few years we always published it at the same time as the announcement in the mailing list.
* Adds information on when we publish CVE records, as requested by MITRE.
* Removes the prompt to encrypt emails with gpg.

cc @rust-lang/security 