### PR TITLE
Remove extra characters

### DIFF
--- a/locales/en-US/funding.ftl
+++ b/locales/en-US/funding.ftl
@@ -2,5 +2,5 @@
 
 ## funding.html.hbs
 funding-page-title = Funding
-funding-intro = Rust depends on hundreds of contributors who improve it on a daily basis, many of whom are volunteers. We want them to be properly supported to ensure the long-term health of the Rust Project. One approach to achieve that is the <a href="https://rustfoundation.org/media/announcing-the-rust-foundation-maintainers-fund/">Rust Foundation Maintainer Fund</a>, which is currently in the works.```
+funding-intro = Rust depends on hundreds of contributors who improve it on a daily basis, many of whom are volunteers. We want them to be properly supported to ensure the long-term health of the Rust Project. One approach to achieve that is the <a href="https://rustfoundation.org/media/announcing-the-rust-foundation-maintainers-fund/">Rust Foundation Maintainer Fund</a>, which is currently in the works.
 funding-intro-individuals = Another way is to sponsor individuals that work on Rust. You can find Rust contributors that can be funded via GitHub Sponsors below. Consider sponsoring them if you want to support the development of Rust.


### PR DESCRIPTION
IDK how, but in my recent PR I somehow included a bunch of extra characters.
<img width="1230" height="182" alt="image" src="https://github.com/user-attachments/assets/20828104-a48c-4d95-8ac3-1e4cbe68334f" />