### PR TITLE
Cleanup stale redirects

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -18,7 +18,6 @@ pub static PAGE_REDIRECTS: &[(&str, &str)] = &[
     ("contribute.html", "community"),
     ("documentation.html", "learn"),
     ("downloads.html", "tools/install"),
-    ("friends.html", "production"),
     ("install.html", "tools/install"),
     ("legal.html", "policies"),
     ("security.html", "policies/security"),
@@ -50,7 +49,7 @@ pub static PAGE_REDIRECTS: &[(&str, &str)] = &[
         "governance/teams#team-wg-secure-code",
     ),
     // miscellaneous
-    ("governance/wgs", "governance#working-groups"),
+    ("governance/wgs", "governance/teams"),
     ("governance/all-team-members.html", "governance/people"),
     (
         "governance/archived-teams.html",


### PR DESCRIPTION
- The production page doesn't exist anymore.
- governance#working-groups doesn't exist anymore either, governance/teams seems like the closest replacement.

reported here:
https://github.com/rust-lang/www.rust-lang.org/pull/2289#issuecomment-4281548995