### PR TITLE
Add a page with everyone in the Rust Project, including alumni

### DIFF
--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -11,6 +11,8 @@ governance-rfc-blurb = Each major decision in Rust starts as a Request for Comme
 governance-teams-header = Teams
 governance-wgs-header = Working Groups
 
+governance-rust-project-link = Show all Rust team members
+
 governance-archived-teams-header = Archived teams
 governance-archived-teams-description = Some past teams are no longer active. We call these "archived teams".
 governance-archived-teams-link = Show archived teams
@@ -31,3 +33,8 @@ governance-user-team-leader = Team leader
 governance-members-header = Members
 governance-alumni-header = Alumni
 governance-alumni-thanks = We also want to thank all past members for their invaluable contributions!
+
+## governance/all-team-members.mbs
+governance-all-team-members-title = All Rust team members
+governance-all-team-members-intro = This section lists the members of currently active Rust teams.
+governance-all-team-members-alumni-intro = This section lists our team alumni.

--- a/src/render.rs
+++ b/src/render.rs
@@ -219,6 +219,18 @@ pub fn render_governance(render_ctx: &RenderCtx) -> anyhow::Result<()> {
             .render(dst_path)
     })?;
 
+    let all_team_members_data = render_ctx.teams.all_team_members();
+    for_all_langs("governance/all-team-members.html", |dst_path, lang| {
+        render_ctx
+            .page(
+                "governance/all-team-members",
+                "governance-all-team-members-title",
+                &all_team_members_data,
+                lang,
+            )
+            .render(dst_path)
+    })?;
+
     Ok(())
 }
 

--- a/templates/governance/all-team-members.html.hbs
+++ b/templates/governance/all-team-members.html.hbs
@@ -1,0 +1,47 @@
+{{#*inline "member"}}
+  <div class="w-100 w-25-l mb3 flex flex-row items-center">
+    <a class="mr4 w3 h3 flex-shrink-0" href="https://github.com/{{member.github}}">
+      <img class="w-100 h-100 bg-white br2"
+           src="https://avatars.githubusercontent.com/{{member.github}}"
+           alt="{{member.name}}">
+    </a>
+    <div>
+      {{member.name}}
+      <div class="f4">
+        GitHub: <a href="https://github.com/{{member.github}}">{{member.github}}</a>
+      </div>
+    </div>
+  </div>
+{{/inline}}
+
+{{#*inline "page"}}
+  <section class="green" style="padding-bottom: 10px;">
+    <div class="w-100 mw-none mw-8-m mw9-l center f2">
+      <p>{{fluent "governance-all-team-members-intro"}}</p>
+    </div>
+  </section>
+
+  <section class="green" style="padding-bottom: 15px;">
+    <div class="w-100 mw-none mw-8-m mw9-l flex flex-column flex-row-l flex-wrap-l center">
+      {{#each data.active as |member|}}
+        {{> member member=member }}
+      {{/each}}
+    </div>
+  </section>
+
+  <section class="red" style="padding-bottom: 10px;">
+    <div class="w-100 mw-none mw-8-m mw9-l center f2">
+      <p>{{fluent "governance-all-team-members-alumni-intro"}}</p>
+    </div>
+  </section>
+
+  <section class="red" style="padding-bottom: 15px;">
+    <div class="w-100 mw-none mw-8-m mw9-l flex flex-column flex-row-l flex-wrap-l center">
+      {{#each data.alumni as |member|}}
+        {{> member member=member }}
+      {{/each}}
+    </div>
+  </section>
+
+{{/inline}}
+{{~> (lookup this "parent")~}}

--- a/templates/governance/index.html.hbs
+++ b/templates/governance/index.html.hbs
@@ -34,6 +34,11 @@
                 {{> governance/index-team team=team baseurl=../baseurl}}
             {{/each~}}
         </div>
+        <div class="flex">
+          <a href="{{baseurl}}/governance/all-team-members.html" class="center w-100 mw6 button button-secondary">
+            {{fluent "governance-rust-project-link"}}
+          </a>
+        </div>
     </div>
 </section>
 


### PR DESCRIPTION
The recent addition of archived teams finally included more alumni on the website. But I think that we're still missing some high-level view. So I thought - why not show *everyone*? The whole Rust Project (although I didn't call it like that on the website, as we don't really have a precise definition of that yet) on a single page, including all alumni.

https://github.com/user-attachments/assets/8a04f34b-7d89-42e3-873c-167c5bae1c3e