### PR TITLE
Add temporary link for RFMF

### DIFF
--- a/locales/en-US/funding.ftl
+++ b/locales/en-US/funding.ftl
@@ -3,5 +3,5 @@
 ## funding.html.hbs
 funding-page-title = Funding
 funding-intro = Rust depends on hundreds of contributors who improve it on a daily basis, many of whom are volunteers. We want them to be properly supported to ensure the long-term health of the Rust Project. We are very grateful for any financial contributions that go towards supporting the development of Rust. There are various ways how to sponsor Rust contributors:
-funding-intro-rfmf = One way is to contribute to the <a href="TODO">Rust Foundation Maintainer Fund</a>, which funds dedicated Maintainers in Residence, who maintain critical areas of the Rust toolchain.
+funding-intro-rfmf = One way is to contribute to the <a href="https://rustfoundation.org/media/announcing-the-rust-foundation-maintainers-fund">Rust Foundation Maintainer Fund</a>, which funds dedicated Maintainers in Residence, who maintain critical areas of the Rust toolchain.
 funding-intro-individuals = Another way is to sponsor individuals that work on Rust directly, through their GitHub Sponsors account. You can find such Rust contributors that can be funded below.


### PR DESCRIPTION
Fixes RFMF link from https://github.com/rust-lang/www.rust-lang.org/pull/2295.
