### PR TITLE
Make logos available under `/logos`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,11 @@ fn main() -> anyhow::Result<()> {
         base_url,
     };
     ctx.copy_asset_dir("static", "static")?;
+
+    // This provides the logos at original /logos URLs, which were available
+    // before the move to a static website.
+    ctx.copy_asset_dir("static/logos", "logos")?;
+
     ctx.copy_asset_file(
         "static/text/well_known_security.txt",
         ".well-known/security.txt",


### PR DESCRIPTION
I noticed on my GitHub page that the Rust logo stopped working. I was using a link to https://www.rust-lang.org/logos/rust-logo-16x16-blk.png, but that is now uder https://www.rust-lang.org/static/logos/rust-logo-16x16-blk.png.

This PR makes the logos available also under the original URL. Note that we can't use HTML redirects here, as it's a static file asset (an image).
