### PR TITLE
Fix breaking change in rust team API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -741,7 +741,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#a32542bd7344a6738b43ac914c0f35eb2bb36175"
+source = "git+https://github.com/rust-lang/team#25b5c87be62c3bdfe7408ce961da75a7b3434756"
 dependencies = [
  "indexmap",
  "serde",

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -360,14 +360,12 @@ mod tests {
                 page: name.into(),
                 email: None,
                 repo: None,
-                discord: None,
                 zulip_stream: None,
                 weight: 0,
                 matrix_room: None,
             }),
             roles: Vec::new(),
             github: None,
-            discord: vec![],
             top_level: None,
         }
     }


### PR DESCRIPTION
Upstream PR that removed the discord field:
https://github.com/rust-lang/team/pull/2043