### PR TITLE
Add GitHub Sponsors link to person profile page

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -792,7 +792,7 @@ dependencies = [
 [[package]]
 name = "rust_team_data"
 version = "1.0.0"
-source = "git+https://github.com/rust-lang/team#6e8fc802c561618d770eca05e76714e22c7af302"
+source = "git+https://github.com/rust-lang/team#e98fd12441f487242a185921e25a53e0b07b1b36"
 dependencies = [
  "indexmap",
  "serde",

--- a/src/render.rs
+++ b/src/render.rs
@@ -2,7 +2,7 @@ use crate::assets::AssetFiles;
 use crate::fs::{copy_dir_all, ensure_directory};
 use crate::i18n::{EXPLICIT_LOCALE_INFO, LocaleInfo, SUPPORTED_LOCALES};
 use crate::rust_version::RustVersion;
-use crate::teams::{PageData, RustTeams};
+use crate::teams::{PageData, RustTeamData};
 use crate::{BaseUrl, ENGLISH, LAYOUT};
 use anyhow::Context;
 use handlebars::Handlebars;
@@ -84,7 +84,7 @@ pub struct RenderCtx<'a> {
     pub fluent_loader: SimpleLoader,
     pub output_dir: PathBuf,
     pub rust_version: RustVersion,
-    pub teams: RustTeams,
+    pub teams: RustTeamData,
     pub assets: AssetFiles,
     pub base_url: BaseUrl,
 }

--- a/templates/governance/person.html.hbs
+++ b/templates/governance/person.html.hbs
@@ -20,7 +20,7 @@
 
 {{#*inline "page"}}
   <section class="green" style="padding-bottom: 10px;">
-    <div class="w-100 mw-none mw-8-m mw9-l center f1 ph3">
+    <div class="w-100 mw-none mw-8-m mw9-l center f1 ph3 flex flex-column flex-row-l items-end-l justify-between">
       <div class="w-100 w-50-l mb3 flex flex-row items-start">
         <a class="mr4 w4 h4 w5-l h5-l flex-shrink-0" href="https://github.com/{{data.github}}">
           <img class="w-100 h-100 bg-white br2"
@@ -33,6 +33,11 @@
             GitHub: <a href="https://github.com/{{data.github}}">{{data.github}}</a>
           </div>
         </div>
+      </div>
+      <div class="f3">
+        {{# if data.github_sponsors }}
+          <a href="https://github.com/sponsors/{{data.github}}" class="button button-secondary mw6">Sponsor {{ data.name }} on GitHub</a>
+        {{/if}}
       </div>
     </div>
   </section>


### PR DESCRIPTION
Makes use of the new data from https://github.com/rust-lang/team/pull/2071.

Desktop:
<img width="1207" height="362" alt="image" src="https://github.com/user-attachments/assets/341a35fd-2306-451f-8d9a-86f2b7a9aceb" />

Mobile:
<img width="294" height="237" alt="image" src="https://github.com/user-attachments/assets/00075bd8-75a2-4c4c-bb17-433213100fec" />