### PR TITLE
Update funding page to point to RFMF

### DIFF
--- a/locales/en-US/funding.ftl
+++ b/locales/en-US/funding.ftl
@@ -4,4 +4,4 @@
 funding-page-title = Funding
 funding-intro = Rust depends on hundreds of contributors who improve it on a daily basis, many of whom are volunteers. We want them to be properly supported to ensure the long-term health of the Rust Project. We are very grateful for any financial contributions that go towards supporting the development of Rust. There are various ways how to sponsor Rust contributors:
 funding-intro-rfmf = One way is to contribute to the <a href="TODO">Rust Foundation Maintainer Fund</a>, which funds dedicated Maintainers in Residence, who maintain critical areas of the Rust toolchain.
-funding-intro-individuals = Another way is to sponsor individuals that work on Rust directly, through their GitHub Sponsors account. You can such Rust contributors that can be funded below.
+funding-intro-individuals = Another way is to sponsor individuals that work on Rust directly, through their GitHub Sponsors account. You can find such Rust contributors that can be funded below.

--- a/locales/en-US/funding.ftl
+++ b/locales/en-US/funding.ftl
@@ -2,5 +2,6 @@
 
 ## funding.html.hbs
 funding-page-title = Funding
-funding-intro = Rust depends on hundreds of contributors who improve it on a daily basis, many of whom are volunteers. We want them to be properly supported to ensure the long-term health of the Rust Project. One approach to achieve that is the <a href="https://rustfoundation.org/media/announcing-the-rust-foundation-maintainers-fund/">Rust Foundation Maintainer Fund</a>, which is currently in the works.
-funding-intro-individuals = Another way is to sponsor individuals that work on Rust. You can find Rust contributors that can be funded via GitHub Sponsors below. Consider sponsoring them if you want to support the development of Rust.
+funding-intro = Rust depends on hundreds of contributors who improve it on a daily basis, many of whom are volunteers. We want them to be properly supported to ensure the long-term health of the Rust Project. We are very grateful for any financial contributions that go towards supporting the development of Rust. There are various ways how to sponsor Rust contributors:
+funding-intro-rfmf = One way is to contribute to the <a href="TODO">Rust Foundation Maintainer Fund</a>, which funds dedicated Maintainers in Residence, who maintain critical areas of the Rust toolchain.
+funding-intro-individuals = Another way is to sponsor individuals that work on Rust directly, through their GitHub Sponsors account. You can such Rust contributors that can be funded below.

--- a/templates/funding.html.hbs
+++ b/templates/funding.html.hbs
@@ -24,6 +24,9 @@
       <p>{{fluent "funding-intro"}}</p>
     </div>
     <div class="w-100 mw-none mw-8-m mw9-l center f1 ph3" style="font-size: 1.2em;">
+      <p>{{fluent "funding-intro-rfmf"}}</p>
+    </div>
+    <div class="w-100 mw-none mw-8-m mw9-l center f1 ph3" style="font-size: 1.2em;">
       <p>{{fluent "funding-intro-individuals"}}</p>
     </div>
   </section>


### PR DESCRIPTION
We want to announce progress on RFMF soon, and by that time I'd like the Rust Project's website Funding page, the various Rust Foundation funding/RFMF webpages and GitHub Sponsors pages to be [in sync](https://rust-lang.zulipchat.com/#narrow/channel/548261-funding/topic/Consolidating.20funding.20web.20presence/with/593840195).

This PR updates the funding page. The link to RFMF is still a TODO, pending figuring out what is the canonical address of RFMF.

Once we update the page, I hope that we could then also merge https://github.com/rust-lang/www.rust-lang.org/pull/2245.

<img width="1563" height="722" alt="image" src="https://github.com/user-attachments/assets/a7aa7d68-340a-427c-95b5-dd2780016385" />