### PR TITLE
Remove Heroku/Rocket config and update docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,106 +27,106 @@ we figure out a better process for it.
 
 Before filing a PR to the site, please file an issue. This way we can ensure
 that the work you are doing meets the requirements of the site and will be very
-likely merged.  If you file a PR before an issue, you will likely be asked to
+likely merged. If you file a PR before an issue, you will likely be asked to
 file an issue, or your PR may be closed outright.
 
 ## Manual testing checklist
 
 Sometimes changes are made which could potentially affect any page, e.g. updating the templating library.
 In that case it's necessary to manually check (almost) every page for obvious regressions before deploying the update.
-To facilitate that, here's a list of links to the staging deployment.
+To facilitate that, here's a list of links.
 Note that like all documentation, this list may become outdated over time.
 So stay vigilant and update it if you notice something missing.
 
 <!-- index -->
-- https://www-staging.rust-lang.org/
+- https://www.rust-lang.org/
 <!-- category_en -->
-- https://www-staging.rust-lang.org/community
-- https://www-staging.rust-lang.org/learn
-- https://www-staging.rust-lang.org/policies
-- https://www-staging.rust-lang.org/production
-- https://www-staging.rust-lang.org/tools
-- https://www-staging.rust-lang.org/what
+- https://www.rust-lang.org/community
+- https://www.rust-lang.org/learn
+- https://www.rust-lang.org/policies
+- https://www.rust-lang.org/production
+- https://www.rust-lang.org/tools
+- https://www.rust-lang.org/what
 <!-- governance -->
-- https://www-staging.rust-lang.org/governance
+- https://www.rust-lang.org/governance
 <!-- team -->
-- https://www-staging.rust-lang.org/governance/teams/leadership-council
-- https://www-staging.rust-lang.org/governance/wgs/wg-async
+- https://www.rust-lang.org/governance/teams/leadership-council
+- https://www.rust-lang.org/governance/wgs/wg-async
 <!-- subject -->
-- https://www-staging.rust-lang.org/learn/get-started
-- https://www-staging.rust-lang.org/policies/code-of-conduct
-- https://www-staging.rust-lang.org/policies/licenses
-- https://www-staging.rust-lang.org/policies/security
-- https://www-staging.rust-lang.org/tools/install
-- https://www-staging.rust-lang.org/what/cli
-- https://www-staging.rust-lang.org/what/embedded
-- https://www-staging.rust-lang.org/what/networking
-- https://www-staging.rust-lang.org/what/wasm
+- https://www.rust-lang.org/learn/get-started
+- https://www.rust-lang.org/policies/code-of-conduct
+- https://www.rust-lang.org/policies/licenses
+- https://www.rust-lang.org/policies/security
+- https://www.rust-lang.org/tools/install
+- https://www.rust-lang.org/what/cli
+- https://www.rust-lang.org/what/embedded
+- https://www.rust-lang.org/what/networking
+- https://www.rust-lang.org/what/wasm
 <!-- files -->
-- https://www-staging.rust-lang.org/static/images/rust-logo-blk.png
+- https://www.rust-lang.org/static/images/rust-logo-blk.png
 <!-- robots_txt -->
-- https://www-staging.rust-lang.org/robots.txt
+- https://www.rust-lang.org/robots.txt
 <!-- logos -->
-- https://www-staging.rust-lang.org/static/logos/cargo.png
+- https://www.rust-lang.org/static/logos/cargo.png
 <!-- index_locale -->
-- https://www-staging.rust-lang.org/es
+- https://www.rust-lang.org/es
 <!-- category_locale -->
-- https://www-staging.rust-lang.org/es/community
-- https://www-staging.rust-lang.org/es/learn
-- https://www-staging.rust-lang.org/es/policies
-- https://www-staging.rust-lang.org/es/production
-- https://www-staging.rust-lang.org/es/tools
-- https://www-staging.rust-lang.org/es/what
+- https://www.rust-lang.org/es/community
+- https://www.rust-lang.org/es/learn
+- https://www.rust-lang.org/es/policies
+- https://www.rust-lang.org/es/production
+- https://www.rust-lang.org/es/tools
+- https://www.rust-lang.org/es/what
 <!-- governance_locale -->
