### PR TITLE
fix: translate Windows install guidance into Turkish

### DIFF
--- a/locales/tr/tools.ftl
+++ b/locales/tr/tools.ftl
@@ -117,6 +117,7 @@ install-other-methods-link = Daha fazla bilgi edinin
 
 tools-rustup-unixy = Görünüşe bakılırsa macOS, Linux veya Unix tabanlı bir işletim sistemi kullanıyorsunuz. Rustup'ı indirmek ve Rust'ı yüklemek için uçbiriminizde şunları çalıştırın ve daha sonra ekranınıza gelen talimatları izleyin.
 tools-rustup-windows = Görünüşe bakılırsa Windows kullanıyorsunuz. Rust'ı yüklemek için şunu indirin ve çalıştırın. Ardından ekrandaki talimatları izleyin.
+tools-rustup-windows-2 = Windows kullanıyor gibi görünüyorsunuz. Rust'ı kullanmaya başlamak için yükleyiciyi indirin, ardından programı çalıştırın ve ekrandaki talimatları izleyin. İstendiğinde <a href="https://rust-lang.github.io/rustup/installation/windows-msvc.html">Visual Studio C++ Build Tools</a>'u yüklemeniz gerekebilir. Windows kullanmıyorsanız <a href="https://forge.rust-lang.org/infra/other-installation-methods.html">"Diğer Kurulum Yöntemleri"</a> bölümüne bakın.
 tools-rustup-wsl-heading = Windows için Linux Altsistemi
 tools-rustup-wsl = Eğer Windows için Linux Altsistemi kullanıcısıysanız Rust'ı yüklemek için uçbiriminizde şunları çalıştırın ve ardından ekrandaki talimatları izleyin.
 tools-rustup-manual-default = Eğer WSL, Linux veya macOS gibi bir Unix işletim sistemi kullanıyorsanız Rust'ı yüklemek için <br> uçbiriminizde şunları çalıştırın. Ardından ekrandaki talimatları izleyin.


### PR DESCRIPTION
Fixes #2309.

## Summary

- Add the missing Turkish `tools-rustup-windows-2` localization so the Turkish installation page no longer falls back to English.

## Testing

- `cargo build --all --locked`
- `cargo clippy -- --deny warnings`
- `cargo test --all --locked` (7 passed)
- `cargo fmt --all -- --check`
- `cargo run` and inspected `build/tr/learn/get-started/index.html`
