### PR TITLE
fr: translate the funding page

### DIFF
--- a/locales/fr/common.ftl
+++ b/locales/fr/common.ftl
@@ -8,6 +8,7 @@ production-use = Utilisation en production
 learn-more = En savoir plus
 zulip = Zulip
 mastodon = Mastodon
+bluesky = Bluesky
 
 ## components/panels/domain.hbs
 

--- a/locales/fr/funding.ftl
+++ b/locales/fr/funding.ftl
@@ -2,10 +2,10 @@
 
 ## index.html.hbs
 funding-page-title = Financement
-funding-intro = Rust repose sur des centaines de contributeurs qui l'améliorent au quotidien, dont beaucoup sont bénévoles. Nous voulons qu'ils soient soutenus comme il se doit, afin d'assurer la santé du projet Rust sur le long terme. Nous sommes très reconnaissants de toute contribution financière apportée au développement de Rust. Cette page présente plusieurs manières de soutenir les contributeurs de Rust.
+funding-intro = Rust dépend de centaines de contributeurs qui l'améliorent au quotidien, dont beaucoup sont bénévoles. Nous voulons qu'ils soient soutenus comme il se doit, afin d'assurer la pérennité du projet Rust. Nous sommes très reconnaissants de toute contribution financière apportée à son développement. Cette page présente plusieurs manières de soutenir ces contributeurs.
 funding-rfmf-title = Rust Foundation Maintainers Fund
 funding-rfmf-description = Le Rust Foundation Maintainers Fund collecte des dons destinés à assurer un financement stable aux contributeurs qui maintiennent des parties critiques de la chaîne d'outils Rust. Ce programme est géré par l'<a href="{ $funding-team-url }">équipe Financement</a>, qui échange aussi bien avec les équipes de Rust qu'avec les sponsors, et qui sélectionne les <a href="https://rust-lang.github.io/rfcs/3931-rfmf-rust-foundation-maintainer-fund.html">Maintainers in Residence</a> financés.<br /><br />
-    Contribuez à ce fonds si vous souhaitez soutenir directement le développement et la maintenance de Rust, en nous laissant choisir là où cet argent aura le plus d'effet.
+    Contribuez à ce fonds si vous souhaitez soutenir directement le développement et la maintenance de Rust, en nous laissant choisir là où cet argent aura le plus d'impact.
 funding-rfmf-donate = Faire un don au Maintainers Fund
 funding-sponsors-title = Sponsoriser des contributeurs à titre individuel
 funding-sponsors-description = Plusieurs contributeurs du projet Rust disposent de leur propre compte GitHub Sponsors. Si vous souhaitez sponsoriser des personnes en particulier qui travaillent sur Rust, vous pouvez le faire ci-dessous.

--- a/locales/fr/funding.ftl
+++ b/locales/fr/funding.ftl
@@ -1,0 +1,11 @@
+## Works in conjunction with team data from teams.ftl
+
+## index.html.hbs
+funding-page-title = Financement
+funding-intro = Rust repose sur des centaines de contributeurs qui l'améliorent au quotidien, dont beaucoup sont bénévoles. Nous voulons qu'ils soient soutenus comme il se doit, afin d'assurer la santé du projet Rust sur le long terme. Nous sommes très reconnaissants de toute contribution financière apportée au développement de Rust. Cette page présente plusieurs manières de soutenir les contributeurs de Rust.
+funding-rfmf-title = Rust Foundation Maintainers Fund
+funding-rfmf-description = Le Rust Foundation Maintainers Fund collecte des dons destinés à assurer un financement stable aux contributeurs qui maintiennent des parties critiques de la chaîne d'outils Rust. Ce programme est géré par l'<a href="{ $funding-team-url }">équipe Financement</a>, qui échange aussi bien avec les équipes de Rust qu'avec les sponsors, et qui sélectionne les <a href="https://rust-lang.github.io/rfcs/3931-rfmf-rust-foundation-maintainer-fund.html">Maintainers in Residence</a> financés.<br /><br />
+    Contribuez à ce fonds si vous souhaitez soutenir directement le développement et la maintenance de Rust, en nous laissant choisir là où cet argent aura le plus d'effet.
+funding-rfmf-donate = Faire un don au Maintainers Fund
+funding-sponsors-title = Sponsoriser des contributeurs à titre individuel
+funding-sponsors-description = Plusieurs contributeurs du projet Rust disposent de leur propre compte GitHub Sponsors. Si vous souhaitez sponsoriser des personnes en particulier qui travaillent sur Rust, vous pouvez le faire ci-dessous.


### PR DESCRIPTION
Follows up on #2324, where @Manishearth confirmed that translation PRs are
welcome as long as they stay small and a native-speaking Rust team member
reviews them.

This is the smallest self-contained piece of the French backlog, and it fixes a
bug that is visible in production: `locales/fr/funding.ftl` simply does not
exist, so https://rust-lang.org/fr/funding/ is served entirely in English —
even though the navigation entry pointing at it already reads « Financement ».

- adds `locales/fr/funding.ftl` (7 messages)
- adds the `bluesky` key, which was missing from `locales/fr/common.ftl`

Message identifiers, ordering, the `{ $funding-team-url }` variable and the
inline HTML are kept identical to the `en-US` source. « Rust Foundation
Maintainers Fund » is left untranslated, as the proper name of the program.
Both files parse with zero `Junk` nodes.

@lqd, @imperio — @Manishearth suggested you as possible native French reviewers.
No rush, and if either of you would rather not, please say so and I'll look for
someone else rather than let this sit.

If this shape works, the rest of the French backlog I inventoried in #2324 is
158 messages, and I'd split it the same way: `security.ftl` (5), `governance.ftl`
(20), then `teams.ftl` (125) in several parts.