-- https://www-staging.rust-lang.org/es/governance
+- https://www.rust-lang.org/es/governance
 <!-- team_locale -->
-- https://www-staging.rust-lang.org/es/governance/teams/leadership-council
-- https://www-staging.rust-lang.org/es/governance/wgs/wg-async
+- https://www.rust-lang.org/es/governance/teams/leadership-council
+- https://www.rust-lang.org/es/governance/wgs/wg-async
 <!-- subject_locale -->
-- https://www-staging.rust-lang.org/es/learn/get-started
-- https://www-staging.rust-lang.org/es/policies/code-of-conduct
-- https://www-staging.rust-lang.org/es/policies/licenses
-- https://www-staging.rust-lang.org/es/policies/security
-- https://www-staging.rust-lang.org/es/tools/install
-- https://www-staging.rust-lang.org/es/what/cli
-- https://www-staging.rust-lang.org/es/what/embedded
-- https://www-staging.rust-lang.org/es/what/networking
-- https://www-staging.rust-lang.org/es/what/wasm
+- https://www.rust-lang.org/es/learn/get-started
+- https://www.rust-lang.org/es/policies/code-of-conduct
+- https://www.rust-lang.org/es/policies/licenses
+- https://www.rust-lang.org/es/policies/security
+- https://www.rust-lang.org/es/tools/install
+- https://www.rust-lang.org/es/what/cli
+- https://www.rust-lang.org/es/what/embedded
+- https://www.rust-lang.org/es/what/networking
+- https://www.rust-lang.org/es/what/wasm
 <!-- redirect_bare_en_us -->
-- https://www-staging.rust-lang.org/en-US
+- https://www.rust-lang.org/en-US
 <!-- not_found catcher, see redirect::maybe_redirect -->
 <!-- static file redirects -->
-- https://www-staging.rust-lang.org/pdfs/Rust-npm-Whitepaper.pdf
-- https://www-staging.rust-lang.org/pdfs/Rust-Tilde-Whitepaper.pdf
+- https://www.rust-lang.org/pdfs/Rust-npm-Whitepaper.pdf
+- https://www.rust-lang.org/pdfs/Rust-Tilde-Whitepaper.pdf
 <!-- external redirects -->
-- https://www-staging.rust-lang.org/other-installers.html
-- https://www-staging.rust-lang.org/policies/privacy
-- https://www-staging.rust-lang.org/policies/media-guide
-- https://www-staging.rust-lang.org/sponsors
+- https://www.rust-lang.org/other-installers.html
+- https://www.rust-lang.org/policies/privacy
+- https://www.rust-lang.org/policies/media-guide
+- https://www.rust-lang.org/sponsors
 <!-- page redirects -->
-- https://www-staging.rust-lang.org/community.html
-- https://www-staging.rust-lang.org/conduct.html
-- https://www-staging.rust-lang.org/contribute-bugs.html
-- https://www-staging.rust-lang.org/contribute-community.html
-- https://www-staging.rust-lang.org/contribute-compiler.html
-- https://www-staging.rust-lang.org/contribute-docs.html
-- https://www-staging.rust-lang.org/contribute-libs.html
-- https://www-staging.rust-lang.org/contribute-tools.html
-- https://www-staging.rust-lang.org/contribute.html
-- https://www-staging.rust-lang.org/documentation.html
-- https://www-staging.rust-lang.org/downloads.html
-- https://www-staging.rust-lang.org/friends.html
-- https://www-staging.rust-lang.org/index.html
-- https://www-staging.rust-lang.org/install.html
-- https://www-staging.rust-lang.org/legal.html
-- https://www-staging.rust-lang.org/security.html
-- https://www-staging.rust-lang.org/team.html
-- https://www-staging.rust-lang.org/user-groups.html
-- https://www-staging.rust-lang.org/governance/teams/release
-- https://www-staging.rust-lang.org/governance/teams/crates-io
-- https://www-staging.rust-lang.org/governance/teams
-- https://www-staging.rust-lang.org/governance/wgs
+- https://www.rust-lang.org/community.html
+- https://www.rust-lang.org/conduct.html
+- https://www.rust-lang.org/contribute-bugs.html
+- https://www.rust-lang.org/contribute-community.html
+- https://www.rust-lang.org/contribute-compiler.html
+- https://www.rust-lang.org/contribute-docs.html
+- https://www.rust-lang.org/contribute-libs.html
+- https://www.rust-lang.org/contribute-tools.html
+- https://www.rust-lang.org/contribute.html
+- https://www.rust-lang.org/documentation.html
+- https://www.rust-lang.org/downloads.html
+- https://www.rust-lang.org/friends.html
+- https://www.rust-lang.org/index.html
+- https://www.rust-lang.org/install.html
+- https://www.rust-lang.org/legal.html
+- https://www.rust-lang.org/security.html
+- https://www.rust-lang.org/team.html
+- https://www.rust-lang.org/user-groups.html
+- https://www.rust-lang.org/governance/teams/release
+- https://www.rust-lang.org/governance/teams/crates-io
+- https://www.rust-lang.org/governance/teams
+- https://www.rust-lang.org/governance/wgs
 <!-- a couple localized redirects -->
