### PR TITLE
Fix legacy URLs for working groups

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,6 +126,7 @@ So stay vigilant and update it if you notice something missing.
 - https://www.rust-lang.org/governance/teams/crates-io
 - https://www.rust-lang.org/governance/teams
 - https://www.rust-lang.org/governance/wgs
+- https://www.rust-lang.org/governance/wgs/wg-secure-code
 <!-- a couple localized redirects -->
 - https://www.rust-lang.org/es-ES
 - https://www.rust-lang.org/es-ES/contribute-compiler.html

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -36,6 +36,16 @@ pub static PAGE_REDIRECTS: &[(&str, &str)] = &[
         "governance/wgs/wg-async",
         "governance/teams/lang#team-wg-async",
     ),
+    ("governance/wgs/cli", "governance/teams#team-wg-cli"),
+    (
+        "governance/wgs/embedded",
+        "governance/teams#team-wg-embedded",
+    ),
+    ("governance/wgs/gamedev", "governance/teams#team-wg-gamedev"),
+    (
+        "governance/wgs/wg-secure-code",
+        "governance/teams#team-wg-secure-code",
+    ),
     // miscellaneous
     ("governance/wgs", "governance#working-groups"),
     ("governance/all-team-members.html", "governance/people"),

--- a/src/render.rs
+++ b/src/render.rs
@@ -194,8 +194,13 @@ pub fn render_governance(
             .render(dst_path)
     })?;
 
-    // Individual teams
-    for team in data.teams {
+    // Individual teams, plus legacy launching-pad subteams that have dedicated pages
+    // for backwards compatibility (e.g. /governance/wgs/wg-secure-code).
+    let all_team_pages = data
+        .teams
+        .into_iter()
+        .chain(render_ctx.teams.launching_pad_subteam_pages());
+    for team in all_team_pages {
         println!("Rendering team page for {}", team.team.name);
         let data: PageData = render_ctx
             .teams

--- a/src/render.rs
+++ b/src/render.rs
@@ -194,13 +194,8 @@ pub fn render_governance(
             .render(dst_path)
     })?;
 
-    // Individual teams, plus legacy launching-pad subteams that have dedicated pages
-    // for backwards compatibility (e.g. /governance/wgs/wg-secure-code).
-    let all_team_pages = data
-        .teams
-        .into_iter()
-        .chain(render_ctx.teams.launching_pad_subteam_pages());
-    for team in all_team_pages {
+    // Individual teams
+    for team in data.teams {
         println!("Rendering team page for {}", team.team.name);
         let data: PageData = render_ctx
             .teams

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -229,6 +229,28 @@ impl RustTeamData {
         })
     }
 
+    /// Returns teams that are subteams of launching-pad and have their own dedicated page.
+    /// These are legacy working groups that were moved under launching-pad but still need
+    /// their own pages to avoid breaking external links (e.g. /governance/wgs/wg-secure-code).
+    pub fn launching_pad_subteam_pages(&self) -> Vec<IndexTeam> {
+        self.teams
+            .iter()
+            .filter(|team| team.website_data.is_some())
+            .filter(|team| team.subteam_of.as_deref() == Some("launching-pad"))
+            .filter(|team| team.kind == TeamKind::WorkingGroup)
+            .map(|team| {
+                let section = kind_to_str(team.kind);
+                let page_name = team.website_data.as_ref().unwrap().page.clone();
+                IndexTeam {
+                    url: format!("{section}/{page_name}"),
+                    section,
+                    page_name,
+                    team: team.clone(),
+                }
+            })
+            .collect()
+    }
+
     pub fn all_teams(&self) -> AllTeams {
         let mut active_teams = self
             .teams

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -103,17 +103,8 @@ impl RustTeamData {
             .ok_or(TeamNotFound)?;
 
         // Don't show pages for subteams
-        if let Some(subteam) = &main_team.subteam_of {
-            // In the past we gave working groups their own dedicated pages linked
-            // from the front page. We have now moved those working groups under
-            // launching-pad, and the groups are listed as subteams of the launching
-            // pad. To avoid breaking external links to things like
-            // https://www.rust-lang.org/governance/wgs/wg-secure-code,
-            // we still generate dedicated pages for these launching-pad teams,
-            // but they are not linked from the main site.
-            if !matches!(subteam.as_ref(), "launching-pad") {
-                return Err(TeamNotFound.into());
-            }
+        if main_team.subteam_of.is_some() {
+            return Err(TeamNotFound.into());
         }
 
         // Then find all the subteams, working groups and project groups.

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -229,28 +229,6 @@ impl RustTeamData {
         })
     }
 
-    /// Returns teams that are subteams of launching-pad and have their own dedicated page.
-    /// These are legacy working groups that were moved under launching-pad but still need
-    /// their own pages to avoid breaking external links (e.g. /governance/wgs/wg-secure-code).
-    pub fn launching_pad_subteam_pages(&self) -> Vec<IndexTeam> {
-        self.teams
-            .iter()
-            .filter(|team| team.website_data.is_some())
-            .filter(|team| team.subteam_of.as_deref() == Some("launching-pad"))
-            .filter(|team| team.kind == TeamKind::WorkingGroup)
-            .map(|team| {
-                let section = kind_to_str(team.kind);
-                let page_name = team.website_data.as_ref().unwrap().page.clone();
-                IndexTeam {
-                    url: format!("{section}/{page_name}"),
-                    section,
-                    page_name,
-                    team: team.clone(),
-                }
-            })
-            .collect()
-    }
-
     pub fn all_teams(&self) -> AllTeams {
         let mut active_teams = self
             .teams


### PR DESCRIPTION
An older version of the website had dedicated pages for working groups that do not exist anymore.

By filtering by teams that are subteam-of = "launching-pad" and kind = "working-group", the legacy pages for these working groups were determined to be:
* wg-cli at governance/wgs/cli
* wg-embedded at governance/wgs/embedded
* wg-gamedev at governance/wgs/gamedev
* wg-secure-code at governance/wgs/wg-secure-code

This PR creates redirects for these URLs to the new location of this information on the governance/teams page and also cleans up logic that was now unused for generating dedicated wg pages.

_Previously:_
~~When the site was converted from a Rocket server to a static generator, render_governance only iterated over top-level teams from index_data(), dropping pages for working groups under launching-pad (e.g. /governance/wgs/wg-secure-code). The page_data logic to preserve these URLs.~~

~~Adds launching_pad_subteam_pages() to produce the missing working group IndexTeam entries and chains them into the render loop.~~

~~By filtering by teams that are subteam-of = "launching-pad" and kind = "working-group", this creates the legacy pages for these working groups:~~
* ~~wg-cli at governance/wgs/cli~~
* ~~wg-embedded at governance/wgs/embedded~~
* ~~wg-gamedev at governance/wgs/gamedev~~
* ~~wg-secure-code at governance/wgs/wg-secure-code~~

~~An alternate solution to add redirects to the new location of the teams on this page here: https://rust-lang.org/governance/teams/~~

Closes #2268