### PR TITLE
Add archived teams to the website

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -740,7 +740,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#5c6c007c3325bb47e55e09f26b8f16832764aa98"
+source = "git+https://github.com/rust-lang/team#cf1b90a143be48cbc583b32c72b64cb106df6bcc"
 dependencies = [
  "indexmap",
  "serde",

--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -11,6 +11,12 @@ governance-rfc-blurb = Each major decision in Rust starts as a Request for Comme
 governance-teams-header = Teams
 governance-wgs-header = Working Groups
 
+governance-archived-teams-header = Archived teams
+governance-archived-teams-link = Show archived teams
+governance-archived-teams-title = Archived teams
+governance-archived-alumni-thanks = We want to thank all past members for their invaluable contributions!
+governance-archived-teams-intro = This page contains archived teams (in alphabetical order) that are no longer active.
+
 ## governance/index-team.hbs
 governance-members = Members & Contacts
 

--- a/src/i18n.rs
+++ b/src/i18n.rs
@@ -129,8 +129,12 @@ impl TeamHelperParam {
 
     fn english<'a>(&'a self, team: &'a serde_json::Value) -> &'a str {
         match self {
-            TeamHelperParam::Name => team["website_data"]["name"].as_str().unwrap(),
-            TeamHelperParam::Description => team["website_data"]["description"].as_str().unwrap(),
+            TeamHelperParam::Name => team["website_data"]["name"]
+                .as_str()
+                .unwrap_or(team["name"].as_str().unwrap()),
+            TeamHelperParam::Description => team["website_data"]["description"]
+                .as_str()
+                .unwrap_or_default(),
             TeamHelperParam::Role(role_id) => {
                 for role in team["roles"].as_array().unwrap() {
                     if role["id"] == *role_id {

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod redirect;
 mod render;
 mod rust_version;
 mod teams;
+mod utils;
 
 const ZULIP_DOMAIN: &str = "https://rust-lang.zulipchat.com";
 

--- a/src/render.rs
+++ b/src/render.rs
@@ -207,6 +207,18 @@ pub fn render_governance(render_ctx: &RenderCtx) -> anyhow::Result<()> {
         )?;
     }
 
+    let archived_teams_data = render_ctx.teams.archived_teams();
+    for_all_langs("governance/archived-teams.html", |dst_path, lang| {
+        render_ctx
+            .page(
+                "governance/archived-teams",
+                "governance-archived-teams-title",
+                &archived_teams_data,
+                lang,
+            )
+            .render(dst_path)
+    })?;
+
     Ok(())
 }
 

--- a/src/rust_version.rs
+++ b/src/rust_version.rs
@@ -1,3 +1,5 @@
+use crate::utils::fetch;
+
 static MANIFEST_URL: &str = "https://static.rust-lang.org/dist/channel-rust-stable.toml";
 
 #[derive(Debug, Clone)]
@@ -6,16 +8,10 @@ pub struct RustVersion(pub String);
 /// Fetch the latest stable version of Rust.
 pub fn fetch_rust_version() -> anyhow::Result<RustVersion> {
     println!("Downloading Rust version");
-    let mut response = ureq::get(MANIFEST_URL).call()?;
-    if !response.status().is_success() {
-        return Err(anyhow::anyhow!(
-            "Failed to download Rust version (HTTP status {}): {}",
-            response.status(),
-            response.body_mut().read_to_string()?
-        ));
-    }
 
-    let manifest: toml::Value = toml::from_str(&response.body_mut().read_to_string()?)?;
+    let response = fetch(MANIFEST_URL)?;
+
+    let manifest: toml::Value = toml::from_str(&response)?;
     let rust_version = manifest["pkg"]["rust"]["version"].as_str().unwrap();
     let version: String = rust_version.split(' ').next().unwrap().to_owned();
     Ok(RustVersion(version))

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -194,6 +194,18 @@ impl RustTeams {
             other_teams,
         })
     }
+
+    pub fn archived_teams(&self) -> ArchivedTeams {
+        let mut teams: Vec<Team> = self
+            .archived_teams
+            .iter()
+            .filter(|t| t.website_data.is_some())
+            .cloned()
+            .collect();
+        teams.sort_by_key(|t| t.name.clone());
+
+        ArchivedTeams { teams }
+    }
 }
 
 #[derive(Serialize)]
@@ -219,6 +231,11 @@ pub struct PageData {
     project_groups: Vec<Team>,
     // Marker teams and other kinds of groups that have a website entry
     other_teams: Vec<Team>,
+}
+
+#[derive(Serialize)]
+pub struct ArchivedTeams {
+    teams: Vec<Team>,
 }
 
 pub fn load_rust_teams() -> anyhow::Result<RustTeams> {

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -1,3 +1,4 @@
+use crate::utils::fetch;
 use handlebars::{
     Context, Handlebars, Helper, HelperResult, Output, RenderContext, RenderErrorReason,
 };
@@ -217,18 +218,10 @@ pub struct PageData {
 pub fn load_rust_teams() -> anyhow::Result<RustTeams> {
     println!("Downloading Team API data");
 
-    let mut response = ureq::get(format!("{BASE_URL}/teams.json")).call()?;
-    if !response.status().is_success() {
-        return Err(anyhow::anyhow!(
-            "Failed to download team API (HTTP status {}): {}",
-            response.status(),
-            response.body_mut().read_to_string()?
-        ));
-    }
+    let response = fetch(&format!("{BASE_URL}/teams.json"))?;
+    let response: Teams = serde_json::from_str(&response)?;
 
-    let resp: Teams = response.body_mut().read_json()?;
-
-    Ok(RustTeams(resp.teams.into_values().collect()))
+    Ok(RustTeams(response.teams.into_values().collect()))
 }
 
 pub(crate) fn kind_to_str(kind: TeamKind) -> &'static str {

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -196,12 +196,7 @@ impl RustTeams {
     }
 
     pub fn archived_teams(&self) -> ArchivedTeams {
-        let mut teams: Vec<Team> = self
-            .archived_teams
-            .iter()
-            .filter(|t| t.website_data.is_some())
-            .cloned()
-            .collect();
+        let mut teams: Vec<Team> = self.archived_teams.clone();
         teams.sort_by_key(|t| t.name.clone());
 
         ArchivedTeams { teams }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,13 @@
+/// Send a GET request to the given `url` and return the result as a string
+pub fn fetch(url: &str) -> anyhow::Result<String> {
+    let mut response = ureq::get(url).call()?;
+    if !response.status().is_success() {
+        return Err(anyhow::anyhow!(
+            "Failed to download data from `{url}` (HTTP status {}): {}",
+            response.status(),
+            response.body_mut().read_to_string()?
+        ));
+    }
+
+    Ok(response.body_mut().read_to_string()?)
+}

--- a/templates/governance/archived-team.html.hbs
+++ b/templates/governance/archived-team.html.hbs
@@ -1,0 +1,36 @@
+<a id="team-{{team.name}}"></a>
+<div class="w-100 mw-none mw-8-m mw9-l ph3 center f3">
+  <header class="pb0 pt5">
+    <a class="linkable-subheading" href="#team-{{team.name}}">
+      <h2>{{team-text team name}}</h2>
+    </a>
+    <div class="highlight"></div>
+  </header>
+  <div>
+    <div class="mv4 flex flex-column flex-row-l justify-between">
+      <p class="ma0 f2">{{team-text team description}}</p>
+    </div>
+  </div>
+  {{#if team.alumni}}
+    <div class="flex flex-column flex-row-l flex-wrap-l justify-start">
+      {{#each team.alumni as |member|}}
+        <div class="w-100 w-33-l mb3 flex flex-row items-center">
+          <a class="mr4 w3 h3 flex-shrink-0" href="https://github.com/{{member.github}}">
+            <img class="w-100 h-100 bg-white br2"
+                 src="https://avatars.githubusercontent.com/{{member.github}}"
+                 alt="{{member.name}}">
+          </a>
+          <div>
+            {{member.name}}
+            <div class="f4">
+              GitHub: <a href="https://github.com/{{member.github}}">{{member.github}}</a>
+            </div>
+            {{#if member.roles}}
+              <div class="f4">{{team-text ../team role (lookup member.roles 0)}}</div>
+            {{/if}}
+          </div>
+        </div>
+      {{/each}}
+    </div>
+  {{/if}}
+</div>

--- a/templates/governance/archived-teams.html.hbs
+++ b/templates/governance/archived-teams.html.hbs
@@ -1,0 +1,15 @@
+{{#*inline "page"}}
+  <section class="green" style="padding-bottom: 10px;">
+    <div class="w-100 mw-none mw-8-m mw9-l center f2">
+      <p>{{fluent "governance-archived-teams-intro"}} {{fluent "governance-archived-alumni-thanks"}}</p>
+    </div>
+  </section>
+
+  {{#each data.teams as |team|}}
+    <section class="green" style="padding-bottom: 15px;">
+      {{> governance/archived-team team=team}}
+    </section>
+  {{/each}}
+
+{{/inline}}
+{{~> (lookup this "parent")~}}

--- a/templates/governance/index.html.hbs
+++ b/templates/governance/index.html.hbs
@@ -37,5 +37,20 @@
     </div>
 </section>
 
+<section id="archived-teams" class="green">
+  <div class="w-100 mw-none ph3 mw-8-m mw9-l center f3">
+    <header>
+      <h2>{{fluent "governance-archived-teams-header"}}</h2>
+      <div class="highlight"></div>
+    </header>
+    <div class="mb2">Some past teams are no longer active. We call these "archived teams".</div>
+
+    <a href="{{baseurl}}/governance/archived-teams.html" class="center w-100 mw6 button button-secondary">
+      {{fluent "governance-archived-teams-link"}}
+    </a>
+    </div>
+  </div>
+</section>
+
 {{/inline}}
 {{~> (lookup this "parent")~}}


### PR DESCRIPTION
This PR adds a new section to the Governance page which links to a single page that contains all archived teams on one place. Especially the design of the archived page section/link on the main governance page is kind of wobbly, I'm open to bikeshedding :)

Currently, we have 40 archives teams, and 9 of them did not have `website_data` entry. I modified the website to show at least something for these teams, so that we don't miss out on any archived teams. But an alternative would be to add this data to the `team` repository. Let me know what you think.