### PR TITLE
Fix alignment of sponsor button in contributor funding list

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -99,6 +99,7 @@ p {
 
 .button.button-secondary {
   font-size: 0.8em;
+  max-width: fit-content;
 }
 
 .button-additional {


### PR DESCRIPTION
I couldn't sleep until I fixed that haha

<details><summary>Before this patch</summary>
<p>

<img width="1088" height="545" alt="vorher" src="https://github.com/user-attachments/assets/b377d7e3-6344-40fd-b8ff-43bd4e103c1b" />


</p>
</details> 

<details><summary>After this patch</summary>
<p>

<img width="1035" height="512" alt="nachher" src="https://github.com/user-attachments/assets/58dd5a52-0be5-4dfb-bab9-8c8719e7effd" />


</p>
</details> 