### PR TITLE
Remove link to old site

### DIFF
--- a/locales/de/common.ftl
+++ b/locales/de/common.ftl
@@ -44,7 +44,6 @@ footer-github-alt = GitHub
 footer-attribution =
     Gepflegt vom Rust-Team. Fehler gefunden?
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Korrektur einreichen!</a>
-footer-old-site = Suchst du die <a href="https://prev.rust-lang.org">vorige Version der Website</a>?
 
 ## what/index.hbs
 

--- a/locales/en-US/common.ftl
+++ b/locales/en-US/common.ftl
@@ -63,7 +63,5 @@ footer-attribution = Maintained by the Rust Team. See a bug?
 
 footer-autoupdate = Web site built every day at { $autoupdate }
 
-footer-old-site = Looking for the <a href="https://prev.rust-lang.org">previous website</a>?
-
 ## what/index.hbs
 what-header = What

--- a/locales/es/common.ftl
+++ b/locales/es/common.ftl
@@ -54,7 +54,6 @@ footer-github-alt = GitHub
 footer-attribution =
     Mantenida por el equipo de Rust. ¿Hay algún error?
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">¡Arréglalo aquí!</a>
-footer-old-site = ¿Buscas la <a href="https://prev.rust-lang.org">web antigua</a>?
 
 ## what/index.hbs
 

--- a/locales/fa/common.ftl
+++ b/locales/fa/common.ftl
@@ -38,7 +38,6 @@ footer-get-help = کمک بگیر!
 footer-youtube-alt = توییتر
 footer-alt-youtube = لوگوی Youtube
 footer-github-alt = گیت هاب
-footer-old-site = به دنبال <a href="https://prev.rust-lang.org">وب سایت قبلی</a> هستید؟
 
 ## what/index.hbs
 

--- a/locales/fr/common.ftl
+++ b/locales/fr/common.ftl
@@ -53,7 +53,6 @@ footer-alt-youtube = Logo YouTube
 footer-github-alt = GitHub
 footer-attribution = Maintenu par l’équipe de Rust. Vous avez trouvé une erreur ? <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Envoyez-nous une correction!</a>
 footer-autoupdate = Site mis à jour quotidiennement à { $autoupdate }
-footer-old-site = Vous cherchez l'ancien <a href="https://prev.rust-lang.org">site web</a> ?
 
 ## what/index.hbs
 

--- a/locales/it/common.ftl
+++ b/locales/it/common.ftl
@@ -54,7 +54,6 @@ footer-github-alt = GitHub
 footer-attribution =
     Mantenuto dal Team Rust. Vedi un errore?
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">manda una correzione qui!</a>
-footer-old-site = Stavi cercando il <a href="https://prev.rust-lang.org">vecchio sito</a>?
 
 ## what/index.hbs
 

--- a/locales/ja/common.ftl
+++ b/locales/ja/common.ftl
@@ -52,7 +52,6 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = youtubeのロゴ
 footer-github-alt = GitHub
 footer-attribution = Rustチームによって管理されています。誤字を見つけましたか？<a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">修正を送ってください！</a>
-footer-old-site = <a href="https://prev.rust-lang.org">以前のウェブサイト</a>をお探しですか？
 
 ## what/index.hbs
 

--- a/locales/ko/common.ftl
+++ b/locales/ko/common.ftl
@@ -46,7 +46,6 @@ footer-get-help = 도움 받기
 footer-youtube-alt = Twitter
 footer-alt-youtube = YouTube 로고
 footer-github-alt = GitHub
-footer-old-site = <a href="https://prev.rust-lang.org">이전 웹사이트</a>
 
 ## what/index.hbs
 

--- a/locales/pl/common.ftl
+++ b/locales/pl/common.ftl
@@ -53,7 +53,6 @@ footer-github-alt = Github
 footer-attribution =
     Strona utrzymywana przez Zespół Rusta. Widzisz błąd?
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Zgłoś go!</a>
-footer-old-site = Szukasz <a href="https://prev.rust-lang.org">poprzedniej wersji strony</a>?
 
 ## what/index.hbs
 

