### PR TITLE
Add mt2 to Show All Teams button

### DIFF
--- a/templates/governance/index.html.hbs
+++ b/templates/governance/index.html.hbs
@@ -53,7 +53,7 @@
     <div class="flex flex-column flex-row-l justify-start w-full mt2">
       <a
         href="{{ baseurl }}/governance/teams"
-        class="center w-100 mw6 button button-secondary"
+        class="center w-100 mw6 button button-secondary mt2"
       >
         {{fluent "governance-all-teams-link"}}
       </a>


### PR DESCRIPTION
This is the smallest of nitpicks, but I figured if I noticed it, I may as well fix it.

Here was the before:

<img width="1121" height="266" alt="image" src="https://github.com/user-attachments/assets/2571a3ec-ea91-4ce6-aa29-2ba140044c93" />

Here's the after:

<img width="1111" height="250" alt="image" src="https://github.com/user-attachments/assets/7d4ef80c-7b42-4b37-964b-7c710ea9f7f4" />

Closes #2290
