### PR TITLE
Invert RBE and Rustlings order

### DIFF
--- a/templates/learn/index.html.hbs
+++ b/templates/learn/index.html.hbs
@@ -24,18 +24,18 @@
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
         <div class="v-top pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
-          <p class="flex-grow-1">{{fluent "learn-rustlings"}}</p>
+          <p class="flex-grow-1">{{fluent "learn-rbe"}}</p>
           <div class="buttons">
-            <a class="button button-secondary" href="https://github.com/rust-lang/rustlings/">{{fluent "learn-rustlings-button"}}</a>
+            <a class="button button-secondary" href="https://doc.rust-lang.org/rust-by-example/">{{fluent "learn-rbe-button"}}</a>
+            {{#if (fluent "translated-rbe")}}<a class="button-additional" href={{fluent "translated-rbe"}}>{{fluent "translated-rbe-button"}}</a>{{/if}}
           </div>
         </div>
       </div>
       <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l pb4 pb5-m pb0-ns ph4-l">
         <div class="v-top pt3-l measure-wide-l flex-l flex-column-l flex-auto-l">
-          <p class="flex-grow-1">{{fluent "learn-rbe"}}</p>
+          <p class="flex-grow-1">{{fluent "learn-rustlings"}}</p>
           <div class="buttons">
-            <a class="button button-secondary" href="https://doc.rust-lang.org/rust-by-example/">{{fluent "learn-rbe-button"}}</a>
-            {{#if (fluent "translated-rbe")}}<a class="button-additional" href={{fluent "translated-rbe"}}>{{fluent "translated-rbe-button"}}</a>{{/if}}
+            <a class="button button-secondary" href="https://github.com/rust-lang/rustlings/">{{fluent "learn-rustlings-button"}}</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
A person reading the Learn Rust page left to right or top to bottom will read the Rustlings section before the RBE section, but the former mentions the latter, so the person will encounter RBE before having read about it.
Inverting the order of the two sections prevents these unnecessary "forward references".