--- a/locales/pt-BR/common.ftl
+++ b/locales/pt-BR/common.ftl
@@ -53,7 +53,6 @@ footer-github-alt = GitHub
 footer-attribution =
     Mantido pela Equipe Rust. Encontrou algum erro?
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Envie uma correção aqui!</a>
-footer-old-site = Procurando pelo <a href="https://prev.rust-lang.org">site antigo</a>?
 
 ## what/index.hbs
 

--- a/locales/ru/common.ftl
+++ b/locales/ru/common.ftl
@@ -52,7 +52,6 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = Логотип youtube
 footer-github-alt = GitHub
 footer-attribution = Поддерживается Rust Team. Увидели опечатку? <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Исправьте здесь!</a>
-footer-old-site = Ищете <a href="https://prev.rust-lang.org">предыдущий сайт</a>?
 
 ## what/index.hbs
 

--- a/locales/tr/common.ftl
+++ b/locales/tr/common.ftl
@@ -51,7 +51,6 @@ footer-github-alt = GitHub
 footer-attribution =
     Rust Ekibi tarafından geliştirilmektedir. Yazım hatasına mı rastladınız?
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">Düzeltmeyi buraya gönderin!</a>
-footer-old-site = <a href="https://prev.rust-lang.org">Önceki siteye</a> mi bakıyorsunuz?
 
 ## what/index.hbs
 

--- a/locales/xx-AU/common.ftl
+++ b/locales/xx-AU/common.ftl
@@ -33,4 +33,3 @@ footer-alt-youtube = oƃol ǝqnʇnoʎ
 footer-github-alt = qnHʇᴉפ
 footer-attribution = <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">¡ ǝɹǝɥ xᴉɟ ɐ puǝS</a>
         ¿odʎʇ ɐ ǝǝS ˙ɯɐǝ┴ ʇsnɹ ǝɥʇ ʎq pǝuᴉɐʇuᴉɐW
-footer-old-site = <a href="https://prev.rust-lang.org">ǝʇᴉsqǝʍ snoᴉʌǝɹd</a> ǝɥʇ ɹoɟ ƃuᴉʞoo˥

--- a/locales/zh-CN/common.ftl
+++ b/locales/zh-CN/common.ftl
@@ -54,7 +54,6 @@ footer-github-alt = GitHub
 footer-attribution =
     由 Rust 团队维护。发现了错别字？
     <a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">在这里提交修复！</a>
-footer-old-site = 想要查看<a href="https://prev.rust-lang.org">旧版网站</a>？
 
 footer-autoupdate = 网站将在每天 { $autoupdate } 构建
 

--- a/locales/zh-TW/common.ftl
+++ b/locales/zh-TW/common.ftl
@@ -52,7 +52,6 @@ footer-youtube-alt = Twitter
 footer-alt-youtube = youtube 標誌
 footer-github-alt = GitHub
 footer-attribution = 由 Rust 團隊維護，發現錯字了嗎？<a target="_blank" href="https://github.com/rust-lang/www.rust-lang.org/issues/new/choose">請在此提交修復！</a>
-footer-old-site = 想查看<a href="https://prev.rust-lang.org">舊版網站</a>嗎？
 
 ## what/index.hbs
 

--- a/templates/components/footer.html.hbs
+++ b/templates/components/footer.html.hbs
@@ -50,7 +50,6 @@
         {{fluent "footer-attribution"}}
       </p>
       <p>{{#fluent "footer-autoupdate"}}{{#fluentparam "autoupdate"}}22:00 UTC{{/fluentparam}}{{/fluent}}</p>
-      <p>{{fluent "footer-old-site"}}</p>
     </div>
   </div>
 </footer>


### PR DESCRIPTION
The old site has been shut down and just redirects to the current one.

closes #2301 