-- https://www-staging.rust-lang.org/es-ES
-- https://www-staging.rust-lang.org/es-ES/contribute-compiler.html
-- https://www-staging.rust-lang.org/es-ES/governance/teams
+- https://www.rust-lang.org/es-ES
+- https://www.rust-lang.org/es-ES/contribute-compiler.html
+- https://www.rust-lang.org/es-ES/governance/teams

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: ROCKET_PORT=$PORT RUST_BACKTRACE=1 ROCKET_PROFILE=release ./target/release/www-rust-lang-org

--- a/README.md
+++ b/README.md
@@ -3,8 +3,6 @@
 
 ![CI](https://github.com/rust-lang/www.rust-lang.org/workflows/CI/badge.svg)
 
-* [**View Staging (master)**](http://www-staging.rust-lang.org)
-
 > [!NOTE]
 > There are currently no reviewers for the translations available.
 > If you have a suggestion to improve the translations, you may still open an issue for future reference.
@@ -12,21 +10,20 @@
 
 ## Development
 
-### Running the app locally
+### Building the web locally
 
-1. Install `cargo watch` by running `cargo install cargo-watch` in your terminal.
+Execute `cargo run`. The web will be compiled into the `build` directory, from which you can serve it using a web server of your choice. For example, with Python it could be:
 
-2. To build the app and run the server, run `cargo watch -x run` in your terminal.
+```console
+$ cargo run
+$ python3 -m http.server -d build
+```
 
-3. Navigate to http://localhost:7878 in your browser. If you make any updates to
-   the styles, or any other project files, `cargo watch` will automatically
-   restart the server for you, all you have to do is refresh your browser to see
-   your changes.
+You can use `cargo watch -x run` to automatically rebuild the web once you make changes to it.
 
 ### Where to edit
 
-- If you would like to edit styles, you should edit [`src/styles/app.scss`](src/styles/app.scss). 
-- If you would like to update group data, you should edit the `yml` files in [`src/data/`](src/data/).
+- If you would like to edit styles, you should edit [`src/styles/app.scss`](src/styles/app.scss).
 - If you would like to edit page content, you should edit the `hbs` files in [`templates`](templates).
 
 ### Contributing
@@ -35,7 +32,6 @@ Please read our [`CONTRIBUTING.md`](CONTRIBUTING.md) before submitting a PR!
 
 ### Deployment
 
-www.rust-lang.org is currently hosted on Heroku. The `master` branch is
-automatically deployed to [www-staging.rust-lang.org](https://www-staging.rust-lang.org)
-and the `deploy` branch is a snapshot of `master` that is manually updated and
-automatically deployed to www.rust-lang.org .
+www.rust-lang.org is currently hosted on GitHub Pages. The `master` branch is
+automatically deployed to [www.rust-lang.org](https://www.rust-lang.org) after
+each push.

--- a/Rocket.toml
+++ b/Rocket.toml
@@ -1,7 +1,0 @@
-[debug]
-address = "127.0.0.1"
-port = 7878
-
-[release]
-# MUST be 0.0.0.0 for Heroku to work
-address = "0.0.0.0"


### PR DESCRIPTION
Should only be merged once we actually switch the production URL to GitHub Pages.