### PR TITLE
Remove special text selection behavior of install command

### DIFF
--- a/src/styles/app.scss
+++ b/src/styles/app.scss
@@ -115,10 +115,6 @@ code.code-header {
   margin: 0 0 3px 0;
 }
 
-code.copyable {
-  user-select: all;
-}
-
 .pre-copy-wrap {
   display: flex;
   align-items: stretch;

--- a/templates/components/tools/rustup.html.hbs
+++ b/templates/components/tools/rustup.html.hbs
@@ -2,7 +2,7 @@
   <div id="platform-instructions-unix" class="instructions db">
     <p>{{fluent "tools-rustup-unixy"}}</p>
     <div class="pre-copy-wrap">
-      <pre><code class="db w-100 copyable">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+      <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
       <button class="copy-code-btn" type="button" aria-label="Copy install command to clipboard">
         <img class="copy-icon" src="{{baseurl_assets}}/static/images/copy.svg" alt="" aria-hidden="true" width="14" height="14">
         <img class="check-icon" src="{{baseurl_assets}}/static/images/check.svg" alt="" aria-hidden="true" width="14" height="14">
@@ -28,7 +28,7 @@
   <h3 class="mt4">{{fluent "tools-rustup-wsl-heading"}}</h3>
   <p>{{fluent "tools-rustup-wsl"}}</p>
   <div class="pre-copy-wrap">
-    <pre><code class="db w-100 copyable">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+    <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
     <button class="copy-code-btn" type="button" aria-label="Copy WSL install command to clipboard">
       <img class="copy-icon" src="{{baseurl_assets}}/static/images/copy.svg" alt="" aria-hidden="true" width="14" height="14">
       <img class="check-icon" src="{{baseurl_assets}}/static/images/check.svg" alt="" aria-hidden="true" width="14" height="14">
@@ -42,7 +42,7 @@
         {{fluent "tools-rustup-manual-default"}}
       </p>
       <div class="pre-copy-wrap">
-        <pre><code class="db w-100 copyable">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
+        <pre><code class="db w-100">curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh</code></pre>
         <button class="copy-code-btn" type="button" aria-label="Copy install command to clipboard">
           <img class="copy-icon" src="{{baseurl_assets}}/static/images/copy.svg" alt="" aria-hidden="true" width="14" height="14">
           <img class="check-icon" src="{{baseurl_assets}}/static/images/check.svg" alt="" aria-hidden="true" width="14" height="14">


### PR DESCRIPTION
This reverts commit c7a310c50e5d6b6be9605d5fc6baa3791e0fc7d2.

Now that there is a copy button, there is no need for special selection behavior anymore.