### PR TITLE
Add the total numbers of members and alumni

### DIFF
--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -36,8 +36,8 @@ governance-alumni-thanks = We also want to thank all past members for their inva
 
 ## governance/all-team-members.hbs
 governance-all-team-members-title = All Rust team members
-governance-all-team-members-intro = This section lists the members of currently active Rust teams.
-governance-all-team-members-alumni-intro = This section lists our team alumni.
+governance-all-team-members-intro = This section lists the { $count } members of currently active Rust teams.
+governance-all-team-members-alumni-intro = This section lists our { $count } team alumni.
 
 ## govenance/person.hbs
 governance-person-title = Rust Project team member

--- a/templates/governance/all-team-members.html.hbs
+++ b/templates/governance/all-team-members.html.hbs
@@ -17,7 +17,8 @@
 {{#*inline "page"}}
   <section class="green" style="padding-bottom: 10px;">
     <div class="w-100 mw-none mw-8-m mw9-l center f2">
-      <p>{{fluent "governance-all-team-members-intro"}}</p>
+      <p>{{#fluent "governance-all-team-members-intro"}}{{#fluentparam
+      "count"}}{{len data.active}}{{/fluentparam}}{{/fluent}}</p>
     </div>
   </section>
 
@@ -31,7 +32,8 @@
 
   <section class="red" style="padding-bottom: 10px;">
     <div class="w-100 mw-none mw-8-m mw9-l center f2">
-      <p>{{fluent "governance-all-team-members-alumni-intro"}}</p>
+      <p>{{#fluent "governance-all-team-members-alumni-intro"}}{{#fluentparam
+      "count"}}{{len data.alumni}}{{/fluentparam}}{{/fluent}}</p>
     </div>
   </section>
 


### PR DESCRIPTION
My partner asked me roughly how many people are "official" rust team members, and I couldn't say, so thought it might be a good addition to the "all team members" page.

Not sure about the placement and whether others will think it's a good idea too.

r? @Kobzol as the person who added this page in the first place :)