### PR TITLE
fix: update wasm docs link

### DIFF
--- a/templates/components/what/wasm/get-started.html.hbs
+++ b/templates/components/what/wasm/get-started.html.hbs
@@ -24,7 +24,7 @@
                     <p class="flex-grow-1">
                         {{fluent "wasm-get-started-book-description"}}
                     </p>
-                    <a href="https://rustwasm.github.io/docs/book" class="button button-secondary">{{fluent "wasm-get-started-book-link"}}</a>
+                    <a href="https://rustwasm.github.io/docs.html" class="button button-secondary">{{fluent "wasm-get-started-book-link"}}</a>
                 </div>
             </div>
             <div class="flex flex-row flex-column-l justify-between-l mw8 measure-wide-l w-100 mt5 mt2-l">


### PR DESCRIPTION
## Summary
- replace the outdated rustwasm book URL on the WebAssembly page
- point users to the current rustwasm docs hub instead of the deprecated book page

Closes #2197