### PR TITLE
Add Funding page navbar link

### DIFF
--- a/locales/de/common.ftl
+++ b/locales/de/common.ftl
@@ -20,6 +20,7 @@ nav-install = Installieren
 nav-learn = Lernen
 nav-tools = Werkzeuge
 nav-governance = Leitung
+nav-funding = Finanzierung
 nav-community = Community
 nav-blog = Blog
 choose-language = Sprache

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -31,6 +31,7 @@ nav-install = Install
 nav-learn = Learn
 nav-tools = Tools
 nav-governance = Governance
+nav-funding = Funding
 nav-community = Community
 nav-blog = Blog
 nav-playground = Playground

--- a/locales/es/common.ftl
+++ b/locales/es/common.ftl
@@ -28,6 +28,7 @@ nav-install = Instala
 nav-learn = Aprende
 nav-tools = Herramientas
 nav-governance = Gobernanza
+nav-funding = Financiación
 nav-community = Comunidad
 nav-blog = Blog
 nav-playground = Playground

--- a/locales/fr/common.ftl
+++ b/locales/fr/common.ftl
@@ -28,6 +28,7 @@ nav-install = Installer
 nav-learn = Apprendre
 nav-tools = Outils
 nav-governance = Gouvernance
+nav-funding = Financement
 nav-community = Communauté
 nav-blog = Blog
 nav-playground = Bac à sable

--- a/locales/it/common.ftl
+++ b/locales/it/common.ftl
@@ -28,6 +28,7 @@ nav-install = Installa
 nav-learn = Impara
 nav-tools = Strumenti
 nav-governance = Governance
+nav-funding = Finanziamento
 nav-community = Community
 nav-blog = Blog
 nav-playground = Playground

--- a/locales/ja/common.ftl
+++ b/locales/ja/common.ftl
@@ -28,6 +28,7 @@ nav-install = インストール
 nav-learn = 学ぶ
 nav-tools = ツール
 nav-governance = ガバナンス
+nav-funding = 支援
 nav-community = コミュニティ
 nav-blog = ブログ
 nav-playground = Playground

--- a/locales/ko/common.ftl
+++ b/locales/ko/common.ftl
@@ -26,6 +26,7 @@ nav-install = 설치
 nav-learn = 배우기
 nav-tools = 도구
 nav-governance = 거버넌스
+nav-funding = 펀딩
 nav-community = 커뮤니티
 nav-blog = 블로그
 choose-language = 언어

--- a/locales/ru/common.ftl
+++ b/locales/ru/common.ftl
@@ -28,6 +28,7 @@ nav-install = Установка
 nav-learn = Изучить
 nav-tools = Инструменты
 nav-governance = Управление
+nav-funding = Финансирование
 nav-community = Сообщество
 nav-blog = Блог
 nav-playground = Песочница

--- a/locales/xx-AU/common.ftl
+++ b/locales/xx-AU/common.ftl
@@ -8,6 +8,7 @@ nav-install = llɐʇsuI
 nav-learn = uɹɐǝ˥
 nav-tools = sloo┴
 nav-governance = ǝɔuɐuɹǝʌoפ
+nav-funding = ƃuıpunℲ
 nav-community = ʎʇᴉunɯɯoƆ
 nav-blog = ƃolq
 

--- a/locales/zh-CN/common.ftl
+++ b/locales/zh-CN/common.ftl
@@ -28,6 +28,7 @@ nav-install = 安装
 nav-learn = 学习
 nav-tools = 工具
 nav-governance = 团队
+nav-funding = 赞助
 nav-community = 社区
 nav-blog = 博客
 nav-playground = 实验

--- a/locales/zh-TW/common.ftl
+++ b/locales/zh-TW/common.ftl
@@ -28,6 +28,7 @@ nav-install = 安裝
 nav-learn = 學習
 nav-tools = 工具
 nav-governance = 治理
+nav-funding = 贊助
 nav-community = 社群
 nav-blog = 網誌
 nav-playground = 遊樂場

--- a/templates/components/nav.html.hbs
+++ b/templates/components/nav.html.hbs
@@ -14,6 +14,7 @@
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://play.rust-lang.org/">{{fluent "nav-playground"}}</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="{{baseurl}}/tools">{{fluent "nav-tools"}}</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="{{baseurl}}/governance">{{fluent "nav-governance"}}</a></li>
+    <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="{{baseurl}}/funding">{{fluent "nav-funding"}}</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="{{baseurl}}/community">{{fluent "nav-community"}}</a></li>
     <li class="tc pv2 ph2 ph4-ns flex-20-s"><a href="https://blog.rust-lang.org/">{{fluent "nav-blog"}}</a></li>
   </ul>


### PR DESCRIPTION
As a part of the effort to promote it (https://rust-lang.zulipchat.com/#narrow/channel/392734-council/topic/Publicizing.20our.20funding.20page/with/560030032, https://github.com/rust-lang/blog.rust-lang.org/pull/1751).

<img width="903" height="91" alt="image" src="https://github.com/user-attachments/assets/d54ac446-68a0-4dfb-a4cd-89b652f9757a" />

We should probably translate it into all current languages, since an untranslated navbar item will probably look quite weird?

Marking as a draft, to sync it with the blog post and other changes.
