### PR TITLE
Change what does an "active team" mean

### DIFF
--- a/src/teams.rs
+++ b/src/teams.rs
@@ -358,7 +358,10 @@ impl RustTeams {
 /// Is this a team for which we should display its members on the "All Project Members" page,
 /// and whose members should receive a separate person page?
 fn is_active_team(team: &Team) -> bool {
-    team.name != "alumni"
+    if team.kind == TeamKind::MarkerTeam && team.website_data.is_none() {
+        return false;
+    }
+    true
 }
 
 /// Get a relative URL of a team that should be appended to


### PR DESCRIPTION
I unified the logic in https://github.com/rust-lang/www.rust-lang.org/pull/2226, which was good, but I chose the "team isn't the alumni team" logic. However, the other logic (team isn't a marker team without website data) IMO makes more sense, as it avoids marker teams such as "all", "leads", etc., which IMO shouldn't be shown on the website, especially on the person profile page, as it's just noise.
