### PR TITLE
Fix endless redirect in index page

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -17,7 +17,6 @@ pub static PAGE_REDIRECTS: &[(&str, &str)] = &[
     ("documentation.html", "learn"),
     ("downloads.html", "tools/install"),
     ("friends.html", "production"),
-    ("index.html", ""),
     ("install.html", "tools/install"),
     ("legal.html", "policies"),
     ("security.html", "policies/security"),

--- a/src/render.rs
+++ b/src/render.rs
@@ -50,6 +50,14 @@ impl<'a, T: Serialize> PageCtx<'a, T> {
 
         let out_path = self.output_dir.join(path);
         ensure_directory(&out_path)?;
+
+        if out_path.is_file() {
+            return Err(anyhow::anyhow!(
+                "Trying to render file {}, which already exists",
+                out_path.display()
+            ));
+        }
+
         let mut output_file = BufWriter::new(
             File::create(&out_path)
                 .with_context(|| anyhow::anyhow!("Cannot create file at {}", path.display()))?,


### PR DESCRIPTION
Fixes endless redirects and adds a check to make sure that it a similar situation won't happen again.