### PR TITLE
Add Zulip contact button to person page

### DIFF
--- a/src/teams.rs
+++ b/src/teams.rs
@@ -3,7 +3,9 @@ use handlebars::{
     Context, Handlebars, Helper, HelperResult, Output, RenderContext, RenderErrorReason,
 };
 use percent_encoding::{AsciiSet, NON_ALPHANUMERIC, utf8_percent_encode};
-use rust_team_data::v1::{BASE_URL, People, Person, Team, TeamKind, TeamMember, Teams};
+use rust_team_data::v1::{
+    BASE_URL, People, Person, Team, TeamKind, TeamMember, Teams, ZulipMapping,
+};
 use serde::Serialize;
 use std::cmp::Reverse;
 use std::collections::HashMap;
@@ -48,12 +50,16 @@ pub fn encode_zulip_stream(
     Ok(())
 }
 
+type GitHubId = u64;
+type ZulipId = u64;
+
 #[derive(Debug, Clone)]
 pub struct RustTeamData {
     pub teams: Vec<Team>,
     pub archived_teams: Vec<Team>,
     // GitHub username => person data
     pub people: HashMap<String, Person>,
+    pub zulip_ids: HashMap<GitHubId, ZulipId>,
 }
 
 impl RustTeamData {
@@ -63,6 +69,7 @@ impl RustTeamData {
             teams,
             archived_teams: vec![],
             people: HashMap::new(),
+            zulip_ids: HashMap::new(),
         }
     }
 
@@ -301,6 +308,7 @@ impl RustTeamData {
                 .or_insert_with(move || PersonData {
                     name: member.name.clone(),
                     github: member.github.clone(),
+                    zulip_id: ctx.zulip_ids.get(&member.github_id).copied(),
                     github_sponsors: person_team_data.github_sponsors,
                     active_teams: vec![],
                     alumni_teams: vec![],
@@ -501,6 +509,7 @@ impl PersonTeam {
 pub struct PersonData {
     name: String,
     pub github: String,
+    zulip_id: Option<ZulipId>,
     github_sponsors: bool,
     active_teams: Vec<PersonTeam>,
     alumni_teams: Vec<PersonTeam>,
@@ -521,7 +530,7 @@ pub fn load_rust_teams() -> anyhow::Result<RustTeamData> {
     println!("Downloading Team API data");
 
     // Parallelize the download to make website build faster
-    let (teams, archived_teams, people) = std::thread::scope(|scope| {
+    let (teams, archived_teams, people, zulip) = std::thread::scope(|scope| {
         let teams = scope.spawn(|| -> anyhow::Result<Teams> {
             let response = fetch(&format!("{BASE_URL}/teams.json"))?;
             Ok(serde_json::from_str(&response)?)
@@ -534,18 +543,27 @@ pub fn load_rust_teams() -> anyhow::Result<RustTeamData> {
             let response = fetch(&format!("{BASE_URL}/people.json"))?;
             Ok(serde_json::from_str(&response)?)
         });
+        let zulip = scope.spawn(|| -> anyhow::Result<ZulipMapping> {
+            let response = fetch(&format!("{BASE_URL}/zulip-map.json"))?;
+            Ok(serde_json::from_str(&response)?)
+        });
         (
             teams.join().unwrap(),
             archived_teams.join().unwrap(),
             people.join().unwrap(),
+            zulip.join().unwrap(),
         )
     });
-    let (teams, archived_teams, people) = (teams?, archived_teams?, people?);
+    let (teams, archived_teams, people, zulip) = (teams?, archived_teams?, people?, zulip?);
+
+    // Invert Zulip -> GitHub to GitHub -> Zulip
+    let zulip_ids = zulip.users.into_iter().map(|(k, v)| (v, k)).collect();
 
     Ok(RustTeamData {
         teams: teams.teams.into_values().collect(),
         archived_teams: archived_teams.teams.into_values().collect(),
         people: people.people.into_iter().collect(),
+        zulip_ids,
     })
 }
 

--- a/templates/governance/person.html.hbs
+++ b/templates/governance/person.html.hbs
@@ -35,8 +35,15 @@
         </div>
       </div>
       <div class="f3">
+        {{# if data.zulip_id }}
+          <div>
+            <a href="https://rust-lang.zulipchat.com/#narrow/dm/{{data.zulip_id}}" class="button button-secondary mw6">Contact me on Zulip</a>
+          </div>
+        {{/if}}
         {{# if data.github_sponsors }}
-          <a href="https://github.com/sponsors/{{data.github}}" class="button button-secondary mw6">Sponsor {{ data.name }} on GitHub</a>
+          <div class="mt2">
+            <a href="https://github.com/sponsors/{{data.github}}" class="button button-secondary mw6">Sponsor me on GitHub</a>
+          </div>
         {{/if}}
       </div>
     </div>


### PR DESCRIPTION
We discussed this at the All Hands, as a way to make it easier to contact Rust Project people, as currently finding their Zulip account is not exactly trivial.

I also changed the text from "Contact [name]" to "Contact me", because if a person had both GH sponsors and Zulip, their name would be repeated and it seemed kind of distracting, and misleading the reader from the important part "Contact on Zulip" and "Sponsor on GitHub".

<img width="467" height="266" alt="image" src="https://github.com/user-attachments/assets/85707cbd-38f7-4b2d-8229-72775c946a7c" />