### PR TITLE
Use nicer URL for all project members page

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -39,6 +39,7 @@ pub static PAGE_REDIRECTS: &[(&str, &str)] = &[
     // miscellaneous
     ("governance/teams", "governance#teams"),
     ("governance/wgs", "governance#working-groups"),
+    ("governance/all-team-members.html", "governance/people"),
 ];
 
 pub static STATIC_FILES_REDIRECTS: &[(&str, &str)] = &[

--- a/src/render.rs
+++ b/src/render.rs
@@ -227,7 +227,7 @@ pub fn render_governance(render_ctx: &RenderCtx) -> anyhow::Result<()> {
 
     // Page with all team members
     let all_team_members_data = render_ctx.teams.all_team_members();
-    for_all_langs("governance/all-team-members.html", |dst_path, lang| {
+    for_all_langs("governance/people/index.html", |dst_path, lang| {
         render_ctx
             .page(
                 "governance/all-team-members",

--- a/templates/governance/index.html.hbs
+++ b/templates/governance/index.html.hbs
@@ -35,7 +35,7 @@
             {{/each~}}
         </div>
         <div class="flex">
-          <a href="{{baseurl}}/governance/all-team-members.html" class="center w-100 mw6 button button-secondary">
+          <a href="{{baseurl}}/governance/people" class="center w-100 mw6 button button-secondary">
             {{fluent "governance-rust-project-link"}}
           </a>
         </div>


### PR DESCRIPTION
Now that we have `/governance/people/<person>.html`, it seems reasonable to have `/governance/people` to point to the page with all Project Members. The old URL was kinda ugly anyway.
