### PR TITLE
Improve title of the person page

### DIFF
--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -47,6 +47,6 @@ governance-all-teams-archived-title = Archived Rust Teams
 governance-all-teams-archived-intro = This section lists the { $count } archived teams that are no longer active. We want to thank all past members for their invaluable contributions!
 
 ## govenance/person.hbs
-governance-person-title = Rust Project team member
+governance-person-title = { $name }
 governance-person-team-member = Team member
 governance-person-team-alumni = Alumni

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,4 +1,3 @@
-use std::collections::HashMap;
 use crate::assets::AssetFiles;
 use crate::fs::{copy_dir_all, ensure_directory};
 use crate::i18n::{EXPLICIT_LOCALE_INFO, LocaleInfo, SUPPORTED_LOCALES};
@@ -7,16 +6,17 @@ use crate::teams::{AllTeamMembers, AllTeams, PageData, RustTeamData};
 use crate::{BaseUrl, ENGLISH, LAYOUT};
 use anyhow::Context;
 use handlebars::Handlebars;
+use handlebars_fluent::fluent_bundle::FluentArgs;
 use handlebars_fluent::{Loader, SimpleLoader};
 use rand::seq::SliceRandom;
 use rayon::iter::IntoParallelRefIterator;
 use rayon::iter::ParallelIterator;
 use serde::Serialize;
+use std::collections::HashMap;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
-use handlebars_fluent::fluent_bundle::FluentArgs;
 
 #[derive(Serialize)]
 pub struct TemplateCtx<'a, T: Serialize> {
@@ -83,10 +83,14 @@ impl<'a, T: Serialize> PageCtx<'a, T> {
 
 pub struct PageTitle {
     id: String,
-    args: HashMap<String, String>
+    args: HashMap<String, String>,
 }
 
 impl PageTitle {
+    pub fn new(id: String, args: HashMap<String, String>) -> Self {
+        Self { id, args }
+    }
+
     fn args(&self) -> FluentArgs<'_> {
         let mut args = FluentArgs::new();
         for (key, value) in &self.args {
@@ -129,7 +133,8 @@ impl<'a> RenderCtx<'a> {
             "".into()
         } else {
             let lang = lang.parse().expect("lang should be valid");
-            self.fluent_loader.lookup(&lang, &title.id, Some(&title.args()))
+            self.fluent_loader
+                .lookup(&lang, &title.id, Some(&title.args()))
         };
         PageCtx {
             template_ctx: TemplateCtx {
@@ -281,7 +286,10 @@ pub fn render_governance(
                     render_ctx
                         .page(
                             "governance/person",
-                            "governance-person-title",
+                            PageTitle::new(
+                                "governance-person-title".to_string(),
+                                HashMap::from([("name".to_string(), person.name.clone())]),
+                            ),
                             &person,
                             lang,
                         )

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use crate::assets::AssetFiles;
 use crate::fs::{copy_dir_all, ensure_directory};
 use crate::i18n::{EXPLICIT_LOCALE_INFO, LocaleInfo, SUPPORTED_LOCALES};
@@ -15,6 +16,7 @@ use std::ffi::OsStr;
 use std::fs::File;
 use std::io::BufWriter;
 use std::path::{Path, PathBuf};
+use handlebars_fluent::fluent_bundle::FluentArgs;
 
 #[derive(Serialize)]
 pub struct TemplateCtx<'a, T: Serialize> {
@@ -79,6 +81,30 @@ impl<'a, T: Serialize> PageCtx<'a, T> {
     }
 }
 
+pub struct PageTitle {
+    id: String,
+    args: HashMap<String, String>
+}
+
+impl PageTitle {
+    fn args(&self) -> FluentArgs<'_> {
+        let mut args = FluentArgs::new();
+        for (key, value) in &self.args {
+            args.set(key.as_str(), value.as_str());
+        }
+        args
+    }
+}
+
+impl<'a> From<&'a str> for PageTitle {
+    fn from(id: &'a str) -> Self {
+        Self {
+            id: id.to_string(),
+            args: Default::default(),
+        }
+    }
+}
+
 pub struct RenderCtx<'a> {
     pub handlebars: Handlebars<'a>,
     pub template_dir: PathBuf,
@@ -91,18 +117,19 @@ pub struct RenderCtx<'a> {
 }
 
 impl<'a> RenderCtx<'a> {
-    pub fn page<T: Serialize>(
+    pub fn page<T: Serialize, Title: Into<PageTitle>>(
         &'a self,
         page: &str,
-        title_id: &str,
+        title: Title,
         data: &'a T,
         lang: &str,
     ) -> PageCtx<'a, T> {
-        let title = if title_id.is_empty() {
+        let title: PageTitle = title.into();
+        let title = if title.id.is_empty() {
             "".into()
         } else {
             let lang = lang.parse().expect("lang should be valid");
-            self.fluent_loader.lookup(&lang, title_id, None)
+            self.fluent_loader.lookup(&lang, &title.id, Some(&title.args()))
         };
         PageCtx {
             template_ctx: TemplateCtx {
@@ -209,7 +236,7 @@ pub fn render_governance(
                 render_ctx
                     .page(
                         "governance/group",
-                        &format!("governance-team-{}-name", team.team.name),
+                        format!("governance-team-{}-name", team.team.name).as_str(),
                         &data,
                         lang,
                     )
@@ -311,7 +338,7 @@ pub fn render_directory(render_ctx: &RenderCtx, category: &str) -> anyhow::Resul
                     render_ctx
                         .page(
                             &format!("{category}/index"),
-                            &format!("{category}-page-title"),
+                            format!("{category}-page-title").as_str(),
                             &(),
                             lang,
                         )
@@ -327,7 +354,7 @@ pub fn render_directory(render_ctx: &RenderCtx, category: &str) -> anyhow::Resul
                         render_ctx
                             .page(
                                 &format!("{category}/{subject}"),
-                                &format!("{category}-{subject}-page-title"),
+                                format!("{category}-{subject}-page-title").as_str(),
                                 &(),
                                 lang,
                             )

--- a/src/teams.rs
+++ b/src/teams.rs
@@ -499,7 +499,7 @@ impl PersonTeam {
 
 #[derive(Serialize)]
 pub struct PersonData {
-    name: String,
+    pub name: String,
     pub github: String,
     github_sponsors: bool,
     active_teams: Vec<PersonTeam>,


### PR DESCRIPTION
I was googling "rust-lang <github username>" recently, and though Google managed to find the correct person page on the Rust website, the title kinda sucked (generic "Rust Project member"). This PR makes the title be the name of the person, which should look much better in search engine results.
