### PR TITLE
Install Clippy on CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: rustfmt
+          components: clippy,rustfmt
 
       - uses: Swatinem/rust-cache@v2
 


### PR DESCRIPTION
Seems like something has changed on GitHub runners, as this worked just a few days ago...