### PR TITLE
goodbye RFC reference

### DIFF
--- a/locales/en-US/governance.ftl
+++ b/locales/en-US/governance.ftl
@@ -3,10 +3,6 @@
 ## governance/index.hbs
 governance-page-title = Governance
 governance-tagline = How Rust is built by its community
-governance-rfc = RFC process
-governance-rfc-blurb = Each major decision in Rust starts as a Request for Comments (RFC).
-          Everyone is invited to discuss the proposal, to work toward a shared understanding of the tradeoffs.
-          Though sometimes arduous, this community deliberation is Rust’s secret sauce for quality.
 
 governance-teams-header = Top-Level Teams
 governance-wgs-header = Working Groups

--- a/locales/es/governance.ftl
+++ b/locales/es/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = Gobernanza
 governance-tagline = Cómo Rust es construido por su comunidad
-governance-rfc = Hoja de ruta y proceso RFC
-governance-rfc-blurb =
-    Cada decisión relevante en Rust comienza como una solicitud de comentarios o Request for Comments (RFC).
-    Se invita a todos a discutir la propuesta, a trabajar hacia un entendimiento común de los pros y contras.
-    Aunque a veces es arduo, esta deliberación de la comunidad es el ingrediente secreto de Rust para garantizar la calidad.
 governance-teams-header = Equipos
 governance-wgs-header = Grupos de trabajo
 

--- a/locales/fa/governance.ftl
+++ b/locales/fa/governance.ftl
@@ -4,7 +4,6 @@
 ## governance/index.hbs
 
 governance-tagline = چگونه Rust توسط جامعه خود ساخته شده است
-governance-rfc = نقشه راه و فرآیند RFC
 governance-teams-header = تیم‌ها
 governance-wgs-header = گروه های درحال کار
 

--- a/locales/fr/governance.ftl
+++ b/locales/fr/governance.ftl
@@ -5,8 +5,6 @@
 
 governance-page-title = Gouvernance
 governance-tagline = Comment Rust est construit par sa communauté
-governance-rfc = Roadmap et processus des RFC
-governance-rfc-blurb = Chaque décision majeure dans Rust commence avec une demande de commentaire, ou RFC. Tout le monde peut discuter de la proposition afin de comprendre l'ensemble des compromis. Bien que ce processus soit parfois pénible, ce débat au sein de la communauté fait la force du langage, et y apporte toute sa qualité.
 governance-teams-header = Équipes
 governance-wgs-header = Groupes de travail
 

--- a/locales/it/governance.ftl
+++ b/locales/it/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = Governance
 governance-tagline = Come Rust è costruito dalla propria community
-governance-rfc = Roadmap e RFC
-governance-rfc-blurb =
-    Ogni principale decisione inizia in Rust con una "Request for Comments" (RFC).
-    Chiunque è invitato a discutere la proposta, per far sì che i compromessi siano in larga parte condivisi.
-    Anche se talora è complesso, questo processo decisionale della community è l'ingrediente segreto per garantire la qualità del risultato.
 governance-teams-header = I Team
 governance-wgs-header = I Working Group
 

--- a/locales/ja/governance.ftl
+++ b/locales/ja/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = ガバナンス
 governance-tagline = Rustがコミュニティによってどのように作られているか
-governance-rfc = ロードマップおよびRFCプロセス
-governance-rfc-blurb =
-    Rustにおける主な決定事項はどれも、Request for Comments (RFC)の一つとして始まります。
-    提案されたRFCについて議論し、トレードオフについて共通理解を得るよう努めることが求められます。
-    時には労力を要しますが、このコミュニティによる熟議こそがRustの質を保つ秘訣なのです。
 governance-teams-header = チーム
 governance-wgs-header = ワーキンググループ
 

--- a/locales/ko/governance.ftl
+++ b/locales/ko/governance.ftl
@@ -4,7 +4,6 @@
 ## governance/index.hbs
 
 governance-page-title = 거버넌스
-governance-rfc = 로드맵 및 RFC 프로세스
 governance-teams-header = 팀
 governance-wgs-header = 작업 그룹
 

--- a/locales/pl/governance.ftl
+++ b/locales/pl/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = Zarządzanie
 governance-tagline = Jak Rust jest tworzony przez swoją społeczność
-governance-rfc = Plan rozwoju i proces RFC
-governance-rfc-blurb =
-    Każda większa decyzja zaczyna jako Prośba o Komentarze (ang. RFC).
-    Każda osoba jest zaproszona do dyskusji nad przedstawioną propozycją, tak aby dojść do wspólnego zrozumienia odnośnie potencjalnie koniecznych kompromisów.
-    Pomimo, że proces ten bywa żmudny, tego rodzaju konsultacja z udziałem społeczności jest podstawowym elementem kontroli jakości całego projektu.
 governance-teams-header = Zespoły
 governance-wgs-header = Grupy Robocze
 

--- a/locales/pt-BR/governance.ftl
+++ b/locales/pt-BR/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = Governança
 governance-tagline = Como Rust é construído pela sua comunidade
-governance-rfc = Planejamento e processo de RFC
-governance-rfc-blurb =
-    Cada uma das maiores decisões em Rust começa com um Pedido por Comentários (RFC em inglês).
-    Todas as pessoas são convidadas a discutir a proposta, para trabalhar em direção a um entendimento compartilhado sobre as vantagens e desvantagens.
-    Mesmo sendo árduo algumas vezes, a deliberação da comunidade é o molho secreto para a qualidade do projeto Rust.
 governance-teams-header = Equipes
 governance-wgs-header = Grupos de Trabalho
 

--- a/locales/ru/governance.ftl
+++ b/locales/ru/governance.ftl
@@ -5,8 +5,6 @@
 
 governance-page-title = Управление
 governance-tagline = Как Rust создаётся его сообществом
