### PR TITLE
fix: update learn page embedded book link

### DIFF
--- a/templates/learn/index.html.hbs
+++ b/templates/learn/index.html.hbs
@@ -120,7 +120,7 @@
           </div>
 
           <div class="pt4 pt3-l flex flex-column flex-row-l items-center-l mb4-l">
-            <a href="https://doc.rust-lang.org/embedded-book"
+            <a href="https://docs.rust-embedded.org/book/"
                class="button button-secondary mw6-l w-100">
               {{fluent "learn-domain-embedded-button"}}
             </a>


### PR DESCRIPTION
## Summary
- update the Learn page Embedded Book button to point to the current embedded Rust book
- replace the outdated doc.rust-lang.org embedded-book link

Closes #2274