### PR TITLE
Disable Jekyll on Github Pages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,9 @@ jobs:
         env:
           BASE_URL: "/"
 
+      - name: Disable Jekyll
+        run: touch build/.nojekyll
+
       - name: Configure GitHub Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
~~Trying to see if this resolves the `/` redirect issue that we're having when deploying the website through CloudFront.~~ We are not using Jekyll, so we should disable it on GitHub Pages.