### PR TITLE
Add Rustroid to editors list.

### DIFF
--- a/locales/de/tools.ftl
+++ b/locales/de/tools.ftl
@@ -34,3 +34,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/en-US/tools.ftl
+++ b/locales/en-US/tools.ftl
@@ -172,3 +172,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/es/tools.ftl
+++ b/locales/es/tools.ftl
@@ -122,3 +122,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/fa/tools.ftl
+++ b/locales/fa/tools.ftl
@@ -26,3 +26,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/fr/tools.ftl
+++ b/locales/fr/tools.ftl
@@ -109,3 +109,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/it/tools.ftl
+++ b/locales/it/tools.ftl
@@ -97,3 +97,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -98,3 +98,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/ko/tools.ftl
+++ b/locales/ko/tools.ftl
@@ -61,3 +61,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/pl/tools.ftl
+++ b/locales/pl/tools.ftl
@@ -45,3 +45,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/pt-BR/tools.ftl
+++ b/locales/pt-BR/tools.ftl
@@ -147,3 +147,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/ru/tools.ftl
+++ b/locales/ru/tools.ftl
@@ -120,3 +120,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -131,3 +131,4 @@ tools-editor-vim = { ENGLISH("Vim/Neovim") }
 tools-editor-emacs = { ENGLISH("Emacs") }
 tools-editor-visual-studio = { ENGLISH("Visual Studio") }
 tools-editor-zed = { ENGLISH("Zed") }
+tools-editor-rustroid = { ENGLISH("Rustroid") }

--- a/locales/zh-CN/tools.ftl
+++ b/locales/zh-CN/tools.ftl
@@ -134,3 +134,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/locales/zh-TW/tools.ftl
+++ b/locales/zh-TW/tools.ftl
@@ -108,3 +108,4 @@ tools-editor-vim = Vim/Neovim
 tools-editor-emacs = Emacs
 tools-editor-visual-studio = Visual Studio
 tools-editor-zed = Zed
+tools-editor-rustroid = Rustroid

--- a/templates/components/tools/editors.html.hbs
+++ b/templates/components/tools/editors.html.hbs
@@ -31,4 +31,8 @@
     <a href="https://zed.dev/docs/languages/rust"
        class="button button-secondary">{{fluent "tools-editor-zed"}}</a>
   </div>
+  <div class="w-25-l w-50-m w-100 pa3">
+    <a href="https://rustroid.is-a.dev"
+        class="button button-secondary">{{fluent "tools-editor-rustroid"}}</a>
+  </div>
 </div>


### PR DESCRIPTION
Rustroid is a fully featured Rust IDE for Android (runs locally on Android)
By IDE, I truly mean an integrated development environment, one that offers features like syntax highlighting, auto-completion, diagnostics, signature help, go-to definition, declaration, implementation, show documentation, and more.

I added it because @oli-obk said that i should do so.
[https://users.rust-lang.org/t/rustroid-a-rust-ide-that-runs-locally-on-your-android-phone/134123/4](https://users.rust-lang.org/t/rustroid-a-rust-ide-that-runs-locally-on-your-android-phone/134123/4)

Thanks for your time!