-governance-rfc = Дорожная карта и процесс RFC
-governance-rfc-blurb = Каждое важное решение в Rust начинается с Request for Comments (RFC). Приглашаем всех обсудить предложение и работать над общим пониманием всех компромиссов. Не смотря на то, что временами это трудно, такое обсуждение сообществом является секретным соусом Rust, повышающим его качество.
 governance-teams-header = Команды
 governance-wgs-header = Рабочие группы
 

--- a/locales/tr/governance.ftl
+++ b/locales/tr/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = Yönetim
 governance-tagline = Rust'ın kendi topluluğu tarafından nasıl yapıldığı
-governance-rfc = Yol haritası ve yorumlar isteği süreci (RFC)
-governance-rfc-blurb =
-    Rust'ta her önemli karar bir yorumlar isteği (RFC) olarak başlar.
-    Yapılan takası herkesin anlayabilmesi için herkes öneriyi tartışmaya katkıda bulunabilir.
-    Bazen zorlu olmasına rağmen bu topluluk müzakeresi Rust'ın kalitesi için bir gizli sostur.
 governance-teams-header = Ekipler
 governance-wgs-header = Çalışma Grupları
 

--- a/locales/xx-AU/governance.ftl
+++ b/locales/xx-AU/governance.ftl
@@ -1,9 +1,5 @@
 governance-page-title = ǝɔuɐuɹǝʌoפ
 governance-tagline = ʎʇᴉunɯɯoɔ sʇᴉ ʎq ʇlᴉnq sᴉ ʇsnɹ ʍoH
-governance-rfc = ssǝɔoɹd ƆℲɹ puɐ dɐɯpɐoɹ
-governance-rfc-blurb = ˙ʎʇᴉlɐnb ɹoɟ ǝɔnɐs ʇǝɹɔǝs s’ʇsnɹ sᴉ uoᴉʇɐɹǝqᴉlǝp ʎʇᴉunɯɯoɔ sᴉɥʇ 'snonpɹɐ sǝɯᴉʇǝɯos ɥƃnoɥ┴
-        ˙sɟɟoǝpɐɹʇ ǝɥʇ ɟo ƃuᴉpuɐʇsɹǝpun pǝɹɐɥs ɐ pɹɐʍoʇ ʞɹoʍ oʇ 'lɐsodoɹd ǝɥʇ ssnɔsᴉp oʇ pǝʇᴉʌuᴉ sᴉ ǝuoʎɹǝʌƎ
-        ˙(ƆℲɹ) sʇuǝɯɯoƆ ɹoɟ ʇsǝnbǝɹ ɐ sɐ sʇɹɐʇs ʇsnɹ uᴉ uoᴉsᴉɔǝp ɹoɾɐɯ ɥɔɐƎ
 governance-learn-more = ǝɹoɯ uɹɐǝ˥
 governance-teams-header = sɯɐǝ┴
 governance-wgs-header = sdnoɹפ ƃuᴉʞɹoM

--- a/locales/zh-CN/governance.ftl
+++ b/locales/zh-CN/governance.ftl
@@ -5,11 +5,6 @@
 
 governance-page-title = 治理
 governance-tagline = 社区如何构筑 Rust
-governance-rfc = 路线图和 RFC 流程
-governance-rfc-blurb =
-    Rust 中的每个重要决定都是从征求意见稿（RFC）开始的。
-    任何人都可以参与提案的讨论，权衡利弊以便达成共识。
-    虽然有时会很艰难，但社区这种深思熟虑正是保证 Rust 高质量的秘诀。
 governance-teams-header = 团队
 governance-wgs-header = 工作组
 

--- a/locales/zh-TW/governance.ftl
+++ b/locales/zh-TW/governance.ftl
@@ -5,8 +5,6 @@
 
 governance-page-title = 治理
 governance-tagline = 社群如何開發出 Rust
-governance-rfc = 願景規劃與 RFC 流程
-governance-rfc-blurb = Rust 每項重要的決定都是從請求意見稿（RFC）開始的。每個人都可以參與提案的討論，衡量利弊來達成共識。雖然有時會遇到困難，但是這樣社群的審議正是維持 Rust 品質的秘訣。
 governance-teams-header = 團隊
 governance-wgs-header = 工作組
 

--- a/templates/governance/index.html.hbs
+++ b/templates/governance/index.html.hbs
@@ -7,25 +7,6 @@
   </div>
 </header>
 
-<section id="roadmap" class="red">
-  <div class="w-100 mw-none ph3 mw8-m mw9-l center f3">
-    <header>
-      <h2>{{fluent "governance-rfc"}}</h2>
-      <div class="highlight"></div>
-    </header>
-    <div class="flex flex-column flex-row-l">
-      <div class="mw8 flex flex-column justify-between pt0 bp2 pv3-ns ph3-l">
-        <p>{{fluent "governance-rfc-blurb"}}</p>
-        <a
-          href="https://github.com/rust-lang/rfcs"
-          class="button button-secondary"
-          >{{fluent "learn-more"}}</a
-        >
-      </div>
-    </div>
-  </div>
-</section>
-
 <section id="teams" class="purple">
   <div class="w-100 mw-none ph3 mw-8-m mw9-l center f3">
     <header>


### PR DESCRIPTION
see https://rust-lang.zulipchat.com/#narrow/channel/392734-council

RFCs should not be the entry-point for new contributors and users to Rust. Teams have their own lower overhead processes and suggesting users to start engaging with the Project by writing fully-fleshed out RFCs is actively harmful imo

unsure how to improve this section given the status quo and better documenting that is likely part of https://rust-lang.org/governance/teams/launching-pad/#team-comprehensibility