### PR TITLE
Add link to Discord server

### DIFF
--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -9,6 +9,7 @@ why-rust = Why Rust?
 production-use = Production use
 learn-more = Learn More
 zulip = Zulip
+discord = Discord
 mastodon = Mastodon
 bluesky = Bluesky
 

--- a/locales/en-US/community.ftl
+++ b/locales/en-US/community.ftl
@@ -28,7 +28,7 @@ community-irlo = The Rust Internals Forum is a place for discussion about the
             as well as the design of the language and the standard library.
 
 community-chat-header = Chat platforms
-community-chat = Development of Rust, and general chatter happens on several chat platforms. Check out general channels and more on the Rust Zulip server, or check out the teams page to find where specific teams meet.
+community-chat = Rust users can chat or get help on the unofficial Discord server. Development of Rust itself happens on the Rust Zulip server, or check out the teams page to find where specific teams meet.
 
 community-teams-learn = Learn more about teams
 

--- a/templates/community/index.html.hbs
+++ b/templates/community/index.html.hbs
@@ -52,6 +52,9 @@
         {{!-- TODO: remove padding and margin once global declarations are gone --}}
         <ul class="list pa0 ma0 dn-l">
           <li class="mb3">
+            <a href="https://discord.com/invite/rust-lang-community" class="button button-secondary">{{fluent "discord"}}</a>
+          </li>
+          <li class="mb3">
             <a href="https://rust-lang.zulipchat.com" class="button button-secondary">{{fluent "zulip"}}</a>
           </li>
           <li class="mb3">


### PR DESCRIPTION
For Rust users (who are likely the main audience for this page), pointing them to the Zulip server isn't helpful because it's only for development of Rust itself. Therefore I added a link to the Discord "server" (note, Discord uses the term "server" in a stupid way; it's like a Slack workspace).

This is not an official Rust project but it's likely what most users are looking for so adding it here is a pragmatic and useful choice. I described it as "unofficial".

This link is especially helpful because there are two Rust Discover servers, but one of them is defunct (in a way that is annoying to discover). Unfortunately it still tops Google results sometimes depending on what you search for.

Finally, I think the layout could probably be cleaned up by having it split in two:

* For users: [User Forum], [Discord]
* For Rust language developers: [Internals Forum] [Zulip] [Teams]

But that's a bigger change and I haven't done it here.