### PR TITLE
Fix typo in Japanese install page

### DIFF
--- a/locales/ja/tools.ftl
+++ b/locales/ja/tools.ftl
@@ -38,7 +38,7 @@ install-notes-rustup-heading = <code>rustup</code>を使ったツールチェー
 install-notes-rustup-description =
     <p>
     Rustは<a href="https://rust-lang.github.io/rustup/"><code>rustup</code></a>というツールによってインストール・管理されます。
-    Rustには６週間ごとの<a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">ラピッドリリースプロセス</a>があり、<a href="https://forge.rust-lang.org/release/platform-support.html">多数のプラットフォーム</a>をサポートしているので、 数多くのビルドがいつても利用できます。
+    Rustには６週間ごとの<a href="https://github.com/rust-lang/rfcs/blob/master/text/0507-release-channels.md">ラピッドリリースプロセス</a>があり、<a href="https://forge.rust-lang.org/release/platform-support.html">多数のプラットフォーム</a>をサポートしているので、 数多くのビルドがいつでも利用できます。
     <code>rustup</code>はこれらのビルドを、Rustがサポートしているすべてのプラットフォームで一貫した方法で管理し、betaやnightly版のリリースチャンネルや、追加のクロスコンパイルターゲットもサポートしています。
     </p>
     <p>


### PR DESCRIPTION
Fixes #2304.

Corrects the Japanese install-page typo `いつても` to `いつでも`, restoring the missing dakuten in the phrase “available at any time.”

## Tests

- `cargo test --locked` — 7 passed
- `cargo fmt --all -- --check` — passed
